### PR TITLE
fix(layout): symbol-font line metrics so form checkbox rows aren't collapsed (#11)

### DIFF
--- a/docs/internal/17-production-readiness-audit.md
+++ b/docs/internal/17-production-readiness-audit.md
@@ -284,15 +284,23 @@ DOM-Y) narrowed it.** It is NOT a global metric:
   21.2px on `demo`. So the §1.3 ascent/descent-approximation worry does *not*
   manifest as a line-height error, and "fix the global line-height" is the wrong
   move. (This also lowers the Word-divergence risk: text metrics are sound.)
-- **The dominant form-drift factor is TABLE ROW HEIGHTS.** On
-  `medical-incident-form`, the editor renders the checkbox table rows at ~33px
-  vs LibreOffice's ~75px (~42px too short each); the drift swings from +70px at
-  the top to −88px at the checkboxes purely from under-sized rows. Rows have two
-  paragraphs/cell + `<w:trHeight w:val="409"/>` (atLeast) + `vAlign=center`; the
-  editor tracks `heightRule` (`toFlowBlocks.ts:1339`) but under-computes the cell
-  content height (likely collapsing the empty second cell paragraph, or ignoring
-  cell margins / vAlign padding). **Tracker task #11.**
-- **Secondary:** header/logo pushes the title down ~70px.
+- **The dominant form-drift factor was CHECKBOX ROW HEIGHTS — ROOT-CAUSED & FIXED
+  (`da8943c`, 2026-06-20, branch `fidelity/table-row-height-11`).** A controlled
+  LibreOffice experiment (vary the source, re-render) proved the row height is
+  driven by the **checkbox cell's font size**, NOT `trHeight`: a 16pt
+  `w14:checkbox` (Wingdings 2) row is 75px in LibreOffice, 35px at 11pt, and
+  unchanged when `trHeight` is removed. The editor substitutes a Unicode `☐` in a
+  normal font → ~34px rows → every form compresses. Fix: `fontResolver` now
+  carries a calibrated `singleLineRatio` (~3.3) for Wingdings/Wingdings 2/3 +
+  Webdings, and `toProseDoc` keeps the dingbat font name on translated symbol
+  glyphs so the measurer applies it (still rendering the safe glyph). Result:
+  checkbox rows now ~78px (ref 75px); p1 aligns closely with LibreOffice.
+  Guarded by `e2e/tests/checkbox-row-height.spec.ts`. The coarse density-grid
+  score only moved 29.8→30.8 (it under-rewards this), but the composite shows the
+  real win. **#11 checkbox driver done.**
+- **Secondary (still open):** header/logo pushes the title down ~70px — the
+  remaining medical-form offset and the main thing still dragging its score.
+  Distinct root cause (header/anchored-logo layout), tracked separately.
 
 So the "systemic spacing" work is really **targeted table cell/row-height fixes**,
 not a metrics-model rewrite — and verifiable against LibreOffice without needing

--- a/docx-editor/e2e/tests/checkbox-row-height.spec.ts
+++ b/docx-editor/e2e/tests/checkbox-row-height.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Form checkbox row-height fidelity (#11)
+ *
+ * Word/LibreOffice set form `w14:checkbox` content controls in a tall dingbat
+ * font (e.g. Wingdings 2), so the table rows that hold them are tall — a 16pt
+ * checkbox row is ~75px in LibreOffice. The editor substitutes a Unicode glyph
+ * in a normal font, which collapsed those rows to ~34px and compressed every
+ * form vertically. With the hardcoded symbol-font line metrics, the rows render
+ * close to the reference again. This guards against regressing back to the
+ * collapsed height.
+ */
+
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MEDICAL_DOCX = path.join(__dirname, '..', 'fixtures', 'medical-incident-form.docx');
+
+test.describe('Form checkbox row height', () => {
+  test('checkbox rows render tall (not collapsed) like the reference', async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.loadDocxFile(MEDICAL_DOCX);
+    await page.waitForSelector('.layout-page', { timeout: 30000 });
+    await page.waitForTimeout(800);
+
+    const heights = await page.evaluate(() => {
+      const rows = [...document.querySelectorAll('.layout-table-row')];
+      return rows
+        .filter((r) => /Medication Error|Fall or Injury|Adverse Reaction/.test(r.textContent || ''))
+        .map((r) => r.getBoundingClientRect().height);
+    });
+
+    expect(heights.length).toBeGreaterThanOrEqual(3);
+    // LibreOffice renders these ~75px. Collapsed (the bug) was ~34px. Assert
+    // they're clearly in the tall regime — a wide band so font-metric drift
+    // across platforms doesn't make this flaky.
+    for (const h of heights) {
+      expect(h).toBeGreaterThan(60);
+      expect(h).toBeLessThan(95);
+    }
+  });
+});

--- a/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1271,7 +1271,14 @@ function convertRunContent(content: RunContent, marks: ReturnType<typeof schema.
       // safe Unicode character — substitution chars (☐ ☒ ➤ etc.) are
       // universally available so forcing a specific font would hurt
       // rather than help.
-      if (isTranslatedUnicode(ch, content.font, content.char)) {
+      //
+      // Exception: tall dingbat fonts (Wingdings/Webdings). Their glyphs have
+      // a much taller ink box than a normal font, so a line set in them gets a
+      // large line height in Word/LibreOffice. We still render the substituted
+      // Unicode glyph (browsers fall back per-glyph), but we KEEP the dingbat
+      // font name so the measurer applies its hardcoded line metrics — without
+      // it, form checkbox rows collapse to ~half height (#11).
+      if (isTranslatedUnicode(ch, content.font, content.char) && !isTallSymbolFont(content.font)) {
         return [schema.text(ch, marks)];
       }
       const fontMark = schema.mark('fontFamily', {
@@ -1314,6 +1321,17 @@ function convertRunContent(content: RunContent, marks: ReturnType<typeof schema.
  * Map sources: Adobe / ECMA-376 Annex L, plus
  * https://www.alanwood.net/demos/wingdings.html (cross-checked).
  */
+/**
+ * Tall dingbat fonts whose glyphs (checkboxes, dingbats) occupy a much taller
+ * ink box than normal text, so lines set in them get an inflated line height in
+ * Word/LibreOffice. Mirrors the calibrated entries in `fontResolver`'s
+ * FONT_MAPPINGS. `Symbol` (Greek/math) is excluded — it has normal metrics.
+ */
+function isTallSymbolFont(font: string | undefined): boolean {
+  const f = (font || '').toLowerCase().trim();
+  return f === 'wingdings' || f === 'wingdings 2' || f === 'wingdings 3' || f === 'webdings';
+}
+
 function symbolToUnicodeChar(font: string, char: string): string | null {
   if (!char) return null;
   // OOXML stores `w:char` as a hex string. Word also sometimes emits

--- a/docx-editor/packages/core/src/utils/fontResolver.ts
+++ b/docx-editor/packages/core/src/utils/fontResolver.ts
@@ -203,6 +203,45 @@ const FONT_MAPPINGS: Record<string, FontMapping> = {
     fallbackStack: ['Malgun Gothic', 'Noto Sans KR', 'sans-serif'],
     singleLineRatio: DEFAULT_SINGLE_LINE_RATIO,
   },
+
+  // Symbol / dingbat fonts. Their glyphs (form checkboxes, dingbats) have a
+  // very tall ink box, so Word/LibreOffice give lines set in these fonts a
+  // line height far above a normal text font. The browser almost never has
+  // these fonts and falls back to a normal one whose metrics are wrong, which
+  // collapsed form rows to ~half height (#11). We can't ship the proprietary
+  // fonts, so we hardcode an empirically-calibrated line ratio instead.
+  //
+  // Wingdings 2 is calibrated against LibreOffice: a 16pt `w14:checkbox` cell
+  // renders a 75px row → ratio ≈ 75px / ptToPx(16) ≈ 3.3. The sibling dingbat
+  // fonts (Wingdings, Wingdings 2/3, Webdings) share the same tall-glyph
+  // character, so they inherit the calibrated value pending per-font
+  // measurement. `Symbol` (Greek/math) has normal text metrics and is left at
+  // the default. fallbackStack keeps a normal font so substituted Unicode
+  // glyphs (☐ ☒ ●) still render; only the line *metrics* are inflated.
+  wingdings: {
+    googleFont: '',
+    category: 'sans-serif',
+    fallbackStack: ['Wingdings', 'sans-serif'],
+    singleLineRatio: 3.3, // empirical (dingbat glyph ink box), not OS/2-derived
+  },
+  'wingdings 2': {
+    googleFont: '',
+    category: 'sans-serif',
+    fallbackStack: ['Wingdings 2', 'sans-serif'],
+    singleLineRatio: 3.3, // calibrated: 16pt checkbox → 75px row in LibreOffice
+  },
+  'wingdings 3': {
+    googleFont: '',
+    category: 'sans-serif',
+    fallbackStack: ['Wingdings 3', 'sans-serif'],
+    singleLineRatio: 3.3,
+  },
+  webdings: {
+    googleFont: '',
+    category: 'sans-serif',
+    fallbackStack: ['Webdings', 'sans-serif'],
+    singleLineRatio: 3.3,
+  },
 };
 
 /**


### PR DESCRIPTION
The dominant real-world fidelity gap (#11). A controlled LibreOffice experiment proved form checkbox row height is driven by the checkbox cell's **font size**, not `trHeight`: a 16pt `w14:checkbox` (Wingdings 2) row is 75px in LibreOffice but the editor substituted a Unicode glyph in a normal font → ~34px rows → every form compressed vertically.

Fix (chosen approach: hardcode symbol-font metrics — can't ship the proprietary fonts):
- `fontResolver` carries a calibrated `singleLineRatio` (~3.3) for Wingdings/Wingdings 2/3 + Webdings (calibrated: 16pt checkbox → 75px in LibreOffice).
- `toProseDoc` keeps the dingbat font name on translated symbol glyphs so the measurer applies the metrics, while still rendering the safe substituted glyph.

Result: `medical-incident-form` checkbox rows render ~78px (was ~34px, ref 75px); p1 now aligns closely with LibreOffice (composite in `visual-fidelity-out`). The coarse density-grid score moved 29.8→30.8 (it under-rewards this — the remaining drag is a separate header-offset issue), but the visual consistency is the real win.

Verified: 893 core + 323 react unit tests green; new `checkbox-row-height.spec.ts`; typecheck/format/lint/smoke clean.