### PR TITLE
feat(layout): page/margin/column-anchored object positioning

### DIFF
--- a/docx-editor/packages/core/src/docx/vmlTextBoxParser.ts
+++ b/docx-editor/packages/core/src/docx/vmlTextBoxParser.ts
@@ -258,6 +258,43 @@ function normalizeHex(value: string): string | null {
   return null;
 }
 
+/** VML `mso-position-horizontal-relative` → OOXML ST_RelFromH. */
+const VML_H_REL: Record<string, ImagePosition['horizontal']['relativeTo']> = {
+  page: 'page',
+  margin: 'margin',
+  text: 'column',
+  char: 'character',
+  'left-margin-area': 'leftMargin',
+  'right-margin-area': 'rightMargin',
+  'inner-margin-area': 'insideMargin',
+  'outer-margin-area': 'outsideMargin',
+};
+/** VML `mso-position-vertical-relative` → OOXML ST_RelFromV. */
+const VML_V_REL: Record<string, ImagePosition['vertical']['relativeTo']> = {
+  page: 'page',
+  margin: 'margin',
+  text: 'paragraph',
+  line: 'line',
+  'top-margin-area': 'topMargin',
+  'bottom-margin-area': 'bottomMargin',
+  'inner-margin-area': 'insideMargin',
+  'outer-margin-area': 'outsideMargin',
+};
+const VML_H_ALIGN: Record<string, ImagePosition['horizontal']['alignment']> = {
+  left: 'left',
+  center: 'center',
+  right: 'right',
+  inside: 'inside',
+  outside: 'outside',
+};
+const VML_V_ALIGN: Record<string, ImagePosition['vertical']['alignment']> = {
+  top: 'top',
+  center: 'center',
+  bottom: 'bottom',
+  inside: 'inside',
+  outside: 'outside',
+};
+
 function parseVmlShapePosition(
   _shapeEl: XmlElement,
   decls: Map<string, string>
@@ -267,17 +304,27 @@ function parseVmlShapePosition(
 
   const left = lengthDeclToEmu(decls.get('margin-left'));
   const top = lengthDeclToEmu(decls.get('margin-top'));
-  if (left === null && top === null) return undefined;
 
-  // The DOCX `mso-position-*-relative` style hints would let us bind
-  // the offset to `page`, `margin`, `paragraph`, etc., but the model's
-  // `ImagePosition.horizontal.relativeTo` is required and the typed
-  // enum doesn't accept the loose VML strings. Default to a margin-
-  // relative anchor — for the SDS-style page-divider shapes this puts
-  // the rectangle inside the content area, which is close enough.
+  // `mso-position-*-relative` binds the offset frame (page / margin / column /
+  // …); `mso-position-*` carries a symbolic alignment (left/center/right or
+  // `absolute` = use the offset). Defaults mirror Word: margin for H, paragraph
+  // for V.
+  const hRel = VML_H_REL[decls.get('mso-position-horizontal-relative') ?? ''] ?? 'margin';
+  const vRel = VML_V_REL[decls.get('mso-position-vertical-relative') ?? ''] ?? 'paragraph';
+  const hPos = decls.get('mso-position-horizontal');
+  const vPos = decls.get('mso-position-vertical');
+  const hAlign = hPos && hPos !== 'absolute' ? VML_H_ALIGN[hPos] : undefined;
+  const vAlign = vPos && vPos !== 'absolute' ? VML_V_ALIGN[vPos] : undefined;
+
+  if (left === null && top === null && !hAlign && !vAlign) return undefined;
+
   return {
-    horizontal: { relativeTo: 'margin', posOffset: left ?? 0 },
-    vertical: { relativeTo: 'paragraph', posOffset: top ?? 0 },
+    horizontal: hAlign
+      ? { relativeTo: hRel, alignment: hAlign }
+      : { relativeTo: hRel, posOffset: left ?? 0 },
+    vertical: vAlign
+      ? { relativeTo: vRel, alignment: vAlign }
+      : { relativeTo: vRel, posOffset: top ?? 0 },
   };
 }
 

--- a/docx-editor/packages/core/src/layout-engine/anchorGeometry.ts
+++ b/docx-editor/packages/core/src/layout-engine/anchorGeometry.ts
@@ -1,0 +1,180 @@
+/**
+ * Anchor geometry — translate OOXML `relativeFrom` anchors (ST_RelFromH /
+ * ST_RelFromV, ECMA-376 §20.4.3.1-2) into painter coordinates.
+ *
+ * Extracted verbatim from the floating-image path in `renderPage.ts` so the
+ * layout engine and the renderer share ONE implementation. All inputs/outputs
+ * are CSS pixels; the painter's coordinate origin is the content-area top-left
+ * (i.e. inset by the page margins), so `relativeFrom="page"` resolves to a
+ * negative margin offset.
+ */
+import { emuToPixels } from '../utils/units';
+
+/** Page geometry needed to resolve an anchor band, in CSS pixels. */
+export interface AnchorGeometry {
+  pageWidth: number;
+  pageHeight: number;
+  marginLeft: number;
+  marginTop: number;
+  contentWidth: number;
+  contentHeight: number;
+  /** Column left edge (content-area-relative). Defaults to 0 (single column). */
+  columnX?: number;
+  /** Column width. Defaults to contentWidth. */
+  columnWidth?: number;
+}
+
+/** Horizontal anchor (`<wp:positionH>` / VML `mso-position-horizontal*`). */
+export interface HorizontalAnchorSpec {
+  relativeTo?: string;
+  align?: string;
+  posOffset?: number;
+}
+
+/** Vertical anchor (`<wp:positionV>` / VML `mso-position-vertical*`). */
+export interface VerticalAnchorSpec {
+  relativeTo?: string;
+  align?: string;
+  posOffset?: number;
+}
+
+/**
+ * Resolve the horizontal position of an anchored object within the painter's
+ * content-area coordinate space. Returns the x (content-area-relative) and the
+ * heuristic `side` the floating-image wrap logic uses.
+ */
+export function resolveAnchorX(
+  h: HorizontalAnchorSpec,
+  objectWidth: number,
+  geom: AnchorGeometry
+): { x: number; side: 'left' | 'right' } {
+  const { pageWidth, marginLeft, contentWidth } = geom;
+  const columnX = geom.columnX ?? 0;
+  const columnWidth = geom.columnWidth ?? contentWidth;
+
+  // ECMA-376 §20.4.3.2 (ST_RelFromH): pick a band origin (`baseX`) and band
+  // width, then `align` or `posOffset` chooses within it. The painter's
+  // content origin is `marginLeft` from the page edge, so `page`/`leftMargin`
+  // is `-marginLeft`.
+  const baseX = (() => {
+    switch (h.relativeTo) {
+      case 'page':
+      case 'leftMargin':
+        return -marginLeft;
+      case 'rightMargin':
+        return contentWidth;
+      case 'column':
+        return columnX;
+      case 'character':
+      case 'margin':
+      case 'insideMargin':
+      case 'outsideMargin':
+      default:
+        return 0;
+    }
+  })();
+  const bandWidth = (() => {
+    switch (h.relativeTo) {
+      case 'page':
+        return pageWidth;
+      case 'leftMargin':
+      case 'rightMargin':
+        return marginLeft;
+      case 'character':
+        return 0;
+      case 'column':
+        return columnWidth;
+      case 'margin':
+      case 'insideMargin':
+      case 'outsideMargin':
+      default:
+        return contentWidth;
+    }
+  })();
+
+  let side: 'left' | 'right' = 'left';
+  let x = 0;
+  if (h.align === 'right') {
+    side = 'right';
+    x = bandWidth ? baseX + bandWidth - objectWidth : 0;
+  } else if (h.align === 'left') {
+    side = 'left';
+    x = baseX;
+  } else if (h.align === 'center') {
+    side = 'left';
+    x = bandWidth ? baseX + (bandWidth - objectWidth) / 2 : 0;
+  } else if (h.posOffset !== undefined) {
+    x = baseX + emuToPixels(h.posOffset);
+    side = x > contentWidth / 2 ? 'right' : 'left';
+  } else {
+    // Bare positionH (no align, no offset) — anchor at band origin.
+    x = baseX;
+  }
+  return { x, side };
+}
+
+/**
+ * Resolve the vertical position of an anchored object within the painter's
+ * content-area coordinate space. `fragmentY` is the in-flow Y of the anchoring
+ * paragraph (used for paragraph/line-relative anchors and as the fallback).
+ */
+export function resolveAnchorY(
+  v: VerticalAnchorSpec,
+  objectHeight: number,
+  fragmentY: number,
+  geom: AnchorGeometry
+): number {
+  const { pageHeight, marginTop, contentHeight } = geom;
+  // ECMA-376 §20.4.3.1 (ST_RelFromV). `topMargin` is the strip ABOVE the
+  // content area (negative offset); `bottomMargin` is BELOW (`contentHeight`).
+  // `margin` is the content area itself. `insideMargin`/`outsideMargin` are
+  // mirror-margins for facing pages — approximated as `margin`.
+  const baseY = (() => {
+    switch (v.relativeTo) {
+      case 'paragraph':
+      case 'line':
+        return fragmentY;
+      case 'page':
+        return -marginTop;
+      case 'topMargin':
+        return -marginTop;
+      case 'bottomMargin':
+        return contentHeight;
+      case 'margin':
+      case 'insideMargin':
+      case 'outsideMargin':
+      default:
+        return 0;
+    }
+  })();
+  const bandHeight = (() => {
+    switch (v.relativeTo) {
+      case 'page':
+        return pageHeight;
+      case 'topMargin':
+      case 'bottomMargin':
+        return marginTop;
+      case 'paragraph':
+      case 'line':
+        return 0;
+      case 'margin':
+      case 'insideMargin':
+      case 'outsideMargin':
+      default:
+        return contentHeight;
+    }
+  })();
+
+  if (v.align === 'top') {
+    return baseY;
+  } else if (v.align === 'center') {
+    return bandHeight ? baseY + (bandHeight - objectHeight) / 2 : fragmentY;
+  } else if (v.align === 'bottom') {
+    return bandHeight ? baseY + bandHeight - objectHeight : fragmentY;
+  } else if (v.posOffset !== undefined) {
+    return baseY + emuToPixels(v.posOffset);
+  }
+  // Bare positionV (no align, no offset): paragraph/line stays in flow; any
+  // other band means "anchor at the band origin".
+  return v.relativeTo === 'paragraph' || v.relativeTo === 'line' ? fragmentY : baseY;
+}

--- a/docx-editor/packages/core/src/layout-engine/index.ts
+++ b/docx-editor/packages/core/src/layout-engine/index.ts
@@ -37,6 +37,8 @@ import {
   getMidChainIndices,
   hasPageBreakBefore,
 } from './keep-together';
+import { resolveAnchorX, resolveAnchorY, type AnchorGeometry } from './anchorGeometry';
+import { pixelsToEmu } from '../utils/units';
 
 // Default page size (US Letter in pixels at 96 DPI)
 const DEFAULT_PAGE_SIZE = { w: 816, h: 1056 };
@@ -303,9 +305,20 @@ export function layoutDocument(
         layoutImage(block, measure as ImageMeasure, paginator);
         break;
 
-      case 'textBox':
-        layoutTextBox(block as TextBoxBlock, measure as TextBoxMeasure, paginator);
+      case 'textBox': {
+        const tb = block as TextBoxBlock;
+        // A textBox carries an `anchor` only when it came from a genuinely
+        // positioned source (DrawingML `wp:anchor` or VML `position:absolute`)
+        // — those float and must NOT reserve in-flow space (Word flows text
+        // independently). Inline textboxes (no anchor) keep the in-flow
+        // reservation, which is the d8b85d1 regression guard.
+        if (tb.anchor) {
+          layoutAnchoredTextBox(tb, measure as TextBoxMeasure, paginator);
+        } else {
+          layoutTextBox(tb, measure as TextBoxMeasure, paginator);
+        }
         break;
+      }
 
       case 'pageBreak':
         paginator.forcePageBreak();
@@ -773,6 +786,73 @@ function layoutTextBox(
 
   const result = paginator.addFragment(fragment, measure.height, 0, 0);
   fragment.y = result.y;
+}
+
+/**
+ * Layout an anchored (floating) text box: position absolutely from its
+ * page/margin/column anchor and push WITHOUT advancing the cursor, so body
+ * text flows independently (matching Word's wrap=none / behind-text shapes).
+ * Mirrors `layoutAnchoredImage` but resolves the full `relativeFrom` band math.
+ */
+function layoutAnchoredTextBox(
+  block: TextBoxBlock,
+  measure: TextBoxMeasure,
+  paginator: ReturnType<typeof createPaginator>
+): void {
+  if (measure.kind !== 'textBox') {
+    throw new Error(`layoutAnchoredTextBox: expected textBox measure`);
+  }
+  const state = paginator.getCurrentState();
+  const page = state.page;
+  const margins = page.margins;
+  const anchor = block.anchor!;
+
+  const contentWidth = page.size.w - margins.left - margins.right;
+  const geom: AnchorGeometry = {
+    pageWidth: page.size.w,
+    pageHeight: page.size.h,
+    marginLeft: margins.left,
+    marginTop: margins.top,
+    contentWidth,
+    contentHeight: page.size.h - margins.top - margins.bottom,
+    // Content-relative column origin (single-column ≈ 0).
+    columnX: paginator.getColumnX(state.columnIndex) - margins.left,
+    columnWidth: contentWidth,
+  };
+
+  // Block anchor offsets are PIXELS (converted in toProseDoc); resolveAnchor*
+  // expects EMU (it converts internally), so round-trip back to EMU.
+  const toEmu = (px: number | undefined) => (px != null ? pixelsToEmu(px) : undefined);
+  const hSpec = {
+    relativeTo: anchor.relFromH,
+    align: anchor.alignH,
+    posOffset: toEmu(anchor.offsetH),
+  };
+  const vSpec = {
+    relativeTo: anchor.relFromV,
+    align: anchor.alignV,
+    posOffset: toEmu(anchor.offsetV),
+  };
+
+  // resolveAnchor* work in content-area coordinates; cursorY is page-absolute.
+  const contentCursorY = state.cursorY - margins.top;
+  const { x: cx } = resolveAnchorX(hSpec, measure.width, geom);
+  const cy = resolveAnchorY(vSpec, measure.height, contentCursorY, geom);
+
+  const fragment: TextBoxFragment = {
+    kind: 'textBox',
+    blockId: block.id,
+    // applyFragmentStyles subtracts margins, so emit page-absolute coords.
+    x: margins.left + cx,
+    y: margins.top + cy,
+    width: measure.width,
+    height: measure.height,
+    pmStart: block.pmStart,
+    pmEnd: block.pmEnd,
+    isAnchored: true,
+    zIndex: anchor.behindDoc ? -1 : undefined,
+  };
+  page.fragments.push(fragment);
 }
 
 /**

--- a/docx-editor/packages/core/src/layout-engine/types.ts
+++ b/docx-editor/packages/core/src/layout-engine/types.ts
@@ -542,6 +542,8 @@ export type TextBoxBlock = {
     relFromV?: string;
     alignH?: string;
     alignV?: string;
+    /** VML `z-index` < 0 — paint behind body text. */
+    behindDoc?: boolean;
   };
   pmStart?: number;
   pmEnd?: number;
@@ -763,6 +765,14 @@ export type TextBoxFragment = FragmentBase & {
   kind: 'textBox';
   /** Height of the text box. */
   height: number;
+  /**
+   * True when positioned absolutely from its anchor (page/margin/column),
+   * NOT advancing the in-flow cursor. The renderer then places it from
+   * `x`/`y` directly instead of the paragraph-relative transform.
+   */
+  isAnchored?: boolean;
+  /** Stacking: negative paints behind body text (VML `z-index` < 0). */
+  zIndex?: number;
 };
 
 /**

--- a/docx-editor/packages/core/src/layout-painter/renderPage.ts
+++ b/docx-editor/packages/core/src/layout-painter/renderPage.ts
@@ -30,6 +30,11 @@ import { renderParagraphFragment } from './renderParagraph';
 import { renderTableFragment } from './renderTable';
 import { renderImageFragment, applyImageVisualAttrs, hasImageVisualAttrs } from './renderImage';
 import { renderTextBoxFragment } from './renderTextBox';
+import {
+  resolveAnchorX,
+  resolveAnchorY,
+  type AnchorGeometry,
+} from '../layout-engine/anchorGeometry';
 import type { BlockLookup } from './index';
 import type { BorderSpec } from '../types/document';
 import { borderToStyle } from '../utils/formatToStyle';
@@ -686,146 +691,32 @@ function extractFloatingImagesFromParagraph(
     // `*Margin` and `character` / `line` variants we fall back to the
     // content-area frame, which matches Word's render for single-column
     // body documents.
+    const geom: AnchorGeometry = {
+      pageWidth: geometry?.pageWidth ?? 0,
+      pageHeight: geometry?.pageHeight ?? 0,
+      marginLeft: geometry?.marginLeft ?? 0,
+      marginTop: geometry?.marginTop ?? 0,
+      contentWidth,
+      contentHeight: geometry?.contentHeight ?? 0,
+    };
+
     let side: 'left' | 'right' = 'left';
     let x = 0;
-
     if (position?.horizontal) {
-      const h = position.horizontal;
-      // ECMA-376 §20.4.3.2 (ST_RelFromH). Same translation pattern as the
-      // vertical axis: pick a band origin (`baseX`) and a band width. For
-      // body text the painter's content origin is `marginLeft` from the page
-      // edge, so `relativeFrom="page"` is just `-marginLeft`.
-      const pageWidth = geometry?.pageWidth ?? 0;
-      const marginLeft = geometry?.marginLeft ?? 0;
-      const baseX = (() => {
-        switch (h.relativeTo) {
-          case 'page':
-          case 'leftMargin':
-            return -marginLeft;
-          case 'rightMargin':
-            return contentWidth;
-          case 'character':
-          case 'column':
-          case 'margin':
-          case 'insideMargin':
-          case 'outsideMargin':
-          default:
-            return 0;
-        }
-      })();
-      const bandWidth = (() => {
-        switch (h.relativeTo) {
-          case 'page':
-            return pageWidth;
-          case 'leftMargin':
-          case 'rightMargin':
-            return marginLeft;
-          case 'character':
-            return 0;
-          case 'column':
-          case 'margin':
-          case 'insideMargin':
-          case 'outsideMargin':
-          default:
-            return contentWidth;
-        }
-      })();
-      if (h.align === 'right') {
-        side = 'right';
-        x = bandWidth ? baseX + bandWidth - imgRun.width : 0;
-      } else if (h.align === 'left') {
-        side = 'left';
-        x = baseX;
-      } else if (h.align === 'center') {
-        side = 'left';
-        x = bandWidth ? baseX + (bandWidth - imgRun.width) / 2 : 0;
-      } else if (h.posOffset !== undefined) {
-        x = baseX + emuToPixels(h.posOffset);
-        side = x > contentWidth / 2 ? 'right' : 'left';
-      } else {
-        // Bare positionH (no align, no offset) — anchor at band origin.
-        x = baseX;
-      }
+      const r = resolveAnchorX(position.horizontal, imgRun.width, geom);
+      x = r.x;
+      side = r.side;
     } else if (imgRun.cssFloat === 'right') {
       side = 'right';
       x = contentWidth - imgRun.width;
     }
 
-    // Determine vertical position. The OOXML attribute can be either an
-    // explicit `posOffset` (EMUs from the relativeFrom origin) or a symbolic
-    // `align` (top / center / bottom). When neither is present, fall back
-    // to the paragraph anchor — that's Word's default for `wp:anchor` with
-    // a bare `<wp:positionV>`.
-    //
-    // `relativeFrom` decides which anchor coordinate offset/align is
-    // computed against. We translate every variant into the painter's
-    // coordinate space (content-area top = 0).
+    // Vertical position: paragraph/line bands stay in flow; page/margin bands
+    // resolve against the painter's content-area coordinate space. See
+    // `resolveAnchorY` (ported from this code) for the full ST_RelFromV map.
     let y = 0;
-
     if (position?.vertical) {
-      const v = position.vertical;
-      const pageHeight = geometry?.pageHeight ?? 0;
-      const marginTop = geometry?.marginTop ?? 0;
-      const contentHeight = geometry?.contentHeight ?? 0;
-      // ECMA-376 §20.4.3.1 (ST_RelFromV) — translate the OOXML anchor band
-      // into the painter's coordinate space (content-area top = 0). `topMargin`
-      // is the strip ABOVE the content area (negative offset); `bottomMargin`
-      // is BELOW (`contentHeight`). `margin` is the content area itself.
-      // `insideMargin`/`outsideMargin` are mirror-margins for facing pages —
-      // we approximate as `margin`, which matches single-sided layouts.
-      const baseY = (() => {
-        switch (v.relativeTo) {
-          case 'paragraph':
-          case 'line':
-            return fragmentY;
-          case 'page':
-            return -marginTop;
-          case 'topMargin':
-            return -marginTop;
-          case 'bottomMargin':
-            return contentHeight;
-          case 'margin':
-          case 'insideMargin':
-          case 'outsideMargin':
-          default:
-            return 0;
-        }
-      })();
-      // The "band height" within which align="center"/"bottom" is computed.
-      // page → page height; topMargin → marginTop; bottomMargin → bottom margin
-      // (which we don't track separately, fall back to marginTop ≈ symmetric
-      // pages); paragraph/line → no band (fall back to paragraph anchor).
-      const bandHeight = (() => {
-        switch (v.relativeTo) {
-          case 'page':
-            return pageHeight;
-          case 'topMargin':
-          case 'bottomMargin':
-            return marginTop;
-          case 'paragraph':
-          case 'line':
-            return 0;
-          case 'margin':
-          case 'insideMargin':
-          case 'outsideMargin':
-          default:
-            return contentHeight;
-        }
-      })();
-      if (v.align === 'top') {
-        y = baseY;
-      } else if (v.align === 'center') {
-        y = bandHeight ? baseY + (bandHeight - imgRun.height) / 2 : fragmentY;
-      } else if (v.align === 'bottom') {
-        y = bandHeight ? baseY + bandHeight - imgRun.height : fragmentY;
-      } else if (v.posOffset !== undefined) {
-        y = baseY + emuToPixels(v.posOffset);
-      } else {
-        // Bare positionV (no align, no offset). For paragraph/line bands the
-        // image stays in flow; for any other band, the spec means "anchor at
-        // the band origin", which is `baseY`.
-        y = v.relativeTo === 'paragraph' || v.relativeTo === 'line' ? fragmentY : baseY;
-      }
+      y = resolveAnchorY(position.vertical, imgRun.height, fragmentY, geom);
     } else {
       // No positionV at all — default to paragraph anchor.
       y = fragmentY;

--- a/docx-editor/packages/core/src/layout-painter/renderTextBox.ts
+++ b/docx-editor/packages/core/src/layout-painter/renderTextBox.ts
@@ -50,9 +50,16 @@ export function renderTextBoxFragment(
   // Basic styling
   containerEl.style.position = 'absolute';
   containerEl.style.width = `${fragment.width}px`;
-  containerEl.style.height = `${fragment.height}px`;
+  // Decorative hairlines (e.g. SDS box borders drawn as ~0.6px filled rects)
+  // would vanish after sub-pixel rounding; clamp filled boxes to ≥1px.
+  const paintedHeight =
+    block.fillColor && fragment.height < 1 ? Math.max(fragment.height, 1) : fragment.height;
+  containerEl.style.height = `${paintedHeight}px`;
   containerEl.style.overflow = 'hidden';
   containerEl.style.boxSizing = 'border-box';
+  if (fragment.zIndex !== undefined) {
+    containerEl.style.zIndex = String(fragment.zIndex);
+  }
 
   // Fill color
   if (block.fillColor) {
@@ -83,7 +90,7 @@ export function renderTextBoxFragment(
   // place + offset" which is worse than the current "wrong place,
   // no offset" — wait for the hybrid cursor-reservation work before
   // touching those.
-  if (block.anchor) {
+  if (block.anchor && !fragment.isAnchored) {
     const isParagraphH = !block.anchor.relFromH || block.anchor.relFromH === 'paragraph';
     const isParagraphV = !block.anchor.relFromV || block.anchor.relFromV === 'paragraph';
     const dxPx =


### PR DESCRIPTION
Implements page/margin/column-anchored object positioning — the architectural lever behind real-world-doc fidelity (forms + multi-page CJK SDS). Previously only paragraph-relative anchors were honored; page/margin/column offsets were zeroed, so anchored objects rendered at the text cursor.

Phased (each independently validated):
- **Phase 0** — extract the ST_RelFromH/V band-math (inline in renderPage's image path) into reusable `anchorGeometry`. Verified no-op (VF baseline unchanged).
- **Phase 1** — `parseVmlShapePosition` now preserves the real `mso-position-*-relative` frame (was hardcoded to margin/paragraph).
- **Phase 2/3** — anchored textboxes (DrawingML `wp:anchor` / VML `position:absolute`) layout absolutely from their relativeFrom band, pushed without advancing the cursor; renderer places them from `fragment.x/y` instead of the paragraph-relative transform. Inline textboxes keep in-flow reservation (the d8b85d1 regression guard).

Validation:
- **No new page-count regressions** — all 6 corpus mismatches predate this change (verified issue-319 is 11pp on main too).
- Anchored/textbox fixtures score high: wrap-none-two-seals 97.3, drawing-fidelity 99, vml-rect 89, drawingml-shape 89, three-section-header 88.
- medical-incident-form 30.8→33.1 (header textboxes no longer push the title down; pages still 4=4), textbox-test 33→46.2.
- 893 core + 323 react unit tests green; 26 textbox/drawing/border e2e green; typecheck/format/lint/smoke clean.

Follow-up (not in this PR): SDS hazard-box hairline rects render & position but need a thickness refinement (empty-placeholder paragraph inflates the ~0.6px decorative rect).