### PR TITLE
fix(vml/header): position anchored text-frame textboxes (incl. headers)

### DIFF
--- a/docx-editor/packages/core/src/docx/vmlTextBoxParser.ts
+++ b/docx-editor/packages/core/src/docx/vmlTextBoxParser.ts
@@ -114,11 +114,20 @@ export function parseVmlTextBox(
 
   const size = parseVmlShapeSize(shape);
   const id = getAttribute(shape, null, 'id') ?? undefined;
+  // Capture the shape's absolute position (`position:absolute; margin-left/top;
+  // mso-position-*-relative`). Without this, VML text-frames lost their anchor
+  // and were laid out in-flow — mispositioned, and in headers the stacked
+  // heights inflated the header so the body spilled onto extra pages.
+  const position = parseVmlShapePosition(
+    shape,
+    parseVmlStyle(getAttribute(shape, null, 'style') ?? '')
+  );
 
   return {
     type: 'textBox',
     id,
     size,
+    position,
     content,
   };
 }

--- a/docx-editor/packages/core/src/layout-bridge/headerFooterLayout.ts
+++ b/docx-editor/packages/core/src/layout-bridge/headerFooterLayout.ts
@@ -17,7 +17,14 @@
  * when they do not contribute to flow height.
  */
 
-import type { FlowBlock, ImageRun, Measure, PageMargins, TableBlock } from '../layout-engine/types';
+import type {
+  FlowBlock,
+  ImageRun,
+  Measure,
+  PageMargins,
+  TableBlock,
+  TextBoxBlock,
+} from '../layout-engine/types';
 import type { HeaderFooter, StyleDefinitions, Theme } from '../types/document';
 import type { HeaderFooterContent } from '../layout-painter/renderPage';
 import { headerFooterToProseDoc } from '../prosemirror/conversion/toProseDoc';
@@ -204,6 +211,48 @@ export function resolveHeaderFooterVisualTop(
   return paragraphY;
 }
 
+/** True when a header/footer textbox is floated by an anchor (don't stack it). */
+function isAnchoredTextBox(block: TextBoxBlock): boolean {
+  const a = block.anchor;
+  return (
+    !!a && (a.offsetH != null || a.offsetV != null || a.relFromH != null || a.relFromV != null)
+  );
+}
+
+/**
+ * Header/footer flow-Y of an anchored textbox's top, mirroring
+ * `resolveHeaderFooterVisualTop` for images. Anchor offsets are already pixels.
+ */
+export function resolveHeaderFooterTextBoxTop(
+  anchor: NonNullable<TextBoxBlock['anchor']>,
+  flowHeight: number,
+  metrics: HeaderFooterMetrics
+): number {
+  const flowTop =
+    metrics.section === 'header'
+      ? (metrics.margins.header ?? 48)
+      : metrics.pageSize.h - (metrics.margins.footer ?? 48) - flowHeight;
+  const offsetPx = anchor.offsetV;
+  if (anchor.relFromV === 'page' && offsetPx != null) return offsetPx - flowTop;
+  if (anchor.relFromV === 'margin' && offsetPx != null)
+    return metrics.margins.top + offsetPx - flowTop;
+  return offsetPx ?? 0;
+}
+
+/** Header/footer flow-X (content-area-relative) of an anchored textbox. */
+export function resolveHeaderFooterTextBoxLeft(
+  anchor: NonNullable<TextBoxBlock['anchor']>,
+  metrics: HeaderFooterMetrics
+): number {
+  const offsetPx = anchor.offsetH;
+  if (offsetPx == null) return 0;
+  // Header content box is inset by margins.left, so a page-relative offset
+  // becomes content-relative by subtracting the left margin; margin/column
+  // relative offsets are already content-relative.
+  if (anchor.relFromH === 'page') return offsetPx - metrics.margins.left;
+  return offsetPx;
+}
+
 export function calculateHeaderFooterVisualBounds(
   blocks: FlowBlock[],
   measures: Measure[],
@@ -244,10 +293,24 @@ export function calculateHeaderFooterVisualBounds(
       visualBottom = Math.max(visualBottom, blockBottomY);
       cursorY = blockBottomY;
     } else if (block.kind === 'textBox' && measure.kind === 'textBox') {
-      const blockBottomY = cursorY + measure.height;
-      visualTop = Math.min(visualTop, cursorY);
-      visualBottom = Math.max(visualBottom, blockBottomY);
-      cursorY = blockBottomY;
+      if (isAnchoredTextBox(block as TextBoxBlock)) {
+        // Floated (anchored) — contributes its ABSOLUTE extent to the bounds
+        // but does NOT take flow space. Stacking these (the old behavior) summed
+        // all heights, inflating the header so the top margin expanded and the
+        // body was pushed onto extra pages.
+        const top = resolveHeaderFooterTextBoxTop(
+          (block as TextBoxBlock).anchor!,
+          flowHeight,
+          metrics
+        );
+        visualTop = Math.min(visualTop, top);
+        visualBottom = Math.max(visualBottom, top + measure.height);
+      } else {
+        const blockBottomY = cursorY + measure.height;
+        visualTop = Math.min(visualTop, cursorY);
+        visualBottom = Math.max(visualBottom, blockBottomY);
+        cursorY = blockBottomY;
+      }
     }
   }
 

--- a/docx-editor/packages/core/src/layout-painter/renderPage.ts
+++ b/docx-editor/packages/core/src/layout-painter/renderPage.ts
@@ -1083,13 +1083,35 @@ function renderHeaderFooterContent(
       // inside `<w:hdr>` rendered nothing.
       const tbBlock = block as TextBoxBlock;
       const tbMeasure = measure as TextBoxMeasure;
+      const a = tbBlock.anchor;
+      const anchored =
+        !!a && (a.offsetH != null || a.offsetV != null || a.relFromH != null || a.relFromV != null);
+
+      // Anchored (floating) header/footer textboxes are positioned absolutely
+      // from their page/margin offset — mapped into the header content box,
+      // which is inset by margins.left with its flow-top at layout.flowTop — and
+      // do NOT take flow space. In-flow stacking (the old behavior) both
+      // mispositioned them (all at left:0) and inflated the header height,
+      // pushing the body onto extra pages.
+      let tbLeft = 0;
+      let tbTop = cursorY;
+      if (anchored) {
+        const offH = a!.offsetH ?? 0;
+        const offV = a!.offsetV ?? 0;
+        tbLeft = a!.relFromH === 'page' ? offH - layout.margins.left : offH;
+        if (a!.relFromV === 'page') tbTop = offV - layout.flowTop;
+        else if (a!.relFromV === 'margin') tbTop = layout.margins.top + offV - layout.flowTop;
+        else tbTop = offV;
+      }
+
       const syntheticFragment: TextBoxFragment = {
         kind: 'textBox',
         blockId: tbBlock.id,
-        x: 0,
-        y: cursorY,
+        x: tbLeft,
+        y: tbTop,
         width: tbMeasure.width,
         height: tbMeasure.height,
+        isAnchored: anchored || undefined,
       };
       const fragEl = renderTextBoxFragment(
         syntheticFragment,
@@ -1098,10 +1120,10 @@ function renderHeaderFooterContent(
         { ...context, positioning: 'absolute' },
         { document: doc }
       );
-      fragEl.style.top = `${cursorY}px`;
-      fragEl.style.left = '0';
+      fragEl.style.top = `${tbTop}px`;
+      fragEl.style.left = `${tbLeft}px`;
       containerEl.appendChild(fragEl);
-      cursorY += tbMeasure.height;
+      if (!anchored) cursorY += tbMeasure.height;
     }
   }
 


### PR DESCRIPTION
Fixes the header-textbox misalignment in the Chinese SDS (user-reported). Root cause: `parseVmlTextBox` parsed VML text-frames (`<v:shape type=t202>`) for **size + content only**, dropping their `position:absolute`/`mso-position-*` entirely. With no anchor, text-frame textboxes were laid out in-flow — in headers they stacked at `left:0` (mispositioned) and their summed heights inflated the header.

- `parseVmlTextBox` now captures the shape position (same `parseVmlShapePosition` PR #7 added for decorative shapes).
- The header layout positions anchored textboxes absolutely (`resolveHeaderFooterTextBoxTop/Left`) and no longer stacks them in the height measurement.

Result: the SDS header now matches LibreOffice — title top-left, version/print-date row positioned across (vs all stacked at left:0). No regression: textbox corpus stable or slightly better (wpg-group 79→81, three-section 87.6→88.6), medical/textbox-test page-stable; 896 core unit + 14 header e2e + smoke green.

Note: this does **not** change the SDS 18-vs-16 page count — that overflow is body CJK advance-width drift (§1.2 / #19), not the header height, as the page count is unchanged after this fix.