### PR TITLE
fix(image): floating images honor explicit width (no vertical-stretch on resize)

### DIFF
--- a/docx-editor/e2e/tests/image-resize-aspect.spec.ts
+++ b/docx-editor/e2e/tests/image-resize-aspect.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Floating-image resize preserves aspect ratio (no distortion).
+ *
+ * Regression for "resizing the logo stretched it height-wise": the floating
+ * image painter set the image's explicit width but never overrode the global
+ * `img { max-width: 100% }` reset, so enlarging a wide image capped its width
+ * to the container while the height grew freely — squishing it vertically under
+ * `object-fit`. Shrinking happened to stay within the cap, so only enlarging
+ * distorted.
+ *
+ * Fixture: `medical-incident-form.docx` — the Safetymint logo is a wide (~4:1)
+ * `inFront` floating image.
+ */
+import { test, expect, type Page } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+const FIXTURE = 'fixtures/medical-incident-form.docx';
+
+async function loadFixture(page: Page) {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await page.locator('input[type="file"][accept*=".docx"]').setInputFiles(`e2e/${FIXTURE}`);
+  await page.waitForSelector('.paged-editor__pages');
+  await page.waitForSelector('[data-page-number]');
+  await page.waitForTimeout(1500);
+}
+
+test.describe('Floating image resize', () => {
+  test('enlarging a wide logo keeps its aspect ratio', async ({ page }) => {
+    await loadFixture(page);
+
+    const img = page.locator('.layout-page img').first();
+    const before = await img.boundingBox();
+    expect(before).not.toBeNull();
+    if (!before) return;
+    const ratioBefore = before.width / before.height;
+
+    // Select, then drag the SE corner outward to enlarge.
+    await page.mouse.click(before.x + before.width / 2, before.y + before.height / 2);
+    await page.waitForTimeout(200);
+    const cx = before.x + before.width;
+    const cy = before.y + before.height;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx + 60, cy + 20, { steps: 6 });
+    await page.mouse.up();
+    await page.waitForTimeout(400);
+
+    const after = await img.boundingBox();
+    expect(after).not.toBeNull();
+    if (!after) return;
+    const ratioAfter = after.width / after.height;
+
+    // It must have grown...
+    expect(after.width).toBeGreaterThan(before.width);
+    // ...and kept its aspect ratio (no vertical stretch).
+    expect(Math.abs(ratioAfter - ratioBefore)).toBeLessThan(0.15);
+  });
+});

--- a/docx-editor/packages/core/src/layout-painter/renderPage.ts
+++ b/docx-editor/packages/core/src/layout-painter/renderPage.ts
@@ -907,6 +907,13 @@ export function renderFloatingImagesLayer(
     img.src = floatImg.src;
     img.style.width = `${floatImg.width}px`;
     img.style.height = `${floatImg.height}px`;
+    // Override the global `img { max-width: 100% }` reset: a floating image is
+    // sized to its explicit anchor extent (and to the user's resize), so it must
+    // honor that width even when it exceeds the container. Without this the width
+    // is capped to the container while the height is not, distorting the image
+    // (e.g. resizing a wide logo larger stretched it vertically).
+    img.style.maxWidth = 'none';
+    img.style.maxHeight = 'none';
     img.style.display = 'block';
     if (floatImg.alt) img.alt = floatImg.alt;
     if (floatImg.transform) {


### PR DESCRIPTION
User report: resizing the medical-form logo stretched it height-wise.

Root cause: the floating-image painter (`paintFloatingImages` in renderPage.ts) sets the image's explicit width/height but never overrode the global `img { max-width: 100% }` reset. Enlarging a wide float past its container capped its width to the container while the height grew freely — squishing it vertically under `object-fit`. Shrinking stayed within the cap, so only enlarging distorted. The sibling float path already set `maxWidth: none` for this exact reason.

Verified: logo enlarge 201×50 → 281×70 (aspect 4.02 preserved; was distorting to 187×70). Also fixes the resting render of wide floats that were slightly width-capped. e2e regression `image-resize-aspect.spec.ts`; full image e2e + 900 core + 323 react unit + smoke green; VF real-world unchanged.