### PR TITLE
fix(layout): keepNext chain height counts table/image anchors

### DIFF
--- a/docx-editor/packages/core/src/layout-engine/keep-together.test.ts
+++ b/docx-editor/packages/core/src/layout-engine/keep-together.test.ts
@@ -1,0 +1,95 @@
+/**
+ * calculateChainHeight — a keepNext chain must reserve enough height to keep
+ * the chain's paragraphs with the START of whatever they anchor to. The anchor
+ * can be a table or image, not just a paragraph: a heading with keepNext above
+ * a table is the common "table caption" case, and the chain height must include
+ * the table's first row so the caption never orphans from its table.
+ */
+import { describe, expect, test } from 'bun:test';
+import { calculateChainHeight, type KeepNextChain } from './keep-together';
+import type {
+  FlowBlock,
+  Measure,
+  ParagraphBlock,
+  ParagraphMeasure,
+  TableBlock,
+  TableMeasure,
+  ImageBlock,
+  ImageMeasure,
+} from './types';
+
+function para(id: number, keepNext: boolean): ParagraphBlock {
+  return {
+    kind: 'paragraph',
+    id,
+    runs: [{ kind: 'text', text: 'x', pmStart: 0, pmEnd: 1 }],
+    attrs: { keepNext },
+    pmStart: 0,
+    pmEnd: 2,
+  };
+}
+
+function paraMeasure(lineHeight: number): ParagraphMeasure {
+  return {
+    kind: 'paragraph',
+    lines: [
+      {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 0,
+        toChar: 1,
+        width: 10,
+        ascent: 8,
+        descent: 2,
+        lineHeight,
+      },
+    ],
+    totalHeight: lineHeight,
+  };
+}
+
+describe('calculateChainHeight anchor handling', () => {
+  test('table anchor contributes its first-row height (caption keeps with table)', () => {
+    const blocks: FlowBlock[] = [
+      para(0, true), // caption heading, keepNext
+      { kind: 'table', id: 1, rows: [] } as unknown as TableBlock, // anchor: table
+    ];
+    const measures: Measure[] = [
+      paraMeasure(24),
+      {
+        kind: 'table',
+        rows: [{ height: 80 }, { height: 80 }],
+        totalWidth: 400,
+      } as unknown as TableMeasure,
+    ];
+    const chain: KeepNextChain = {
+      startIndex: 0,
+      endIndex: 0,
+      memberIndices: [0],
+      anchorIndex: 1,
+    };
+
+    // 24 (caption) + 80 (first table row) — NOT just 24 (the old bug ignored
+    // the table entirely, letting the table orphan to the next page).
+    expect(calculateChainHeight(chain, blocks, measures)).toBe(104);
+  });
+
+  test('image anchor contributes its full height (images are atomic)', () => {
+    const blocks: FlowBlock[] = [
+      para(0, true),
+      { kind: 'image', id: 1, src: 'x' } as unknown as ImageBlock,
+    ];
+    const measures: Measure[] = [
+      paraMeasure(24),
+      { kind: 'image', width: 100, height: 150 } as unknown as ImageMeasure,
+    ];
+    const chain: KeepNextChain = {
+      startIndex: 0,
+      endIndex: 0,
+      memberIndices: [0],
+      anchorIndex: 1,
+    };
+
+    expect(calculateChainHeight(chain, blocks, measures)).toBe(174);
+  });
+});

--- a/docx-editor/packages/core/src/layout-engine/keep-together.ts
+++ b/docx-editor/packages/core/src/layout-engine/keep-together.ts
@@ -5,7 +5,14 @@
  * (keep all lines together) properties that affect pagination.
  */
 
-import type { FlowBlock, ParagraphBlock, Measure, ParagraphMeasure } from './types';
+import type {
+  FlowBlock,
+  ParagraphBlock,
+  Measure,
+  ParagraphMeasure,
+  TableMeasure,
+  ImageMeasure,
+} from './types';
 
 /**
  * A chain of consecutive keepNext paragraphs.
@@ -141,15 +148,25 @@ export function calculateChainHeight(
     totalHeight += spacingAfter;
   }
 
-  // Add first line height of anchor (if any)
+  // Add the leading height of the anchor — enough that the chain stays with
+  // the START of whatever it anchors to, so a caption never separates from its
+  // content. For a paragraph that's the first line; for a table it's the first
+  // row (Word keeps a heading with at least the first table row); for an image
+  // it's the whole image (an image is atomic and can't split).
   if (chain.anchorIndex !== -1) {
     const anchorMeasure = measures[chain.anchorIndex];
     if (anchorMeasure?.kind === 'paragraph') {
       const anchorPara = anchorMeasure as ParagraphMeasure;
       if (anchorPara.lines.length > 0) {
-        // Add just the first line height
         totalHeight += anchorPara.lines[0].lineHeight;
       }
+    } else if (anchorMeasure?.kind === 'table') {
+      const anchorTable = anchorMeasure as TableMeasure;
+      if (anchorTable.rows.length > 0) {
+        totalHeight += anchorTable.rows[0].height;
+      }
+    } else if (anchorMeasure?.kind === 'image') {
+      totalHeight += (anchorMeasure as ImageMeasure).height;
     }
   }
 


### PR DESCRIPTION
Found while instrumenting SDS pagination. `calculateChainHeight` only added the first-line height of a *paragraph* anchor and ignored table/image anchors. So a heading with `keepNext` above a table (table-caption pattern) under-counted its chain height — the chain 'fit' the remaining space while the table itself overflowed to the next page, orphaning the caption from its table.

Now a table anchor contributes its first-row height (Word keeps a heading with at least the first row) and an image anchor its full height (atomic). Unit test in keep-together.test.ts; 902 core unit + full layout-engine suite green; VF real-world unchanged (the SDS has no keepNext chains, so it's unaffected — this targets table-caption docs).