### PR TITLE
fix(layout): pixel-faithful real-world fixtures (B1 logo, B2 hazard-box, SDS 18→16 pages)

### DIFF
--- a/docs/internal/20-overlap-and-interaction.md
+++ b/docs/internal/20-overlap-and-interaction.md
@@ -14,36 +14,31 @@ verified / investigating / pending.
 
 | # | Bug | Type | Evidence / root cause | Status |
 |---|-----|------|-----------------------|--------|
-| B1 | **Logo image overlaps the "Powered by:" text** (medical-incident-form p1) | R | **Root-caused.** Logo is an `inFront` body image (not header), `position={H: column +532px, V: paragraph +22.7px}`. Extracted by `extractFloatingImagesFromParagraph` (`renderPage.ts:685`) → positioned `resolveAnchorY(vertical, h, fragmentY) = fragmentY + 22.7px`. Measured: logo paints at y105, but its anchoring paragraph's text ("Take a free trial") flows at y180 — the `fragmentY` handed to the extractor (~82) doesn't track the paragraph's real flow position, so the logo lands ~75px too high and overlaps "Powered by:" (y122). Fix = source the correct paragraph `fragmentY` for `inFront`/`behind` body images. **Caution: shared float-image pipeline — verify against all floating-image fixtures + round-trip before shipping.** Note: `convertImage` (`toFlowBlocks.ts:1487`) also builds the layout-engine anchor from `distLeft`/`distTop` (wrong fields) and drops `relativeFrom` — dead path for body floats (painter wins) but should be aligned with the textbox anchor (PR #7) for consistency. | root-caused, fix pending |
-| B2 | **SDS hazard-box overlaps the flow** (sds-anti-t-zh p1) | R | **Fully root-caused.** The hazard box is one behind-doc VML `<v:group>` (`docshape12` = border path + 3 text shapes for 外观与性状/液体/statement), `margin-left:88.46pt width:439.9pt`, `coordsize 8798×1508`, `z-index:-15728128`, anchored to an **empty** paragraph (`mso-position-vertical-relative:paragraph`). **A1's coordinate transform is CORRECT** — computed child positions/widths match our render to the pixel (label x123/w68, value x312/w60, statement x123/w572). The overlap is NOT the transform: behind-doc objects don't reserve space, so the flow GHS list (易燃液体/皮肤过敏…) renders at y542 right under 紧急情况概述 (y523) instead of ~75pt lower, and the behind-doc box paints over it. Root cause = **flow doesn't reserve the box's vertical band** (the hazard rows aren't in the flow between 紧急情况概述 and GHS 危险性类别; they only exist in the behind-doc group). Fix space = make a behind-doc group anchored to an empty paragraph reserve its height, OR reproduce the authored flow spacing. Same family as the cumulative CJK drift. **Hard; needs a focused pass with VF + round-trip — not a transform tweak.** | root-caused, fix pending |
+| B1 | **Logo image overlaps the "Powered by:" text** (medical-incident-form p1) | R | **FIXED** — the letterhead is a DrawingML group (Powered-by box + logo + free-trial box at fixed offsets). Root cause was an anchor-base mismatch: the float-image path resolves `relFromV='paragraph'` against the paragraph TOP (`fragment.y`), but `layoutAnchoredTextBox` used the flow cursor (which sits at the paragraph BOTTOM, ~a line lower by the time the sibling-extracted box lays out), pushing the "Powered by:" box below the logo. Now paragraph/line-relative anchored textboxes share the float path's base (last paragraph's first-fragment top, on-page guarded); page/margin anchors unaffected. Header renders Powered-by → logo → free-trial, matches LibreOffice. | **FIXED (PR #17)** |
+| B2 | **SDS hazard-box overlaps the flow** (sds-anti-t-zh p1) | R | **Fully root-caused.** The hazard box is one behind-doc VML `<v:group>` (`docshape12` = border path + 3 text shapes for 外观与性状/液体/statement), `margin-left:88.46pt width:439.9pt`, `coordsize 8798×1508`, `z-index:-15728128`, anchored to an **empty** paragraph (`mso-position-vertical-relative:paragraph`). **A1's coordinate transform is CORRECT** — computed child positions/widths match our render to the pixel (label x123/w68, value x312/w60, statement x123/w572). The overlap is NOT the transform: behind-doc objects don't reserve space, so the flow GHS list (易燃液体/皮肤过敏…) renders at y542 right under 紧急情况概述 (y523) instead of ~75pt lower, and the behind-doc box paints over it. Root cause = **flow doesn't reserve the box's vertical band** (the hazard rows aren't in the flow between 紧急情况概述 and GHS 危险性类别; they only exist in the behind-doc group). Fix space = make a behind-doc group anchored to an empty paragraph reserve its height, OR reproduce the authored flow spacing. Same family as the cumulative CJK drift. | **FIXED** — behind-doc paragraph-anchored groups now reserve their flow band so the GHS list flows below the box (no overlap). Enablers were two dead plumbing gaps (VML z-index never parsed; `anchor.behindDoc` never set). Reserve once per group cluster, gated `relFromV==='paragraph'` (watermark guard) + hairline floor (dividers reserve 0). VF sds 43.1→43.6, no regression. *Remaining incremental:* the address text-frame above is still slightly cramped (separate behind-doc frame). |
 | B3 | **Some SDS text appears vertical** ("idk if doc is that way") | R | **Not a rotation bug** — scanned all 18 pages: zero `writing-mode: vertical-*` and zero rotated transforms on text. The "vertical" look is narrow hazard/address text-frames (e.g. 外观与性状 in a ~68px box) wrapping CJK one character per line. Subset of B2 — fixing the text-frame width/positioning resolves it. | folded into B2 |
 | B4 | **SDS page-1 line-2 ("按照 GB/T 16483、GB/T 17519") position wrong vs LibreOffice** | R | Title block subtitle sits at a different Y than the reference; likely the title/subtitle is in an anchored header text-frame whose vertical offset is off (same family as B1). | investigating |
 | B5 | **Image move snaps top-left to cursor (movement "screwed up")** | I | **FIXED.** Repro: resize works 1:1 for inline + floating images; but *moving* a floating image snapped its top-left to the drop cursor, ignoring the grab offset — grabbing the centre and dragging +80,+40 moved the image +128,+88 (jumped by the ~48px grab offset). `handleImageDragMove` set `posOffset` to the raw drop cursor; the drag ghost also centred on the cursor. Now both subtract the grab offset captured at mousedown (`ImageSelectionOverlay` → `onDragMove`), so the grabbed point stays under the cursor. Verified +80,+40 → +80,+40; e2e regression `image-drag-move.spec.ts`; 16 image e2e still green. | **FIXED** |
 | B6 | **Image + text editing / handling on user action broken** | I | Largely the same drag-move defect as B5 (now fixed). Remaining: re-verify caret-place/type/select across an anchored object once B1/B2 anchor geometry lands. | partially fixed |
 
-## Unifying conclusion (after full diagnosis)
+## Outcome (after implementation)
 
-**B1, B2, and B4 are one systemic issue, not three discrete anchor bugs.** In
-each case the anchored object is placed *correctly relative to its anchor
-paragraph* (verified: B2's group transform is pixel-exact; B1's logo sits at
-its anchor-paragraph Y + offset). What diverges from Word is **the flow
-position of the anchor paragraphs themselves** — order and/or accumulated
-spacing:
+The earlier hypothesis that B1/B2/B4 were one diffuse "empty-paragraph spacing"
+problem requiring a big metrics pass was **wrong** — each had a discrete,
+targeted root cause and was fixed surgically:
 
-- B1: the logo anchors to an early empty paragraph that, in our flow, sits
-  *above* "Powered by:"; in the reference the logo lands *below* it. The
-  surrounding empty paragraphs (y82 h25, y107 h54, y161 h29) don't match Word's
-  heights/order, so the anchor lands a line too high.
-- B2: the behind-doc hazard group is placed correctly, but the flow GHS list
-  doesn't leave the ~75pt band it occupies, so they collide.
-- B4: title-block subtitle Y, same family.
+- **B1 — FIXED**: anchor-base mismatch between the float and anchored-textbox
+  paths (paragraph TOP vs flow cursor). One change unifies them.
+- **B2 — FIXED**: behind-doc anchored groups didn't reserve their flow band
+  (plus two dead plumbing gaps: z-index never parsed, `anchor.behindDoc` never
+  set). Reserve once per cluster, watermark-guarded.
+- **B4 — open**: SDS title subtitle Y. Likely the same anchored-textbox-base
+  family as B1; re-check now that B1 landed.
 
-This is the same root as the cumulative CJK drift (#19) and the
-medical-incident-form row drift: **empty-paragraph + line-height spacing
-fidelity vs Word.** Piecemeal anchor patches won't hold — the fix is a spacing
-metrics pass (empty-paragraph heights, line-spacing) validated against the VF
-real-world group, then anchored objects fall into place. Large surface; needs
-its own scoped effort with round-trip + VF guards.
+The verified-correct facts still hold: anchored objects are placed correctly
+*relative to their anchor* (B2 transform pixel-exact; line height honored; CJK
+width ~1em). The remaining SDS **18-vs-16 page count** is multi-column layout
+(see Plan), NOT diffuse spacing.
 - B5/B6 are interaction, invisible to the VF PNG pipeline — they need live
   Playwright drag/keyboard repros (see [[feedback-verify-ui-with-playwright]]).
 - VF scoring caveat: editor PNGs render at ~192dpi, reference at ~150dpi; the
@@ -79,8 +74,36 @@ missed ones flow single-column at ~2× height → the 2 extra pages (18 vs 16).
 Margins/padding are 0 and the ~8px inter-paragraph gaps match the doc's
 `space-before=122`, so paragraph spacing is NOT the cause.
 
-Next pass = **multi-column completion**: ensure every `cols=2` continuous
-section renders two balanced columns, and the 1↔2 column transitions don't
-waste vertical space. Feature-completion (not a one-line fix); gate each step
-on the VF `real-world` group + the 39 round-trip fixtures. Earlier paragraph
-column breaks (PR #11) and this share the same multi-column subsystem.
+**FIXED (PR #17).** The cause was narrower than "balancing": the paginator
+split every multi-column section into EQUAL halves, ignoring `equalWidth="0"`
+and the per-column `<w:col>` widths. The SDS's 7 label/value sections use a
+narrow label + wide value column; squeezing the value column to an even split
+over-wrapped its text and inflated every region → +2 pages. Threaded
+`columnWidths` through `ColumnLayout` → `toFlowBlocks` → PagedEditor per-block
+measurement → paginator positioning/`getCurrentColumnContentWidth`, plus
+`ensureColumnRegionFits` (keeps a short 2-col region together, fixes a stray
+overflow strip). Gated behind `equalWidth===false` + complete widths, so
+equal/single-column layouts are unchanged. **SDS 18→16 pages (matches
+reference), VF 43.6→60.7**; medical/Form025U unchanged. Also fixed (earlier,
+this branch) the column-region resume-below-deepest overpaint.
+
+### Net result of this fidelity push (PR #17)
+SDS `sds-anti-t-zh`: **43.0 → 60.7**, page-count mismatch **resolved (16=16)**.
+Corpus mean 43.8 → **52.7**. B1 (logo overlap), B2 (hazard overlap), and the
+multi-column page count all solved.
+
+### Remaining for pixel-faithful
+- **medical-incident-form body drift (33.1)** — ROOT-CAUSED (not table rows; rows
+  match the reference within the validated Wingdings tolerance). The driver is
+  the **header-margin path with a negative `w:pgMar` top** (`w:top="-270"` =
+  −13.5pt): `getMargins`/`extendHeader` in `PagedEditor.tsx` sets
+  `effectiveMargins.top = headerDistance + headerContentHeight`, and our
+  `headerContentHeight` for `header1.xml` is ~25–32pt larger than LibreOffice's,
+  starting the body ~22–32pt low on every page → content cascades (page count
+  still 4=4 but offset by ~1 section). In LibreOffice a negative top margin lets
+  the header OVERLAP the body rather than fully displacing it. **Next step:** a
+  header-focused fix to `headerContentHeight`/overlap behavior — high regression
+  risk (shared by SDS 16pp + Form025U + the 39 round-trip fixtures), needs full
+  VF + round-trip guards.
+- **B4** (SDS subtitle Y) — recheck since B1 landed.
+- **Address text-frame cramp** (SDS p1, incremental — separate behind-doc frame).

--- a/docx-editor/packages/core/src/docx/__tests__/vmlTextBoxParser-behind.test.ts
+++ b/docx-editor/packages/core/src/docx/__tests__/vmlTextBoxParser-behind.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit test — VML `<v:group>` with `z-index < 0` parses to behind-doc wrap.
+ *
+ * The SDS hazard box is one `<v:group z-index:-15728128>` whose children must
+ * inherit the behind-text wrap so the flow reserves their band (B2). Decorative
+ * dividers carry the same negative z-index but, being hairlines, are screened
+ * out later in the layout engine — here we only assert the wrap is parsed.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { parseXml, getChildElements } from '../xmlParser';
+import { parseVmlShapes } from '../vmlTextBoxParser';
+import type { Paragraph } from '../../types/content';
+
+// Minimal paragraph parser stub — the shapes we test carry no inner text.
+const stubParseParagraph = (): Paragraph => ({ type: 'paragraph', content: [] });
+
+// parseXml returns a synthetic document wrapper; the real <w:pict> is its
+// first element child.
+function pict(inner: string) {
+  const root = parseXml(`<w:pict xmlns:w="w" xmlns:v="v">${inner}</w:pict>`);
+  return getChildElements(root)[0];
+}
+
+describe('parseVmlShapes — behind-doc z-index', () => {
+  test('group with negative z-index → children get behind wrap', () => {
+    const el = pict(
+      `<v:group style="position:absolute;margin-left:88pt;margin-top:19pt;width:439.9pt;height:75.4pt;mso-position-horizontal-relative:page;mso-position-vertical-relative:paragraph;z-index:-15728128" coordorigin="1769,389" coordsize="8798,1508">
+         <v:shape type="#_x0000_t202" style="position:absolute;left:1779;top:993;width:1360;height:520">
+           <v:textbox><w:txbxContent><w:p/></w:txbxContent></v:textbox>
+         </v:shape>
+       </v:group>`
+    );
+    const shapes = parseVmlShapes(el, stubParseParagraph);
+    expect(shapes.length).toBeGreaterThan(0);
+    expect(shapes[0].wrap?.type).toBe('behind');
+  });
+
+  test('group with no z-index → no wrap (default inline flow)', () => {
+    const el = pict(
+      `<v:group style="position:absolute;margin-left:88pt;margin-top:19pt;width:100pt;height:50pt;mso-position-vertical-relative:paragraph" coordorigin="0,0" coordsize="1000,500">
+         <v:shape type="#_x0000_t202" style="position:absolute;left:0;top:0;width:500;height:250">
+           <v:textbox><w:txbxContent><w:p/></w:txbxContent></v:textbox>
+         </v:shape>
+       </v:group>`
+    );
+    const shapes = parseVmlShapes(el, stubParseParagraph);
+    expect(shapes.length).toBeGreaterThan(0);
+    expect(shapes[0].wrap).toBeUndefined();
+  });
+
+  test('ungrouped shape with negative z-index → behind wrap', () => {
+    const el = pict(
+      `<v:shape type="#_x0000_t202" style="position:absolute;margin-left:10pt;margin-top:10pt;width:100pt;height:30pt;mso-position-vertical-relative:paragraph;z-index:-1">
+         <v:textbox><w:txbxContent><w:p/></w:txbxContent></v:textbox>
+       </v:shape>`
+    );
+    const shapes = parseVmlShapes(el, stubParseParagraph);
+    expect(shapes.length).toBeGreaterThan(0);
+    expect(shapes[0].wrap?.type).toBe('behind');
+  });
+});

--- a/docx-editor/packages/core/src/docx/vmlTextBoxParser.ts
+++ b/docx-editor/packages/core/src/docx/vmlTextBoxParser.ts
@@ -34,6 +34,7 @@ import type {
   ShapeFill,
   ShapeOutline,
   ImagePosition,
+  ImageWrap,
 } from '../types/content';
 import {
   findDeep,
@@ -271,6 +272,21 @@ const VML_V_ALIGN: Record<string, ImagePosition['vertical']['alignment']> = {
   outside: 'outside',
 };
 
+/**
+ * A negative VML `z-index` means the shape paints BEHIND the body text
+ * (Word's "Behind Text" wrap). Word authors the SDS hazard box this way
+ * (`z-index:-15728128`). The sign is what matters; the magnitude is just a
+ * stacking order among other behind-doc shapes. Returns the `behind` wrap so
+ * downstream layout can both paint it behind and reserve its band in the flow.
+ */
+function parseVmlBehindWrap(decls: Map<string, string>): ImageWrap | undefined {
+  const z = decls.get('z-index');
+  if (z === undefined) return undefined;
+  const n = parseFloat(z);
+  if (Number.isFinite(n) && n < 0) return { type: 'behind' };
+  return undefined;
+}
+
 function parseVmlShapePosition(
   _shapeEl: XmlElement,
   decls: Map<string, string>
@@ -348,6 +364,7 @@ function decorativeShapeToTextBox(shape: XmlElement, transform?: GroupTransform)
 
   const fill = parseFillForShape(shape);
   const outline = parseOutlineForShape(shape);
+  const wrap = transform ? transform.wrap : parseVmlBehindWrap(decls);
   const id = getAttribute(shape, null, 'id') ?? undefined;
 
   return {
@@ -355,6 +372,7 @@ function decorativeShapeToTextBox(shape: XmlElement, transform?: GroupTransform)
     id,
     size,
     position,
+    wrap,
     fill,
     outline,
     // Decorative shapes (box-border rects, dividers) are pure fill with no text
@@ -391,6 +409,8 @@ interface GroupTransform {
   topEmu: number | null;
   /** Group anchoring frame, inherited by every child. */
   position: ImagePosition | undefined;
+  /** Behind-text wrap inherited from the group's `z-index < 0`, if any. */
+  wrap: ImageWrap | undefined;
   originX: number;
   originY: number;
   scaleX: number;
@@ -428,6 +448,7 @@ function buildGroupTransform(groupEl: XmlElement): GroupTransform {
     leftEmu: lengthDeclToEmu(decls.get('margin-left')),
     topEmu: lengthDeclToEmu(decls.get('margin-top')),
     position: parseVmlShapePosition(groupEl, decls),
+    wrap: parseVmlBehindWrap(decls),
     originX: origin[0],
     originY: origin[1],
     scaleX,
@@ -569,6 +590,9 @@ function textBoxShapeToTextBox(
   const position = transform
     ? transformChildPosition(decls, transform)
     : parseVmlShapePosition(shape, decls);
+  // Behind-text wrap: a grouped child inherits the group's z-index<0; an
+  // ungrouped shape carries its own.
+  const wrap = transform ? transform.wrap : parseVmlBehindWrap(decls);
   const id = getAttribute(shape, null, 'id') ?? undefined;
 
   return {
@@ -576,6 +600,7 @@ function textBoxShapeToTextBox(
     id,
     size,
     position,
+    wrap,
     content,
   };
 }

--- a/docx-editor/packages/core/src/layout-bridge/__tests__/toFlowBlocks-behind-doc-anchor.test.ts
+++ b/docx-editor/packages/core/src/layout-bridge/__tests__/toFlowBlocks-behind-doc-anchor.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Integration test — a behind-doc shape's wrap survives end-to-end so the
+ * layout engine can both paint it behind text AND reserve its flow band.
+ *
+ *   Document model (Shape with wrap.type 'behind', anchored to a paragraph)
+ *     → toProseDoc (textBox node carries wrapType='behind')
+ *     → toFlowBlocks (TextBoxBlock.anchor.behindDoc === true)
+ *
+ * Regression guard for B2 (SDS hazard box): before this, the VML group's
+ * `z-index < 0` was dropped at parse time and `convertTextBoxNode` never set
+ * `anchor.behindDoc`, so behind-doc anchored shapes could not reserve space.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { toProseDoc } from '../../prosemirror/conversion/toProseDoc';
+import { toFlowBlocks } from '../toFlowBlocks';
+import type { Document, Paragraph, Shape } from '../../types/document';
+import type { TextBoxBlock } from '../../layout-engine/types';
+
+function paragraphWithShape(shape: Shape): Paragraph {
+  return {
+    type: 'paragraph',
+    content: [{ type: 'run', content: [{ type: 'shape', shape }] }],
+  };
+}
+
+function makeDocument(paragraph: Paragraph): Document {
+  return { package: { document: { content: [paragraph] } } };
+}
+
+function behindShape(): Shape {
+  return {
+    type: 'shape',
+    shapeType: 'rect',
+    size: { width: 914400, height: 914400 }, // 1in × 1in (EMU)
+    position: {
+      horizontal: { relativeTo: 'page', posOffset: 914400 },
+      vertical: { relativeTo: 'paragraph', posOffset: 304800 },
+    },
+    wrap: { type: 'behind' },
+    textBody: { content: [{ type: 'paragraph', content: [] }] },
+  };
+}
+
+describe('toFlowBlocks — behind-doc anchored shape', () => {
+  test('wrap.type "behind" → anchor.behindDoc true on the layout block', () => {
+    const pmDoc = toProseDoc(makeDocument(paragraphWithShape(behindShape())));
+    const blocks = toFlowBlocks(pmDoc, {});
+    const tb = blocks.find((b): b is TextBoxBlock => b.kind === 'textBox');
+    expect(tb).toBeDefined();
+    expect(tb!.anchor?.behindDoc).toBe(true);
+    expect(tb!.anchor?.relFromV).toBe('paragraph');
+  });
+
+  test('a non-behind (inFront) shape leaves behindDoc unset', () => {
+    const shape = behindShape();
+    shape.wrap = { type: 'inFront' };
+    const pmDoc = toProseDoc(makeDocument(paragraphWithShape(shape)));
+    const blocks = toFlowBlocks(pmDoc, {});
+    const tb = blocks.find((b): b is TextBoxBlock => b.kind === 'textBox');
+    expect(tb).toBeDefined();
+    expect(tb!.anchor?.behindDoc).toBeUndefined();
+  });
+});

--- a/docx-editor/packages/core/src/layout-bridge/toFlowBlocks.ts
+++ b/docx-editor/packages/core/src/layout-bridge/toFlowBlocks.ts
@@ -1530,6 +1530,10 @@ function convertTextBoxNode(
     attrs.posRelFromV != null ||
     attrs.posAlignH != null ||
     attrs.posAlignV != null;
+  // `behindDoc` (VML z-index<0 → wrapType 'behind') drives both the paint
+  // order (z-index −1) and the flow space-reservation for paragraph-anchored
+  // groups (the SDS hazard box). Carried on the anchor only.
+  const behindDoc = (attrs.wrapType as string | undefined) === 'behind';
   const anchor: TextBoxBlock['anchor'] = hasAnchor
     ? {
         offsetH: (attrs.posOffsetH as number | undefined) ?? undefined,
@@ -1538,6 +1542,7 @@ function convertTextBoxNode(
         relFromV: (attrs.posRelFromV as string | undefined) ?? undefined,
         alignH: (attrs.posAlignH as string | undefined) ?? undefined,
         alignV: (attrs.posAlignV as string | undefined) ?? undefined,
+        behindDoc: behindDoc || undefined,
       }
     : undefined;
 
@@ -1655,6 +1660,22 @@ export function toFlowBlocks(doc: PMNode, options: ToFlowBlocksOptions = {}): Fl
                   equalWidth: secProps.equalWidth ?? true,
                   separator: secProps.separator,
                 };
+                // Unequal columns (`w:equalWidth="0"`): carry the explicit
+                // per-column `w:col` widths/spaces so the value column gets its
+                // true (wider) width instead of an even split — even columns
+                // over-narrow the wide column, over-wrapping its text and
+                // inflating the region (and document) height.
+                if (
+                  secProps.equalWidth === false &&
+                  secProps.columns &&
+                  secProps.columns.length === colCount &&
+                  secProps.columns.every((c) => typeof c.width === 'number' && c.width > 0)
+                ) {
+                  cols.columnWidths = secProps.columns.map((c) => ({
+                    width: twipsToPixels(c.width as number),
+                    space: twipsToPixels(c.space ?? 0),
+                  }));
+                }
                 sectionBreak.columns = cols;
               }
             }

--- a/docx-editor/packages/core/src/layout-engine/__tests__/anchored-textbox-paragraph-base.test.ts
+++ b/docx-editor/packages/core/src/layout-engine/__tests__/anchored-textbox-paragraph-base.test.ts
@@ -1,0 +1,115 @@
+/**
+ * A `relFromV="paragraph"` anchored textbox (e.g. a letterhead "Powered by:"
+ * box that `convertParagraphWithTextBoxes` extracts into a sibling block
+ * immediately after its empty source paragraph) must anchor to the TOP of that
+ * paragraph — the same base the float-image path uses (`fragment.y`). The bug:
+ * the engine used the post-paragraph `cursorY` (the paragraph BOTTOM) as the
+ * base, pushing the box a paragraph-height too low and flipping it below a
+ * sibling object that correctly anchored to the paragraph top
+ * (medical-incident-form's Safetymint header).
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { layoutDocument } from '../index';
+import type {
+  FlowBlock,
+  Measure,
+  ParagraphBlock,
+  ParagraphMeasure,
+  TextBoxBlock,
+  TextBoxMeasure,
+  TextBoxFragment,
+} from '../types';
+
+const PAGE = { w: 816, h: 1056 };
+const MARGINS = { top: 96, right: 96, bottom: 96, left: 96 };
+
+function para(id: string, height: number): { block: ParagraphBlock; measure: ParagraphMeasure } {
+  return {
+    block: {
+      kind: 'paragraph',
+      id,
+      pmStart: 0,
+      pmEnd: 0,
+      runs: [{ kind: 'text', text: id }],
+      attrs: {},
+    },
+    measure: {
+      kind: 'paragraph',
+      lines: [
+        {
+          fromRun: 0,
+          fromChar: 0,
+          toRun: 0,
+          toChar: 0,
+          width: 100,
+          ascent: 10,
+          descent: 3,
+          lineHeight: height,
+        },
+      ],
+      totalHeight: height,
+    },
+  };
+}
+
+function anchoredTextBox(
+  id: string,
+  offsetV: number
+): { block: TextBoxBlock; measure: TextBoxMeasure } {
+  return {
+    block: {
+      kind: 'textBox',
+      id,
+      width: 200,
+      height: 20,
+      content: [],
+      anchor: { relFromV: 'paragraph', offsetV, relFromH: 'column', offsetH: 0 },
+      pmStart: 0,
+      pmEnd: 0,
+    },
+    measure: { kind: 'textBox', width: 200, height: 20, innerMeasures: [] },
+  };
+}
+
+describe('paragraph-anchored textbox base', () => {
+  test('anchors to the source paragraph TOP, ordered by offsetV', () => {
+    // An empty anchor paragraph (height 40), then two sibling textboxes that
+    // both anchor relative to that paragraph at different vertical offsets.
+    const P = para('anchor', 40);
+    const top = anchoredTextBox('tb-top', 10);
+    const bottom = anchoredTextBox('tb-bottom', 60);
+
+    const blocks: FlowBlock[] = [P.block, top.block, bottom.block];
+    const measures: Measure[] = [P.measure, top.measure, bottom.measure];
+
+    const layout = layoutDocument(blocks, measures, { pageSize: PAGE, margins: MARGINS });
+    const frags = layout.pages[0].fragments;
+
+    const paraFrag = frags.find((f) => f.kind === 'paragraph')!;
+    const tbTop = frags.find(
+      (f) => f.kind === 'textBox' && (f as TextBoxFragment).blockId === 'tb-top'
+    ) as TextBoxFragment;
+    const tbBottom = frags.find(
+      (f) => f.kind === 'textBox' && (f as TextBoxFragment).blockId === 'tb-bottom'
+    ) as TextBoxFragment;
+
+    // Base is the paragraph TOP (its fragment.y), not the post-paragraph cursor
+    // (paragraph top + 40). Each box = paragraphTop + offsetV.
+    expect(tbTop.y).toBeCloseTo(paraFrag.y + 10, 1);
+    expect(tbBottom.y).toBeCloseTo(paraFrag.y + 60, 1);
+
+    // Ordering preserved: smaller offsetV paints above larger.
+    expect(tbTop.y).toBeLessThan(tbBottom.y);
+  });
+
+  test('falls back to the flow cursor when no paragraph precedes the box', () => {
+    // A textbox with no preceding paragraph on the page keeps the cursor-based
+    // base (no regression for the standalone / leading-shape case).
+    const tb = anchoredTextBox('tb-lone', 30);
+    const layout = layoutDocument([tb.block], [tb.measure], { pageSize: PAGE, margins: MARGINS });
+    const frag = layout.pages[0].fragments.find((f) => f.kind === 'textBox') as TextBoxFragment;
+    // cursor starts at top margin → base = margins.top → y = margins.top + 30.
+    expect(frag.y).toBeCloseTo(MARGINS.top + 30, 1);
+  });
+});

--- a/docx-editor/packages/core/src/layout-engine/__tests__/continuous-section-geometry.test.ts
+++ b/docx-editor/packages/core/src/layout-engine/__tests__/continuous-section-geometry.test.ts
@@ -145,4 +145,133 @@ describe('continuous section break geometry', () => {
     // Column 0 (B) ended at 450; D must be at or below that, never at ~230.
     expect(dFrag!.y).toBeGreaterThanOrEqual(450);
   });
+
+  test('unequal columns (equalWidth=0) position fragments at their explicit column X + width', () => {
+    // Narrow left column (label) + wide right column (value), like the SDS
+    // label/value sections. The wide column's text must NOT be squeezed into
+    // an even split — that over-wraps and inflates region height.
+    //
+    // ECMA-376: a section break carries the properties of the section it ENDS,
+    // so the unequal-2-column config sits on the break that FOLLOWS the
+    // label/value content (`endRegion`); a trailing break drops back to 1
+    // column for `tail`.
+    const label = para('label', 40); // column 0
+    const colBreak: FlowBlock = { kind: 'columnBreak', id: 'cb' };
+    const value = para('value', 40); // column 1
+    const endRegion: SectionBreakBlock = {
+      kind: 'sectionBreak',
+      id: 'endRegion',
+      type: 'continuous',
+      columns: {
+        count: 2,
+        gap: 10,
+        equalWidth: false,
+        columnWidths: [
+          { width: 150, space: 10 }, // left label column
+          { width: 540, space: 0 }, // wide value column
+        ],
+      },
+    };
+    const to1: SectionBreakBlock = {
+      kind: 'sectionBreak',
+      id: 'to1',
+      type: 'continuous',
+      columns: { count: 1, gap: 0 },
+    };
+    const tail = para('tail', 40);
+
+    const blocks: FlowBlock[] = [label.block, colBreak, value.block, endRegion, to1, tail.block];
+    const measures = [
+      label.measure,
+      { kind: 'columnBreak' },
+      value.measure,
+      { kind: 'sectionBreak' },
+      { kind: 'sectionBreak' },
+      tail.measure,
+    ] as never;
+
+    const result = layoutDocument(blocks, measures, {
+      pageSize: { w: 800, h: 2000 },
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+    });
+
+    const frags = result.pages.flatMap((p) => p.fragments);
+    const labelFrag = frags.find((f) => f.blockId === 'label')!;
+    const valueFrag = frags.find((f) => f.blockId === 'value')!;
+    expect(labelFrag).toBeDefined();
+    expect(valueFrag).toBeDefined();
+    // Left column starts at the left margin and is the narrow width.
+    expect(labelFrag.x).toBe(50);
+    expect(labelFrag.width).toBe(150);
+    // Right column starts after left width + its trailing space (150 + 10),
+    // measured from the left margin, and takes the wide width.
+    expect(valueFrag.x).toBe(50 + 150 + 10);
+    expect(valueFrag.width).toBe(540);
+  });
+
+  test('a short 2-column region that will not fit in the remaining page space is pushed whole', () => {
+    // Fill most of the page, then a continuous break entering a 2-column
+    // region that needs more than the leftover height but fits on a fresh
+    // page. The region must move whole to the next page rather than splitting
+    // one column's overflow into a stray strip on the next page.
+    //
+    // `enter` switches the flow into the 2-column section; `endRegion` (which
+    // carries the 2-column config per ECMA-376) ends it. The 50px leftover
+    // after A is far less than the region's ~120px tallest column.
+    const A = para('a', 850); // 50(margin)+850 = 900; leftover to 950 is 50px
+    const enter: SectionBreakBlock = { kind: 'sectionBreak', id: 'enter', type: 'continuous' };
+    const left = para('left', 120); // column 0 (taller than the 50px leftover)
+    const colBreak: FlowBlock = { kind: 'columnBreak', id: 'cb' };
+    const right = para('right', 120); // column 1
+    const endRegion: SectionBreakBlock = {
+      kind: 'sectionBreak',
+      id: 'endRegion',
+      type: 'continuous',
+      columns: { count: 2, gap: 20 },
+    };
+    const to1: SectionBreakBlock = {
+      kind: 'sectionBreak',
+      id: 'to1',
+      type: 'continuous',
+      columns: { count: 1, gap: 0 },
+    };
+    const tail = para('tail', 40);
+
+    const blocks: FlowBlock[] = [
+      A.block,
+      enter,
+      left.block,
+      colBreak,
+      right.block,
+      endRegion,
+      to1,
+      tail.block,
+    ];
+    const measures = [
+      A.measure,
+      { kind: 'sectionBreak' },
+      left.measure,
+      { kind: 'columnBreak' },
+      right.measure,
+      { kind: 'sectionBreak' },
+      { kind: 'sectionBreak' },
+      tail.measure,
+    ] as never;
+
+    const result = layoutDocument(blocks, measures, {
+      pageSize: { w: 800, h: 1000 }, // contentBottom = 950
+      margins: { top: 50, right: 50, bottom: 50, left: 50 },
+    });
+
+    const pageOf = (id: string) =>
+      result.pages.findIndex((p) => p.fragments.some((f) => f.blockId === id));
+    const leftPage = pageOf('left');
+    const rightPage = pageOf('right');
+    // The whole region lands together on the SECOND page (index 1), below A.
+    expect(leftPage).toBe(1);
+    expect(rightPage).toBe(1);
+    // And it starts at that page's top margin, not split from the first page.
+    const leftFrag = result.pages[1].fragments.find((f) => f.blockId === 'left')!;
+    expect(leftFrag.y).toBe(50);
+  });
 });

--- a/docx-editor/packages/core/src/layout-engine/index.ts
+++ b/docx-editor/packages/core/src/layout-engine/index.ts
@@ -102,6 +102,73 @@ export function collectSectionConfigs(
   return { configs, breakIndices };
 }
 
+/**
+ * Measured height a single block contributes to a column's running height.
+ * Mirrors what the per-kind layout helpers consume from the cursor (paragraph
+ * line stack, image/table/text-box box height); breaks and section markers add
+ * nothing.
+ */
+function blockFlowHeight(block: FlowBlock, measure: Measure): number {
+  switch (measure.kind) {
+    case 'paragraph':
+      return measure.totalHeight;
+    case 'image':
+      return measure.height;
+    case 'table':
+      return measure.totalHeight;
+    case 'textBox':
+      // Anchored text boxes float and don't consume column height; inline ones do.
+      return (block as TextBoxBlock).anchor ? 0 : measure.height;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Estimate the height of the multi-column region beginning at the section break
+ * `startIdx` (its tallest column), walking to the next section break.
+ *
+ * Distributes blocks across `columnCount` columns the way the paginator does:
+ * accumulate into the current column, jump to the next column on an explicit
+ * `columnBreak`, collapse adjacent paragraph spacing to the larger side. The
+ * region's height is the deepest column. Used only to decide whether a short
+ * region should be pushed whole to the next page (see
+ * `paginator.ensureColumnRegionFits`); it is an estimate, so it caps the column
+ * index at the last column and ignores in-column overflow (the paginator still
+ * owns real pagination).
+ */
+function computeColumnRegionHeight(
+  blocks: FlowBlock[],
+  measures: Measure[],
+  startIdx: number,
+  columnCount: number
+): number {
+  const colHeights = new Array<number>(columnCount).fill(0);
+  const colTrailing = new Array<number>(columnCount).fill(0);
+  let col = 0;
+  for (let i = startIdx + 1; i < blocks.length; i++) {
+    const block = blocks[i];
+    if (block.kind === 'sectionBreak') break;
+    if (block.kind === 'pageBreak') break; // a hard page break ends the region's single-page extent
+    if (block.kind === 'columnBreak') {
+      if (col < columnCount - 1) col += 1;
+      continue;
+    }
+    const height = blockFlowHeight(block, measures[i]);
+    if (height <= 0) continue;
+    let spaceBefore = 0;
+    let spaceAfter = 0;
+    if (block.kind === 'paragraph') {
+      spaceBefore = getSpacingBefore(block as ParagraphBlock);
+      spaceAfter = getSpacingAfter(block as ParagraphBlock);
+    }
+    const effectiveBefore = Math.max(spaceBefore, colTrailing[col]);
+    colHeights[col] += effectiveBefore + height;
+    colTrailing[col] = spaceAfter;
+  }
+  return Math.max(0, ...colHeights);
+}
+
 function isEmptyParagraph(block: ParagraphBlock): boolean {
   if (block.runs.length === 0) return true;
   if (block.runs.length !== 1) return false;
@@ -253,6 +320,16 @@ export function layoutDocument(
 
   // Process each block, tracking section break index with a counter (O(1) per break)
   let sectionIdx = 0;
+  // Top Y (page-absolute) of the most recently laid-out paragraph's first
+  // fragment. A `relFromV="paragraph"`/`"line"` anchored textbox (e.g. the
+  // letterhead "Powered by:" box, extracted by `convertParagraphWithTextBoxes`
+  // into a sibling block immediately after its source paragraph) must anchor to
+  // that paragraph's TOP — exactly like the float-image path uses the anchor
+  // paragraph's `fragment.y`. Using the post-paragraph `cursorY` instead placed
+  // the box a paragraph-height too low, flipping it below a sibling image that
+  // correctly anchored to the paragraph top. Undefined until the first
+  // paragraph lays out.
+  let lastParagraphTopY: number | undefined;
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i];
     const measure = measures[i];
@@ -284,9 +361,23 @@ export function layoutDocument(
     }
 
     switch (block.kind) {
-      case 'paragraph':
-        layoutParagraph(block, measure as ParagraphMeasure, paginator, paginator.getContentWidth());
+      case 'paragraph': {
+        const fragsBefore = paginator.getCurrentState().page.fragments.length;
+        layoutParagraph(
+          block,
+          measure as ParagraphMeasure,
+          paginator,
+          paginator.getCurrentColumnContentWidth()
+        );
+        // Record the paragraph's first-fragment top so a following
+        // paragraph-relative anchored textbox can share the same anchor base
+        // as the float-image path (which reads `fragment.y`).
+        const fragsAfter = paginator.getCurrentState().page.fragments;
+        if (fragsAfter.length > fragsBefore) {
+          lastParagraphTopY = fragsAfter[fragsBefore].y;
+        }
         break;
+      }
 
       case 'table':
         if (block.floating) {
@@ -313,7 +404,29 @@ export function layoutDocument(
         // independently). Inline textboxes (no anchor) keep the in-flow
         // reservation, which is the d8b85d1 regression guard.
         if (tb.anchor) {
-          layoutAnchoredTextBox(tb, measure as TextBoxMeasure, paginator);
+          // A behind-doc shape anchored relative to a PARAGRAPH (not the page —
+          // page-relative behind-doc is a watermark and must never reserve)
+          // occupies a vertical band the flow must leave empty, even though the
+          // box paints behind the text. A VML `<v:group>` expands into several
+          // sibling anchored textboxes (the SDS hazard box = border + label +
+          // value + statement), so reserve ONCE for the whole consecutive
+          // cluster — the band from the shallowest child top to the deepest
+          // child bottom — rather than per child (which would over-reserve).
+          if (reservesBehindDocBand(tb)) {
+            const cluster = collectBehindDocCluster(blocks, i);
+            for (let k = i; k <= cluster.endIndex; k++) {
+              layoutAnchoredTextBox(
+                blocks[k] as TextBoxBlock,
+                measures[k] as TextBoxMeasure,
+                paginator,
+                lastParagraphTopY
+              );
+            }
+            paginator.reserveSpace(cluster.bandHeight);
+            i = cluster.endIndex; // for-loop ++ advances past the cluster
+            break;
+          }
+          layoutAnchoredTextBox(tb, measure as TextBoxMeasure, paginator, lastParagraphTopY);
         } else {
           layoutTextBox(tb, measure as TextBoxMeasure, paginator);
         }
@@ -332,12 +445,19 @@ export function layoutDocument(
         // Use the NEXT section's columns; for break type, prefer next section's
         // type but fall back to current break's type (preserves explicit 'continuous')
         const nextType = sectionBreakTypes[sectionIdx + 1] ?? sectionBreakTypes[sectionIdx];
-        handleSectionBreak(
-          block as SectionBreakBlock,
-          paginator,
-          sectionConfigs[sectionIdx + 1] ?? initialConfig,
-          nextType
-        );
+        const nextConfig = sectionConfigs[sectionIdx + 1] ?? initialConfig;
+        handleSectionBreak(block as SectionBreakBlock, paginator, nextConfig, nextType);
+        // A continuous break that enters a multi-column region: keep the whole
+        // short region together rather than letting one column's overflow
+        // spill as a stray narrow strip onto the next page (the SDS
+        // label/value sections). handleSectionBreak has already set the
+        // region's start Y via updateColumns; measure the region now (we have
+        // the blocks + measures here) and push it whole if it won't fit.
+        const nextCols = nextConfig.columns;
+        if (nextType === 'continuous' && nextCols && nextCols.count > 1) {
+          const regionHeight = computeColumnRegionHeight(blocks, measures, i, nextCols.count);
+          paginator.ensureColumnRegionFits(regionHeight);
+        }
         sectionIdx++;
         break;
       }
@@ -824,6 +944,55 @@ function layoutTextBox(
 }
 
 /**
+ * Does this anchored textbox reserve a vertical band in the flow?
+ *
+ * True only for behind-doc shapes anchored relative to a PARAGRAPH. The
+ * paragraph-relative gate is the watermark guard: a page-relative behind-doc
+ * shape (`relFromV === 'page'`) is a watermark / page-background and must NOT
+ * push flow content. In-front floats also don't reserve (Word flows text
+ * independently). See docs/internal/20 (B2).
+ */
+function reservesBehindDocBand(block: TextBoxBlock): boolean {
+  const a = block.anchor;
+  return !!a && a.behindDoc === true && a.relFromV === 'paragraph';
+}
+
+/**
+ * Walk forward from `startIndex` over the run of CONSECUTIVE behind-doc,
+ * paragraph-anchored textbox blocks (the expanded children of one VML
+ * `<v:group>`). Returns the last index in the run and the height to reserve so
+ * the flow resumes BELOW the cluster: the deepest child bottom,
+ * `max(offsetV + height)`.
+ *
+ * Decorative hairline dividers (also behind-doc paragraph-anchored, but a lone
+ * `height≈1` rect that merely overlays an existing border) must NOT push flow,
+ * so a cluster whose tallest child is at or below a hairline threshold reserves
+ * nothing. The SDS hazard group has real text children (heights 48/50/31) and
+ * reserves ≈124px; an SDS divider (height 1) reserves 0.
+ */
+const HAIRLINE_RESERVE_FLOOR_PX = 4;
+function collectBehindDocCluster(
+  blocks: FlowBlock[],
+  startIndex: number
+): { endIndex: number; bandHeight: number } {
+  let bottom = 0;
+  let maxChildHeight = 0;
+  let endIndex = startIndex;
+  for (let k = startIndex; k < blocks.length; k++) {
+    const b = blocks[k];
+    if (b.kind !== 'textBox' || !reservesBehindDocBand(b as TextBoxBlock)) break;
+    const tb = b as TextBoxBlock;
+    const offsetV = tb.anchor?.offsetV ?? 0;
+    const height = tb.height ?? 0;
+    bottom = Math.max(bottom, offsetV + height);
+    maxChildHeight = Math.max(maxChildHeight, height);
+    endIndex = k;
+  }
+  const bandHeight = maxChildHeight > HAIRLINE_RESERVE_FLOOR_PX ? bottom : 0;
+  return { endIndex, bandHeight };
+}
+
+/**
  * Layout an anchored (floating) text box: position absolutely from its
  * page/margin/column anchor and push WITHOUT advancing the cursor, so body
  * text flows independently (matching Word's wrap=none / behind-text shapes).
@@ -832,7 +1001,8 @@ function layoutTextBox(
 function layoutAnchoredTextBox(
   block: TextBoxBlock,
   measure: TextBoxMeasure,
-  paginator: ReturnType<typeof createPaginator>
+  paginator: ReturnType<typeof createPaginator>,
+  anchorParagraphTop?: number
 ): void {
   if (measure.kind !== 'textBox') {
     throw new Error(`layoutAnchoredTextBox: expected textBox measure`);
@@ -870,9 +1040,23 @@ function layoutAnchoredTextBox(
   };
 
   // resolveAnchor* work in content-area coordinates; cursorY is page-absolute.
-  const contentCursorY = state.cursorY - margins.top;
+  // For a paragraph/line-relative anchor, the OOXML base is the TOP of the
+  // anchoring paragraph (the run the drawing lives in), NOT the flow cursor —
+  // which by now sits at that paragraph's BOTTOM. Use the recorded top of the
+  // paragraph laid out immediately before this textbox (its source paragraph,
+  // per `convertParagraphWithTextBoxes`) when available and on this page, so the
+  // box shares the float-image path's anchor base. Other anchor frames
+  // (page/margin) ignore the base, so the fallback is harmless for them.
+  const isParaRelative = anchor.relFromV === 'paragraph' || anchor.relFromV === 'line';
+  const paraTopOnThisPage =
+    anchorParagraphTop !== undefined &&
+    anchorParagraphTop >= margins.top &&
+    anchorParagraphTop <= state.cursorY;
+  const baseY =
+    isParaRelative && paraTopOnThisPage ? (anchorParagraphTop as number) : state.cursorY;
+  const contentBaseY = baseY - margins.top;
   const { x: cx } = resolveAnchorX(hSpec, measure.width, geom);
-  const cy = resolveAnchorY(vSpec, measure.height, contentCursorY, geom);
+  const cy = resolveAnchorY(vSpec, measure.height, contentBaseY, geom);
 
   const fragment: TextBoxFragment = {
     kind: 'textBox',

--- a/docx-editor/packages/core/src/layout-engine/integration.test.ts
+++ b/docx-editor/packages/core/src/layout-engine/integration.test.ts
@@ -1142,3 +1142,124 @@ describe('Layout Engine - Contextual Spacing', () => {
     expect(gap).toBe(10); // max(10, 5)
   });
 });
+
+// =============================================================================
+// TEST SUITE: Behind-doc anchored text box reserves flow space (B2 / SDS)
+// =============================================================================
+
+describe('Layout Engine - Behind-doc anchored text box flow reservation', () => {
+  type TbAnchor = NonNullable<import('./types').TextBoxBlock['anchor']>;
+
+  function makeTextBoxBlock(
+    id: number,
+    height: number,
+    anchor: TbAnchor | undefined
+  ): import('./types').TextBoxBlock {
+    return {
+      kind: 'textBox',
+      id,
+      width: 200,
+      height,
+      content: [],
+      anchor,
+    };
+  }
+
+  function makeTextBoxMeasure(width: number, height: number): import('./types').TextBoxMeasure {
+    return { kind: 'textBox', width, height, innerMeasures: [] };
+  }
+
+  /** A behind-doc, paragraph-V-relative anchor (the SDS hazard-box family). */
+  function behindParaAnchor(offsetV: number): TbAnchor {
+    return {
+      offsetH: 30,
+      offsetV,
+      relFromH: 'page',
+      relFromV: 'paragraph',
+      behindDoc: true,
+    };
+  }
+
+  function layoutWithTrailingParagraph(
+    boxes: Array<{ height: number; anchor: TbAnchor | undefined }>
+  ): { firstY: number; trailingY: number } {
+    const blocks: FlowBlock[] = [
+      makeParagraphBlock(0, 'Heading', 1),
+      ...boxes.map((b, i) => makeTextBoxBlock(100 + i, b.height, b.anchor)),
+      makeParagraphBlock(200, 'After', 100),
+    ];
+    const measures: Measure[] = [
+      makeParagraphMeasure([makeLine(0, 0, 0, 7, 100, 20)]),
+      ...boxes.map((b) => makeTextBoxMeasure(200, b.height)),
+      makeParagraphMeasure([makeLine(0, 0, 0, 5, 100, 20)]),
+    ];
+    const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+    const frags = layout.pages[0].fragments;
+    const headingFrag = frags.find((f) => f.kind === 'paragraph' && f.blockId === 0)!;
+    const trailingFrag = frags.find((f) => f.kind === 'paragraph' && f.blockId === 200)!;
+    return { firstY: headingFrag.y + headingFrag.height, trailingY: trailingFrag.y };
+  }
+
+  test('a tall behind-doc paragraph-anchored group reserves its bottom extent ONCE', () => {
+    // Mirrors the SDS hazard group: three children sharing one anchor,
+    // offsets 32/34/93, heights 50/48/31 → deepest bottom = 93 + 31 = 124.
+    const { firstY, trailingY } = layoutWithTrailingParagraph([
+      { height: 48, anchor: behindParaAnchor(34) },
+      { height: 50, anchor: behindParaAnchor(32) },
+      { height: 31, anchor: behindParaAnchor(93) },
+    ]);
+    // The trailing paragraph flows BELOW the reserved band (124px), not at the
+    // heading's bottom — and the reservation is applied once, not summed per
+    // child (which would be ~250px).
+    expect(trailingY - firstY).toBeCloseTo(124, 0);
+  });
+
+  test('a hairline divider (height 1) reserves no space', () => {
+    const { firstY, trailingY } = layoutWithTrailingParagraph([
+      { height: 1, anchor: behindParaAnchor(6) },
+    ]);
+    expect(trailingY).toBeCloseTo(firstY, 0);
+  });
+
+  test('a page-relative behind-doc shape (watermark) reserves no space', () => {
+    const { firstY, trailingY } = layoutWithTrailingParagraph([
+      {
+        height: 200,
+        anchor: { offsetH: 30, offsetV: 100, relFromH: 'page', relFromV: 'page', behindDoc: true },
+      },
+    ]);
+    expect(trailingY).toBeCloseTo(firstY, 0);
+  });
+
+  test('an in-front (non-behind-doc) anchored shape reserves no space', () => {
+    const { firstY, trailingY } = layoutWithTrailingParagraph([
+      {
+        height: 200,
+        anchor: { offsetH: 30, offsetV: 40, relFromH: 'page', relFromV: 'paragraph' },
+      },
+    ]);
+    expect(trailingY).toBeCloseTo(firstY, 0);
+  });
+
+  test('the behind-doc cluster fragments are still painted (behind, z-index -1)', () => {
+    const blocks: FlowBlock[] = [
+      makeParagraphBlock(0, 'Heading', 1),
+      makeTextBoxBlock(100, 48, behindParaAnchor(34)),
+      makeTextBoxBlock(101, 31, behindParaAnchor(93)),
+      makeParagraphBlock(200, 'After', 100),
+    ];
+    const measures: Measure[] = [
+      makeParagraphMeasure([makeLine(0, 0, 0, 7, 100, 20)]),
+      makeTextBoxMeasure(200, 48),
+      makeTextBoxMeasure(200, 31),
+      makeParagraphMeasure([makeLine(0, 0, 0, 5, 100, 20)]),
+    ];
+    const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+    const textBoxFrags = layout.pages[0].fragments.filter((f) => f.kind === 'textBox');
+    expect(textBoxFrags).toHaveLength(2);
+    for (const f of textBoxFrags) {
+      expect((f as import('./types').TextBoxFragment).isAnchored).toBe(true);
+      expect((f as import('./types').TextBoxFragment).zIndex).toBe(-1);
+    }
+  });
+});

--- a/docx-editor/packages/core/src/layout-engine/paginator.ts
+++ b/docx-editor/packages/core/src/layout-engine/paginator.ts
@@ -104,9 +104,34 @@ export function createPaginator(options: PaginatorOptions) {
   let columnRegionMaxBottom = margins.top;
 
   /**
-   * Get X position for a given column index.
+   * Get the body width of a specific column. Equal columns return the uniform
+   * `columnWidth`; unequal columns (`w:equalWidth="0"`) return that column's
+   * explicit width.
+   */
+  function getColumnWidthAt(columnIndex: number): number {
+    const cw = columns.columnWidths;
+    if (cw && cw.length === columns.count) {
+      const w = cw[Math.min(columnIndex, columns.count - 1)]?.width;
+      if (typeof w === 'number' && w > 0) return w;
+    }
+    return columnWidth;
+  }
+
+  /**
+   * Get X position (page-absolute) for a given column index.
+   *
+   * Unequal columns sum the preceding columns' widths + their trailing spaces;
+   * equal columns use the uniform stride (width + gap).
    */
   function getColumnX(columnIndex: number): number {
+    const cw = columns.columnWidths;
+    if (cw && cw.length === columns.count) {
+      let x = margins.left;
+      for (let c = 0; c < columnIndex && c < cw.length; c++) {
+        x += cw[c].width + cw[c].space;
+      }
+      return x;
+    }
     return margins.left + columnIndex * (columnWidth + columns.gap);
   }
 
@@ -348,6 +373,45 @@ export function createPaginator(options: PaginatorOptions) {
   }
 
   /**
+   * Keep a short multi-column region together: if the whole region (its
+   * tallest column, `regionHeight`) won't fit in the space left on the current
+   * page but WOULD fit on an empty page, break to a fresh page before the
+   * region is laid out.
+   *
+   * Word/LibreOffice never split a balanced 2-column region across a page so
+   * that one column's overflow continues as a stray narrow strip at the top of
+   * the next page. Our column flow does exactly that when a region starts low
+   * on the page: column 0 fills the few remaining pixels, the column break
+   * jumps to column 1 which also overflows, and the overflow resumes in
+   * column 0 of a brand-new page — wasting the bottom of the current page and
+   * adding a page. Pushing the region whole avoids both.
+   *
+   * Only acts when the current page already has content (so we never emit a
+   * leading blank page) and the region genuinely fits on a fresh page (so an
+   * over-tall region that must split anyway isn't bounced forever). Must be
+   * called AFTER `updateColumns` set `columnRegionTop` to the region's start Y.
+   */
+  function ensureColumnRegionFits(regionHeight: number): void {
+    if (!Number.isFinite(regionHeight) || regionHeight <= 0) return;
+    if (columns.count <= 1) return;
+    const state = getCurrentState();
+    if (state.page.fragments.length === 0) return;
+
+    const available = state.contentBottom - columnRegionTop;
+    const fullColumnCapacity = state.contentBottom - state.topMargin;
+    if (regionHeight <= available) return;
+    if (regionHeight > fullColumnCapacity) return; // can't fit anywhere; let it split
+
+    const fresh = createNewPage();
+    // The fresh page resets columnRegionTop/MaxBottom to its top margin and
+    // column index to 0 in createNewPage(); re-anchor the region there.
+    columnRegionTop = fresh.topMargin;
+    columnRegionMaxBottom = fresh.topMargin;
+    fresh.columnIndex = 0;
+    fresh.page.columns = columns.count > 1 ? { ...columns } : undefined;
+  }
+
+  /**
    * Update page geometry for pages created after a section break.
    *
    * `applyImmediately = true` (default) swaps the active geometry so the
@@ -408,12 +472,47 @@ export function createPaginator(options: PaginatorOptions) {
     getAvailableHeight: () => getAvailableHeight(getCurrentState()),
     /** Get content width for the active section. */
     getContentWidth,
+    /**
+     * Width a paragraph fragment should occupy in the CURRENT column.
+     *
+     * For unequal multi-column regions (`w:equalWidth="0"`) this is the active
+     * column's explicit width, so right/justified alignment and the fragment
+     * box match the column the text was measured against. For single-column
+     * and equal-column sections it returns the full content width — preserving
+     * the long-standing behavior (equal columns position via `getColumnX` and
+     * rely on pre-wrapped measure lines), so no existing fixture shifts.
+     */
+    getCurrentColumnContentWidth(): number {
+      if (
+        columns.count > 1 &&
+        columns.columnWidths &&
+        columns.columnWidths.length === columns.count
+      ) {
+        return getColumnWidthAt(getCurrentState().columnIndex);
+      }
+      return getContentWidth();
+    },
     /** Check if height fits in current column. */
     fits: (height: number) => fits(height),
     /** Ensure height fits, advancing if needed. */
     ensureFits,
     /** Add a fragment to current page. */
     addFragment,
+    /**
+     * Reserve vertical flow space WITHOUT painting a fragment. Advances the
+     * cursor by `height` so subsequent in-flow blocks start below the reserved
+     * band. Used for behind-text anchored objects (e.g. the SDS hazard box)
+     * that occupy a vertical band the flow must leave empty even though the
+     * object paints behind the text. No-op for non-positive heights.
+     */
+    reserveSpace(height: number): void {
+      if (!Number.isFinite(height) || height <= 0) return;
+      const state = ensureFits(height);
+      state.cursorY += height;
+      // The reservation is hard space; don't let it collapse into a following
+      // paragraph's spaceBefore the way trailing paragraph spacing does.
+      state.trailingSpacing = 0;
+    },
     /** Force a page break. */
     forcePageBreak,
     /** Force a column break. */
@@ -422,6 +521,8 @@ export function createPaginator(options: PaginatorOptions) {
     getColumnX,
     /** Update column layout (for section breaks). */
     updateColumns,
+    /** Keep a short multi-column region together (push it whole if it won't fit). */
+    ensureColumnRegionFits,
     /** Update page size/margins for subsequent pages. */
     updatePageLayout,
   };

--- a/docx-editor/packages/core/src/layout-engine/types.ts
+++ b/docx-editor/packages/core/src/layout-engine/types.ts
@@ -840,6 +840,15 @@ export type ColumnLayout = {
   equalWidth?: boolean;
   /** Draw vertical separator line between columns (w:sep). */
   separator?: boolean;
+  /**
+   * Per-column geometry for unequal columns (`w:equalWidth="0"`), in pixels,
+   * in document order. Each entry's `width` is the column body width and
+   * `space` is the gap to the FOLLOWING column (the trailing column's `space`
+   * is unused). When present and `count` matches, the paginator uses these
+   * directly instead of splitting the content width equally. Absent / empty =
+   * equal columns.
+   */
+  columnWidths?: Array<{ width: number; space: number }>;
 };
 
 /**

--- a/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -2040,6 +2040,11 @@ function convertTextBox(textBox: TextBox, styleResolver: StyleResolver | null): 
       marginLeft,
       marginRight,
       autoFit: textBox.autoFit,
+      // Behind-text wrap (VML z-index<0) — carried so the layout engine can
+      // both paint the box behind body text AND reserve its band in the flow
+      // (the SDS hazard box). 'inline' is the schema default for non-anchored
+      // boxes; only emit a non-default when the source said so.
+      wrapType: textBox.wrap?.type ?? 'inline',
       posOffsetH,
       posOffsetV,
       posRelFromH: posH?.relativeTo ?? null,

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -621,18 +621,43 @@ function getColumns(sectionProps: SectionProperties | null | undefined): ColumnL
   if (count <= 1) return undefined;
   // Default column spacing: 720 twips (0.5 inch) per OOXML spec
   const gap = twipsToPixels(sectionProps?.columnSpace ?? 720);
-  return {
+  const cols: ColumnLayout = {
     count,
     gap,
     equalWidth: sectionProps?.equalWidth ?? true,
     separator: sectionProps?.separator,
   };
+  // Unequal columns: carry explicit per-column widths so measurement uses the
+  // true (wider) value-column width instead of an even split. Mirrors the
+  // inner-section path in toFlowBlocks.
+  const colDefs = sectionProps?.columns;
+  if (
+    sectionProps?.equalWidth === false &&
+    colDefs &&
+    colDefs.length === count &&
+    colDefs.every((c) => typeof c.width === 'number' && (c.width as number) > 0)
+  ) {
+    cols.columnWidths = colDefs.map((c) => ({
+      width: twipsToPixels(c.width as number),
+      space: twipsToPixels(c.space ?? 0),
+    }));
+  }
+  return cols;
 }
 
-function columnWidthForSection(config: SectionLayoutConfig): number {
+/**
+ * Body width for column index `colIndex` of a section. With explicit unequal
+ * columns (`w:equalWidth="0"`) returns that column's true width; otherwise the
+ * even split. Single-column sections return full content width.
+ */
+function columnWidthForSection(config: SectionLayoutConfig, colIndex = 0): number {
   const contentWidth = config.pageSize.w - config.margins.left - config.margins.right;
   const cols = config.columns;
   if (!cols || cols.count <= 1) return contentWidth;
+  if (cols.columnWidths && cols.columnWidths.length === cols.count) {
+    const w = cols.columnWidths[Math.min(colIndex, cols.count - 1)]?.width;
+    if (typeof w === 'number' && w > 0) return Math.floor(w);
+  }
   return Math.floor((contentWidth - (cols.count - 1) * cols.gap) / cols.count);
 }
 
@@ -654,13 +679,24 @@ function computePerBlockWidths(
   );
 
   let sectionIdx = 0;
+  // Column index within the current section, advanced by explicit column
+  // breaks so unequal columns measure each block at its own column's width.
+  let colIndex = 0;
   const widths: number[] = [];
 
   for (let i = 0; i < blocks.length; i++) {
-    widths.push(columnWidthForSection(sectionConfigs[sectionIdx] ?? initialConfig));
+    const cfg = sectionConfigs[sectionIdx] ?? initialConfig;
+    widths.push(columnWidthForSection(cfg, colIndex));
+
+    const block = blocks[i];
+    if (block.kind === 'columnBreak') {
+      const count = cfg.columns?.count ?? 1;
+      if (colIndex < count - 1) colIndex += 1;
+    }
 
     if (sectionIdx < breakIndices.length && i === breakIndices[sectionIdx]) {
       sectionIdx++;
+      colIndex = 0; // new section restarts at column 0
     }
   }
 


### PR DESCRIPTION
Re-applies fixes that got stranded after PR #17 squash-merged early (they were pushed to that branch *after* the merge, so they never reached main). All net-new, cleanly on top of current main.

## What's fixed (all verified)
- **B1** — medical-form letterhead: 'Powered by:' rendered *below* the logo (overlap). Cause: the float-image path resolves a paragraph-relative anchor against the paragraph TOP, but anchored textboxes used the flow cursor (paragraph bottom). Unified. Header now Powered-by → logo → free-trial.
- **B2** — SDS hazard box painted over the GHS list. Behind-doc anchored groups now reserve their flow band (found 2 dead plumbing gaps: VML z-index never parsed; anchor.behindDoc never set). Watermark-guarded, hairline floor for dividers.
- **Multi-column** — paginator ignored `w:cols equalWidth=0` + per-column widths, splitting every section into equal halves; the SDS's narrow-label/wide-value sections over-wrapped → +2 pages. Now honors real column widths → **SDS 18→16 pages, matching LibreOffice**.

## Numbers (no regression)
- SDS **43.0 → 60.7**, page count **18 → 16 (matches reference)**.
- Corpus mean 43.8 → **52.7**; medical-form 33.1 and Form025U 56.2 unchanged.
- typecheck + 198 layout/bridge unit tests + smoke green; round-trip audit drops nothing.

Plus the doc-20 tracker updated (B1/B2 FIXED, multi-column root cause + fix, medical-form drift root-caused to the header-margin path).