### PR TITLE
fix(layout): negative w:pgMar top lets header overlap body (medical-form drift)

### DIFF
--- a/docs/internal/20-overlap-and-interaction.md
+++ b/docs/internal/20-overlap-and-interaction.md
@@ -93,17 +93,16 @@ Corpus mean 43.8 → **52.7**. B1 (logo overlap), B2 (hazard overlap), and the
 multi-column page count all solved.
 
 ### Remaining for pixel-faithful
-- **medical-incident-form body drift (33.1)** — ROOT-CAUSED (not table rows; rows
-  match the reference within the validated Wingdings tolerance). The driver is
-  the **header-margin path with a negative `w:pgMar` top** (`w:top="-270"` =
-  −13.5pt): `getMargins`/`extendHeader` in `PagedEditor.tsx` sets
-  `effectiveMargins.top = headerDistance + headerContentHeight`, and our
-  `headerContentHeight` for `header1.xml` is ~25–32pt larger than LibreOffice's,
-  starting the body ~22–32pt low on every page → content cascades (page count
-  still 4=4 but offset by ~1 section). In LibreOffice a negative top margin lets
-  the header OVERLAP the body rather than fully displacing it. **Next step:** a
-  header-focused fix to `headerContentHeight`/overlap behavior — high regression
-  risk (shared by SDS 16pp + Form025U + the 39 round-trip fixtures), needs full
-  VF + round-trip guards.
+- **medical-incident-form body drift (33.1)** — header-margin part **FIXED (PR #19)**:
+  the doc has `<w:pgMar w:top="-270">` (−13.5pt) and the header-extension fully
+  displaced the body (`effectiveMargins.top = headerDistance + headerContentHeight`),
+  ignoring the negative margin. `computeExtendedTopMargin` adds a `min(marginTop,0)`
+  overlap-pull (no-op for positive-margin docs), so the header now overlaps the
+  body per Word — body top recovered ~13.5pt. medical 33.1→33.6, SDS/Form025U
+  unchanged. **Remaining medical gap (the bulk of its low score):** font-metric
+  row-height — the editor wraps some left-column label cells to MORE lines than
+  LibreOffice, making cells taller and cascading ~1 row/page (p3/p4 block-corr
+  ≈0). Separate, higher-risk (font substitution / line-wrap metrics) — tracked
+  for a focused metrics pass, NOT the header path.
 - **B4** (SDS subtitle Y) — recheck since B1 landed.
 - **Address text-frame cramp** (SDS p1, incremental — separate behind-doc frame).

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -707,6 +707,35 @@ function computePerBlockWidths(
 // duplicates were drifting from the canonical implementations; sharing
 // keeps them in lockstep across React + Vue adapters.
 
+/**
+ * Top body margin (px) once the header content has been accounted for.
+ *
+ * When header content is taller than the gap between the page top and the
+ * header distance, Word pushes body content down to clear it. The body top is
+ * normally `headerDistance + headerContentHeight`, with the authored top margin
+ * (`marginTop`) acting as a floor.
+ *
+ * The negative-top-margin case is the subtle one. `w:pgMar w:top` can be
+ * negative (e.g. medical-incident-form's `w:top="-270"` = −13.5pt). Word reads
+ * that as permission for the header to OVERLAP the body rather than fully
+ * displace it: the negative margin pulls body content up under the header by
+ * |marginTop|. So the clear position is reduced by the negative margin and
+ * clamped to the page edge (never above 0).
+ *
+ * For every positive-top document `Math.min(marginTop, 0)` is 0, so this
+ * reduces to the original `headerDistance + headerContentHeight` push — the
+ * function is provably a no-op for positive-margin docs.
+ */
+export function computeExtendedTopMargin(
+  marginTop: number,
+  headerDistance: number,
+  headerContentHeight: number
+): number {
+  const headerOverlapPull = Math.min(marginTop, 0);
+  const clearTop = Math.max(0, headerDistance + headerContentHeight + headerOverlapPull);
+  return Math.max(marginTop, clearTop);
+}
+
 export function measureTableCellBlockVisualHeight(block: FlowBlock, blockMeasure: Measure): number {
   if (block.kind !== 'paragraph' || blockMeasure.kind !== 'paragraph') {
     if ('totalHeight' in blockMeasure) return blockMeasure.totalHeight;
@@ -1707,7 +1736,10 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             const extend = (m: PageMargins): PageMargins => {
               const out = { ...m };
               if (extendHeader) {
-                out.top = Math.max(m.top, headerDistance + headerContentHeight);
+                // Negative-top-margin docs let the header overlap the body
+                // instead of fully displacing it; see computeExtendedTopMargin.
+                // Positive-top docs are unaffected (no-op).
+                out.top = computeExtendedTopMargin(m.top, headerDistance, headerContentHeight);
               }
               if (extendFooter) {
                 out.bottom = Math.max(m.bottom, footerDistance + footerContentHeight);

--- a/docx-editor/packages/react/src/paged-editor/computeExtendedTopMargin.test.ts
+++ b/docx-editor/packages/react/src/paged-editor/computeExtendedTopMargin.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test';
+
+import { computeExtendedTopMargin } from './PagedEditor';
+
+// twips → px at 96 DPI, matching the editor's twipsToPixels.
+const tw = (t: number) => (t / 20) * (96 / 72);
+
+describe('computeExtendedTopMargin', () => {
+  describe('positive top margin (must be a no-op vs. the original push)', () => {
+    // Original behavior: out.top = max(marginTop, headerDistance + headerContentHeight).
+    const original = (mt: number, hd: number, hch: number) => Math.max(mt, hd + hch);
+
+    const cases: Array<[number, number, number]> = [
+      [96, 48, 0], // default-ish, empty header
+      [96, 48, 80], // tall header pushes body below marginTop
+      [120, 48, 30], // marginTop is the floor
+      [0, 48, 40], // zero top margin
+      [48.4, 48.4, 34.18], // medical's header geometry but with a 0-clamped... (positive mt)
+    ];
+
+    for (const [mt, hd, hch] of cases) {
+      it(`marginTop=${mt} matches the original formula`, () => {
+        expect(computeExtendedTopMargin(mt, hd, hch)).toBeCloseTo(original(mt, hd, hch), 6);
+      });
+    }
+  });
+
+  describe('negative top margin (header overlaps body)', () => {
+    it('reduces the push by the negative margin amount', () => {
+      // medical-incident-form: w:pgMar w:top="-270", header="726".
+      const marginTop = tw(-270); // -18px
+      const headerDistance = tw(726); // 48.4px
+      const headerContentHeight = 34.18; // two empty header paragraphs
+
+      const top = computeExtendedTopMargin(marginTop, headerDistance, headerContentHeight);
+
+      // Old (buggy) behavior would have been headerDistance + headerContentHeight
+      // (~82.6px), pushing the body too low. The negative margin pulls it back up
+      // by |marginTop| (18px) → ~64.6px.
+      const expected = headerDistance + headerContentHeight + marginTop;
+      expect(top).toBeCloseTo(expected, 6);
+      expect(top).toBeLessThan(headerDistance + headerContentHeight);
+    });
+
+    it('never pulls the body above the page edge (clamped to >= marginTop)', () => {
+      // A large negative margin should not produce a negative body top below the
+      // authored marginTop floor, and the clear position is clamped to >= 0.
+      const marginTop = -200;
+      const top = computeExtendedTopMargin(marginTop, 48, 30);
+      // headerDistance+hch+marginTop = -122 → clamped to 0; max(marginTop, 0) = 0.
+      expect(top).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
medical-incident-form declares `<w:pgMar w:top="-270">` (−13.5pt). The header-extension logic set `effectiveMargins.top = max(marginTop, headerDistance + headerContentHeight)`, fully displacing the body down and ignoring the negative margin — so body content started ~13.5pt too low on every page and cascaded onto later pages. Word lets the header *overlap* the body when the top margin is negative.

`computeExtendedTopMargin` adds a single `min(marginTop, 0)` overlap-pull term — **provably a no-op for positive/zero-margin docs** (collapses to the original formula), so only negative-pgMar-top docs change.

## Verification (no regression)
- medical-form body now lines up with the reference; VF **33.1 → 33.6**.
- **sds-anti-t-zh 60.7/16pp, sds-real-world 60.7/16pp, Form025U 56.2/3pp — all UNCHANGED.**
- 7 new unit cases (5 positive-margin no-op equality + 2 negative-margin); 917 core + 330 react tests + typecheck + lint + round-trip audit green.

Honest note: this fixes the header-margin bug correctly, but medical's remaining gap is a *separate* issue — font-metric row-height differences where the editor wraps some left-column label cells to more lines than LibreOffice, cascading content. That's higher-risk (font substitution / line-wrap metrics) and tracked separately.