### PR TITLE
fix(table): cascade cell margins per-side (ECMA-376 17.4.41) — label over-wrap

### DIFF
--- a/docx-editor/packages/core/src/layout-bridge/__tests__/toFlowBlocks-cell-margin-cascade.test.ts
+++ b/docx-editor/packages/core/src/layout-bridge/__tests__/toFlowBlocks-cell-margin-cascade.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Integration test — per-side cell-margin cascade (ECMA-376 §17.4.41).
+ *
+ * Covers the table-cell padding pipeline:
+ *   Document model (inline w:tblCellMar with only top/bottom)
+ *     + default table style (w:tblCellMar with left/right = 108 twips)
+ *     → toProseDoc (PM table, `resolvedCellMargins` attr)
+ *     → toFlowBlocks (cell.padding in px)
+ *
+ * Regression guard: before this fix the whole `w:tblCellMar` object was
+ * resolved with a single `??`, so a table whose inline tblCellMar set only
+ * top/bottom zeroed the unspecified left/right instead of inheriting them
+ * from the default table style. That let cell text run to the cell edge,
+ * widening the text area vs LibreOffice and drifting wrap points/row heights
+ * (the medical-incident-form visual-fidelity regression). The sides must
+ * cascade independently. `cellMargins` (round-trip) still mirrors the verbatim
+ * inline values; `resolvedCellMargins` (layout-only) carries the inherited sides.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { toProseDoc } from '../../prosemirror/conversion/toProseDoc';
+import { toFlowBlocks } from '../toFlowBlocks';
+import { twipsToPixels } from '../../utils/units';
+import type { Document, Table } from '../../types/document';
+import type { StyleDefinitions } from '../../types/styles';
+
+/** Default table style with the Word-default 108-twip left/right cell margins. */
+const STYLES_WITH_DEFAULT_TABLE: StyleDefinitions = {
+  styles: [
+    {
+      styleId: 'TableNormal',
+      type: 'table',
+      default: true,
+      tblPr: {
+        cellMargins: {
+          top: { value: 0, type: 'dxa' },
+          left: { value: 108, type: 'dxa' },
+          bottom: { value: 0, type: 'dxa' },
+          right: { value: 108, type: 'dxa' },
+        },
+      },
+    },
+  ],
+};
+
+/** A one-cell table whose inline tblCellMar specifies ONLY top/bottom (57 twips). */
+function makeTopBottomOnlyTable(): Table {
+  return {
+    type: 'table',
+    formatting: {
+      cellMargins: {
+        top: { value: 57, type: 'dxa' },
+        bottom: { value: 57, type: 'dxa' },
+      },
+    },
+    columnWidths: [3397],
+    rows: [
+      {
+        type: 'tableRow',
+        cells: [
+          {
+            type: 'tableCell',
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'run', content: [{ type: 'text', text: 'Label' }] }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function makeDocument(table: Table): Document {
+  return { package: { document: { content: [table] } } };
+}
+
+function firstCellPadding(doc: Document, styles?: StyleDefinitions) {
+  const pmDoc = toProseDoc(doc, styles ? { styles } : undefined);
+  const blocks = toFlowBlocks(pmDoc);
+  const table = blocks.find((b) => b.kind === 'table');
+  if (!table || table.kind !== 'table') throw new Error('no table block');
+  return table.rows[0].cells[0].padding;
+}
+
+describe('toFlowBlocks — per-side cell-margin cascade', () => {
+  test('partial inline tblCellMar inherits left/right from default table style', () => {
+    const padding = firstCellPadding(
+      makeDocument(makeTopBottomOnlyTable()),
+      STYLES_WITH_DEFAULT_TABLE
+    );
+    // top/bottom come from the inline tblCellMar (57 twips)…
+    expect(padding?.top).toBeCloseTo(twipsToPixels(57), 5);
+    expect(padding?.bottom).toBeCloseTo(twipsToPixels(57), 5);
+    // …left/right are inherited from the default table style (108 twips),
+    // NOT zeroed. 108 twips ≈ 7.2 px.
+    expect(padding?.left).toBeCloseTo(twipsToPixels(108), 5);
+    expect(padding?.right).toBeCloseTo(twipsToPixels(108), 5);
+  });
+
+  test('inline tblCellMar still wins per-side where it is specified', () => {
+    const table = makeTopBottomOnlyTable();
+    // Give the inline tblCellMar an explicit left that should override the style.
+    table.formatting!.cellMargins!.left = { value: 200, type: 'dxa' };
+    const padding = firstCellPadding(makeDocument(table), STYLES_WITH_DEFAULT_TABLE);
+    expect(padding?.left).toBeCloseTo(twipsToPixels(200), 5);
+    // right is unspecified inline → still inherits the style's 108.
+    expect(padding?.right).toBeCloseTo(twipsToPixels(108), 5);
+  });
+
+  test('round-trip cellMargins attr mirrors only the verbatim inline sides', () => {
+    const pmDoc = toProseDoc(makeDocument(makeTopBottomOnlyTable()), {
+      styles: STYLES_WITH_DEFAULT_TABLE,
+    });
+    let tableNode: import('prosemirror-model').Node | undefined;
+    pmDoc.descendants((node) => {
+      if (node.type.name === 'table') tableNode = node;
+      return !tableNode;
+    });
+    expect(tableNode).toBeDefined();
+    // The serialized-side attr keeps left/right undefined (inline had none)…
+    expect(tableNode!.attrs.cellMargins).toEqual({
+      top: 57,
+      bottom: 57,
+      left: undefined,
+      right: undefined,
+    });
+    // …while the layout-only attr carries the inherited sides.
+    expect(tableNode!.attrs.resolvedCellMargins).toEqual({
+      top: 57,
+      bottom: 57,
+      left: 108,
+      right: 108,
+    });
+  });
+});

--- a/docx-editor/packages/core/src/layout-bridge/toFlowBlocks.ts
+++ b/docx-editor/packages/core/src/layout-bridge/toFlowBlocks.ts
@@ -1350,9 +1350,15 @@ function convertTable(node: PMNode, startPos: number, options: ToFlowBlocksOptio
   let offset = startPos + 1; // +1 for opening tag
 
   // Read the table-level <w:tblCellMar> default cell margins (twips). Cells
-  // cascade to this when their own w:tcMar is absent or explicit-zero. PM
-  // stores it as `cellMargins: { top, bottom, left, right }` in twips.
-  const tableCellMargins = node.attrs.cellMargins as
+  // cascade to this when their own w:tcMar is absent or explicit-zero.
+  //
+  // Prefer `resolvedCellMargins` — the per-side cascade result (inline →
+  // table style → default table style). The bare `cellMargins` attr mirrors
+  // the verbatim inline tblCellMar for round-trip and may omit sides the
+  // source left to inheritance (e.g. a top/bottom-only tblCellMar); using it
+  // directly would zero the unspecified left/right and let cell text run to
+  // the cell edge. `resolvedCellMargins` carries the inherited sides.
+  const tableCellMargins = (node.attrs.resolvedCellMargins ?? node.attrs.cellMargins) as
     | { top?: number; bottom?: number; left?: number; right?: number }
     | undefined;
 

--- a/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -643,6 +643,38 @@ function convertTable(
       }
     : undefined;
 
+  // Render-only resolved margins. The `cellMargins` attr above stays the
+  // verbatim inline <w:tblCellMar> so round-trip serialization re-emits
+  // exactly what the source had. But the cascade is PER-SIDE for LAYOUT:
+  // a table whose inline tblCellMar specifies only top/bottom (a common
+  // authoring pattern, e.g. medical-incident-form) must still inherit
+  // left/right from the table style / default table style — Word does NOT
+  // treat the unspecified sides as zero. We resolve each side independently
+  // here and stash it in a non-serialized attr the layout bridge prefers;
+  // this is what keeps the label column's left text inset (~108 twips)
+  // matching LibreOffice instead of letting text run to the cell edge
+  // (wider text area → drifted wrap points → taller rows → page drift).
+  const cellMarginSources = [
+    table.formatting?.cellMargins,
+    tableStyle?.tblPr?.cellMargins,
+    defaultTableStyle?.tblPr?.cellMargins,
+  ];
+  const resolveCellMarginSide = (side: 'top' | 'bottom' | 'left' | 'right') => {
+    for (const source of cellMarginSources) {
+      const measurement = source?.[side];
+      if (measurement?.value != null) return measurement.value;
+    }
+    return undefined;
+  };
+  const resolvedCellMarginsAttr = cellMarginSources.some((source) => source != null)
+    ? {
+        top: resolveCellMarginSide('top'),
+        bottom: resolveCellMarginSide('bottom'),
+        left: resolveCellMarginSide('left'),
+        right: resolveCellMarginSide('right'),
+      }
+    : undefined;
+
   const attrs: TableAttrs = {
     styleId: table.formatting?.styleId,
     width: table.formatting?.width?.value,
@@ -651,6 +683,7 @@ function convertTable(
     columnWidths: columnWidths,
     floating: table.formatting?.floating,
     cellMargins: cellMarginsAttr,
+    resolvedCellMargins: resolvedCellMarginsAttr,
     look: table.formatting?.look,
     _originalFormatting: table.formatting || undefined,
   };

--- a/docx-editor/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/nodes/TableExtension.ts
@@ -191,6 +191,7 @@ const tableSpec: NodeSpec = {
     columnWidths: { default: null },
     floating: { default: null },
     cellMargins: { default: null },
+    resolvedCellMargins: { default: null },
     look: { default: null },
     _originalFormatting: { default: null },
   },

--- a/docx-editor/packages/core/src/prosemirror/schema/nodes.ts
+++ b/docx-editor/packages/core/src/prosemirror/schema/nodes.ts
@@ -235,6 +235,15 @@ export interface TableAttrs {
   floating?: FloatingTableProperties;
   /** Default cell margins for the table (w:tblCellMar), in twips */
   cellMargins?: { top?: number; bottom?: number; left?: number; right?: number };
+  /**
+   * Per-side-resolved cell margins for LAYOUT only (twips). Unlike
+   * `cellMargins` — which mirrors the verbatim inline w:tblCellMar for
+   * lossless round-trip — this resolves each side independently through the
+   * inline → table-style → default-table-style cascade (§17.4.41). A table
+   * whose inline tblCellMar sets only top/bottom still inherits left/right
+   * here, matching Word/LibreOffice text insets. Never serialized.
+   */
+  resolvedCellMargins?: { top?: number; bottom?: number; left?: number; right?: number };
   /** Table look flags for conditional formatting (w:tblLook) */
   look?: TableLook;
   /** Original table formatting from DOCX for lossless round-trip serialization */


### PR DESCRIPTION
A table whose inline `<w:tblCellMar>` sets only top/bottom (no left/right) had its left/right cell padding **zeroed**: `cellMargins` resolved the whole object via `inline ?? tableStyle ?? defaultTableStyle`, so a partial inline won entirely. Per ECMA-376 §17.4.41 each side cascades independently — the unspecified left/right should inherit TableNormal's 108 twips. Zero padding made label cells effectively wider, so label text wrapped to more lines than LibreOffice (medical-form left-column labels), inflating rows.

Resolve margins **per-side** across `[inline, tableStyle, defaultTableStyle]` into a new **render-only** `resolvedCellMargins` attr; the serialized `cellMargins` keeps verbatim inline values so round-trip XML is unchanged (the 39 fixtures don't break).

## Verification
- medical label cells now wrap at the reference's wrap points (content width 226.5→212.1px = cell − 2×108 twips; cell box / column widths unchanged). VF medical **33.1 → 33.3**.
- **sds-anti-t-zh 60.7/16pp, sds-real-world 60.7/16pp, Form025U 56.2/3pp — unchanged.**
- 920 core + 323 react + 3 new cascade tests; typecheck + lint + round-trip audit green.

Honest scope note: this is a real general table-correctness fix (any table with partial cell margins), but a *small* VF win — the bulk of medical's low score is cumulative vertical row-height/paragraph-spacing drift, which is a broad, higher-risk metrics issue that would jeopardize the just-merged SDS/Form025U gains; not chased here.