### PR TITLE
chore(vf): align editor render DPI to reference (150) for trustworthy scores

### DIFF
--- a/docs/internal/20-overlap-and-interaction.md
+++ b/docs/internal/20-overlap-and-interaction.md
@@ -41,9 +41,12 @@ width ~1em). The remaining SDS **18-vs-16 page count** is multi-column layout
 (see Plan), NOT diffuse spacing.
 - B5/B6 are interaction, invisible to the VF PNG pipeline — they need live
   Playwright drag/keyboard repros (see [[feedback-verify-ui-with-playwright]]).
-- VF scoring caveat: editor PNGs render at ~192dpi, reference at ~150dpi; the
-  block/row-correlation proxy is scale-sensitive, so a faithful page can score
-  low. Convert to physical units before trusting a "broken" score
+- VF dpi alignment (was a caveat, now **fixed**): editor PNGs used to render at
+  ~192dpi vs reference ~150dpi. `render-editor.mjs` now renders at
+  `deviceScaleFactor = VF_DPI/96` (150dpi), so both sides are byte-comparable
+  (1275×1650 = 1275×1650, no resampling). Re-running with alignment moved the
+  scores <1pt — so **medical's 33 is REAL vertical drift, not a scale artifact**
+  (confirmed). Convert to physical units only when a row looks off
   (`reference-dingbat-line-ratio` memory).
 
 ## Plan

--- a/docx-editor/scripts/visual-fidelity/render-editor.mjs
+++ b/docx-editor/scripts/visual-fidelity/render-editor.mjs
@@ -38,8 +38,15 @@ const browser = await chromium.launch();
 // region) and bogus 0-scores for fixtures like oversized-header-image whose
 // body sits low on the page. A viewport that contains a whole page captures
 // it in one shot. Page width (≤1056px) is < 1200, so no fit-to-width zoom.
+// Render at the SAME effective DPI as the reference (render-reference.mjs uses
+// 150 DPI). The editor lays out at 96 CSS px/inch, so deviceScaleFactor =
+// 150/96 = 1.5625 produces a PNG the same physical resolution as the reference
+// PDF raster. Previously this was 2 (= 192 DPI), a 1.28× mismatch that forced
+// diff.py to resample one side and depressed the block/row-correlation scores
+// (a faithful page could score low purely from the scale gap). VF_DPI overrides.
+const VF_DPI = Number(process.env.VF_DPI ?? 150);
 const ctx = await browser.newContext({
-  deviceScaleFactor: 2,
+  deviceScaleFactor: VF_DPI / 96,
   viewport: { width: 1200, height: 1700 },
 });
 const page = await ctx.newPage();


### PR DESCRIPTION
The VF harness rendered the editor at deviceScaleFactor 2 (192dpi) but the reference PDF at 150dpi — a 1.28× mismatch that forced `diff.py` to resample one side and depressed the block/row-correlation scores (a standing 'faithful page can score low' caveat). Now the editor renders at `deviceScaleFactor = VF_DPI/96` (150dpi), so both sides are native same-resolution (1275×1650 == 1275×1650), no resampling.

Re-running with alignment moved scores <1pt (SDS 60.7→60.6, Form025U 56.2→56.9, medical 33.3→33.1) — which **confirms medical-form's low score is real vertical drift, not a scale artifact**, removing a confound for future fidelity work. Tool-only change; no product code touched.