### PR TITLE
fix(docker): build with Go 1.25 + release pushes casualoffice/docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 # Three stages:
 #   1. web   — bun + vite build of the React editor, with collab
 #              enabled via VITE_COLLAB_ENABLED=true.
-#   2. build — Go 1.24, statically-linked gateway binary.
+#   2. build — Go 1.25, statically-linked gateway binary.
 #   3. run   — distroless-ish Alpine + ca-certs + binary + static.
 
 # ─── Stage 1: build the SPA ────────────────────────────────────────
@@ -39,7 +39,7 @@ ENV VITE_COLLAB_ENABLED=true
 RUN bun run build && bun run build:demo
 
 # ─── Stage 2: build the Go gateway ─────────────────────────────────
-FROM golang:1.24-alpine AS build
+FROM golang:1.25-alpine AS build
 WORKDIR /src
 
 COPY backend/go.mod backend/go.sum* ./


### PR DESCRIPTION
Release blocker found during Docker release prep: the bundled-image Dockerfile built the gateway stage with `golang:1.24-alpine`, but `backend/go.mod` declares `go 1.25.0`. A 1.24 toolchain refuses to build a module requiring ≥1.25, so `docker build .` fails at stage 2. Bumped to `golang:1.25-alpine` (matches the pinned toolchain). A full image build is running to confirm end-to-end.