### PR TITLE
ci: drop broken Microsoft apt repo before apt-get (fixes 403 e2e failure)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,16 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
 
+      - name: Drop broken Microsoft apt repo
+        # The GitHub-hosted runner image pre-configures Microsoft's apt repos
+        # (azure-cli / packages.microsoft.com). They intermittently return 403,
+        # and `playwright install --with-deps` runs `apt-get update`, which
+        # fails the whole step (exit 100) when any configured repo errors. We
+        # don't need those repos for the browser system deps (they come from
+        # the stock Ubuntu archives), so remove them first.
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* 2>/dev/null || true
+
       - name: Install Playwright browsers
         if: steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/fidelity-compare.yml
+++ b/.github/workflows/fidelity-compare.yml
@@ -62,6 +62,10 @@ jobs:
 
       - name: Install LibreOffice
         run: |
+          # Drop Microsoft's pre-configured apt repos first — they intermittently
+          # 403 and would fail `apt-get update` (exit 100). LibreOffice comes
+          # from the stock Ubuntu archives, so they're not needed.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* 2>/dev/null || true
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends libreoffice
           soffice --version


### PR DESCRIPTION
The CI e2e shard failed at **Install Playwright browsers** with:
```
Err: https://packages.microsoft.com/repos/azure-cli noble InRelease  403 Forbidden
E: Failed to fetch ... The repository is no longer signed.
Failed to install browser dependencies — exit code 100
```
The GitHub-hosted runner image pre-configures Microsoft's apt repos, which are intermittently returning 403. `playwright install --with-deps` runs `apt-get update`, and a single failing repo aborts the whole step. **External infra flakiness, not a code/test failure** (shards 2/3/4 passed; only shard 1 hit it).

Fix: remove the Microsoft apt sources before any `apt-get` — in `ci.yml` (e2e) and `fidelity-compare.yml` (LibreOffice install). The browser/LibreOffice system deps come from the stock Ubuntu archives, so nothing is lost.