### PR TITLE
chore(branding): rename product → Casual Docs + repoint stale schnsrw URLs

### DIFF
--- a/docx-editor/examples/vite/index.html
+++ b/docx-editor/examples/vite/index.html
@@ -22,8 +22,8 @@
   <meta property="og:site_name" content="Casual Editor" />
   <meta property="og:title" content="Casual Editor — Word-flavored web document editor" />
   <meta property="og:description" content="Open .docx in the browser, edit like the web, save back. Real-time co-editing via a stateless Go gateway. ProseMirror + OOXML-preserving model. Open source." />
-  <meta property="og:url" content="https://doc.schnsrw.live/" />
-  <meta property="og:image" content="https://doc.schnsrw.live/og.png" />
+  <meta property="og:url" content="https://docs.casualoffice.org/" />
+  <meta property="og:image" content="https://docs.casualoffice.org/og.png" />
   <meta property="og:image:type" content="image/png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -34,14 +34,14 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Casual Editor — Word-flavored web document editor" />
   <meta name="twitter:description" content="Open .docx in the browser, edit like the web, save back. Real-time co-editing. ProseMirror + OOXML-preserving model. Open source." />
-  <meta name="twitter:image" content="https://doc.schnsrw.live/og.png" />
+  <meta name="twitter:image" content="https://docs.casualoffice.org/og.png" />
   <meta name="twitter:image:alt" content="Casual Editor — Word-flavored web document editor" />
 
   <!-- Discoverability — explicit AI-crawler opt-in lives in /robots.txt -->
   <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
   <meta name="keywords" content="web document editor, .docx editor, Word for the web, open-source document editor, real-time document editing, collaborative .docx, ProseMirror, OOXML, Yjs, y-prosemirror, Go gateway, stateless backend, WOPI, eigenpal docx-editor, Apache-2.0, MIT, Casual Editor, Sachin Sarwa" />
 
-  <link rel="canonical" href="https://doc.schnsrw.live/" />
+  <link rel="canonical" href="https://docs.casualoffice.org/" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
 
@@ -57,27 +57,27 @@
       "@graph": [
         {
           "@type": "SoftwareApplication",
-          "@id": "https://doc.schnsrw.live/#app",
+          "@id": "https://docs.casualoffice.org/#app",
           "name": "Casual Editor",
           "alternateName": "casual-editor",
           "applicationCategory": "BusinessApplication",
           "applicationSubCategory": "WordProcessor",
           "operatingSystem": "Web Browser, Docker (Linux/amd64, Linux/arm64)",
-          "url": "https://doc.schnsrw.live/",
-          "codeRepository": "https://github.com/schnsrw/docx",
+          "url": "https://docs.casualoffice.org/",
+          "codeRepository": "https://github.com/CasualOffice/docs",
           "license": "https://www.apache.org/licenses/LICENSE-2.0",
           "description": "Open-source, real-time collaborative .docx editor. ProseMirror with an OOXML-preserving model; React + Bun on the frontend; Go for the stateless WebSocket gateway implementing the y-websocket protocol. Document persistence is delegated to a pluggable host integration (inline for v0; WOPI / JWT-API later).",
-          "image": "https://doc.schnsrw.live/og.png",
-          "screenshot": "https://doc.schnsrw.live/og.png",
+          "image": "https://docs.casualoffice.org/og.png",
+          "screenshot": "https://docs.casualoffice.org/og.png",
           "offers": {
             "@type": "Offer",
             "price": "0",
             "priceCurrency": "USD",
             "availability": "https://schema.org/InStock"
           },
-          "author": { "@id": "https://schnsrw.live/#person" },
-          "creator": { "@id": "https://schnsrw.live/#person" },
-          "publisher": { "@id": "https://schnsrw.live/#person" },
+          "author": { "@id": "https://casualoffice.org/#person" },
+          "creator": { "@id": "https://casualoffice.org/#person" },
+          "publisher": { "@id": "https://casualoffice.org/#person" },
           "featureList": [
             "Open and save native .docx files",
             "Real-time multi-user co-editing via Yjs and y-prosemirror",
@@ -95,20 +95,20 @@
         },
         {
           "@type": "Person",
-          "@id": "https://schnsrw.live/#person",
+          "@id": "https://casualoffice.org/#person",
           "name": "Sachin Sarwa",
-          "url": "https://schnsrw.live/",
+          "url": "https://casualoffice.org/",
           "sameAs": [
-            "https://github.com/schnsrw",
-            "https://hub.docker.com/u/schnsrw"
+            "https://github.com/CasualOffice",
+            "https://hub.docker.com/u/casualoffice"
           ]
         },
         {
           "@type": "WebSite",
-          "@id": "https://doc.schnsrw.live/#website",
-          "url": "https://doc.schnsrw.live/",
+          "@id": "https://docs.casualoffice.org/#website",
+          "url": "https://docs.casualoffice.org/",
           "name": "Casual Editor",
-          "publisher": { "@id": "https://schnsrw.live/#person" }
+          "publisher": { "@id": "https://casualoffice.org/#person" }
         }
       ]
     }

--- a/docx-editor/examples/vite/public/llms.txt
+++ b/docx-editor/examples/vite/public/llms.txt
@@ -10,11 +10,11 @@
 ## Quick facts
 
 - **License:** Apache-2.0 (gateway) + MIT (editor fork)
-- **Repo:** https://github.com/schnsrw/docx
-- **Live demo:** https://doc.schnsrw.live/
-- **Docker:** https://hub.docker.com/r/schnsrw/casual-editor
-- **Marketing site:** https://schnsrw.live/casual-editor/
-- **Author:** Sachin Sarwa — https://schnsrw.live/
+- **Repo:** https://github.com/CasualOffice/docs
+- **Live demo:** https://docs.casualoffice.org/
+- **Docker:** https://hub.docker.com/r/casualoffice/docs
+- **Marketing site:** https://casualoffice.org/
+- **Author:** Sachin Sarwa — https://casualoffice.org/
 - **Status:** Public preview. 26 of 39 .docx fixtures round-trip
   pristine in the per-tag audit; working toward ≥ 90% before the
   desktop binary ships.
@@ -59,9 +59,9 @@
 
 Part of a three-project suite all by Sachin Sarwa:
 
-- **Casual Editor** — this project — https://doc.schnsrw.live/
+- **Casual Editor** — this project — https://docs.casualoffice.org/
 - **Casual Sheets** — Excel-flavored web spreadsheet —
-  https://sheet.schnsrw.live/ — https://github.com/schnsrw/sheets
+  https://sheets.casualoffice.org/ — https://github.com/CasualOffice/sheets
 - **Casual Desktop** — Tauri binaries reusing both web cores —
   in progress.
 

--- a/docx-editor/examples/vite/public/robots.txt
+++ b/docx-editor/examples/vite/public/robots.txt
@@ -1,8 +1,8 @@
-# doc.schnsrw.live — open to search engines + AI crawlers.
+# docs.casualoffice.org — open to search engines + AI crawlers.
 # The app is the live demo for Casual Editor, an open-source web .docx
 # editor. Indexing helps users + assistants discover it.
 # Matches the policy declared on the canonical landing site
-# (https://schnsrw.live/robots.txt).
+# (https://casualoffice.org/robots.txt).
 
 User-agent: *
 Allow: /
@@ -45,4 +45,4 @@ Allow: /
 User-agent: Applebot-Extended
 Allow: /
 
-Sitemap: https://doc.schnsrw.live/sitemap.xml
+Sitemap: https://docs.casualoffice.org/sitemap.xml

--- a/docx-editor/examples/vite/public/sitemap.xml
+++ b/docx-editor/examples/vite/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://doc.schnsrw.live/</loc>
+    <loc>https://docs.casualoffice.org/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
Full branding pass:

**1. Rename product Casual Editor → Casual Docs** (45 files) — the user-facing name across the app UI (TitleBar, About dialog, Home, sign-in prompt, embed runtime), SEO/marketing (index.html title/og/JSON-LD, llms.txt, robots.txt, logo/favicon SVG), the `.docx` Application property (unzip.ts), build scripts, internal docs, and backend comments. **Only the spaced display string changes** — the code identifiers (`CasualEditorIframe`, `CasualEditorRef`, `CasualEditorProps`, etc. and their exports) keep their names; renaming them would be a breaking API change. `README.md` is untouched here (its rename is in PR #24). Two binary `.docx` template fixtures keep baked-in metadata (regenerated by the now-renamed generator script).

**2. Repoint stale schnsrw SEO URLs → casualoffice** — `doc.schnsrw.live`→`docs.casualoffice.org`, `github.com/schnsrw/docx`→`github.com/CasualOffice/docs`, etc. (`@schnsrw/core` package import left untouched — it's the published core dep).

Verified: backend `go build`+`go vet`, editor typecheck, 330 react unit, home-page e2e (asserts the renamed text), smoke, format — all green.