### PR TITLE
fix(title-bar): auto-grow doc-name field; ellipsis is CSS-only

### DIFF
--- a/docx-editor/e2e/tests/doc-name-field.spec.ts
+++ b/docx-editor/e2e/tests/doc-name-field.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression: the document-name field must never bake "…" into the
+ * actual name.
+ *
+ * A user reported that a long document name showed "…" and that the
+ * ellipsis "stayed" while editing/renaming — as if the name itself had
+ * been concatenated. The truncation is purely a CSS affordance: the
+ * field auto-grows to fit short names, caps for long ones (showing a
+ * blurred "…"), and reveals the full text again on focus. These checks
+ * lock that contract so the ellipsis can't regress into the stored
+ * value or persist while the field is being edited.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+const LONG_NAME = 'Q3 2026 Regional Sales Performance Review and Strategic Outlook';
+
+test.describe('Document name field — auto-grow, no baked-in ellipsis', () => {
+  test('field grows with content and never stores "…" in the name', async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.loadDocxFile('fixtures/example-with-image.docx');
+
+    const nameInput = page.getByRole('textbox', { name: /document name/i });
+    await expect(nameInput).toBeVisible();
+
+    // Short name → field hugs the text.
+    await nameInput.click();
+    await nameInput.fill('Report');
+    await page.keyboard.press('Tab');
+    const shortWidth = await nameInput.evaluate((el) => el.getBoundingClientRect().width);
+
+    // Long name → field grows (capped), but the value is the full name.
+    await nameInput.click();
+    await nameInput.fill(LONG_NAME);
+    await page.keyboard.press('Tab');
+    const longWidth = await nameInput.evaluate((el) => el.getBoundingClientRect().width);
+
+    expect(longWidth).toBeGreaterThan(shortWidth);
+
+    // The stored/editable value must be the full name with no ellipsis —
+    // the truncation is CSS only.
+    expect(await nameInput.inputValue()).toBe(LONG_NAME);
+    expect(await nameInput.inputValue()).not.toContain('…');
+    expect(await nameInput.inputValue()).not.toContain('...');
+
+    // Re-focusing for an edit/rename still shows the full name.
+    await nameInput.click();
+    expect(await nameInput.inputValue()).toBe(LONG_NAME);
+  });
+});

--- a/docx-editor/packages/react/src/components/TitleBar.tsx
+++ b/docx-editor/packages/react/src/components/TitleBar.tsx
@@ -8,7 +8,7 @@
  * - TitleBarRight: right-aligned actions slot
  */
 
-import React, { useCallback, Children, isValidElement } from 'react';
+import React, { useCallback, useState, Children, isValidElement } from 'react';
 import type { ReactNode } from 'react';
 import { MenuDropdown, SubMenuItem } from './ui/MenuDropdown';
 import type { MenuEntry } from './ui/MenuDropdown';
@@ -74,26 +74,41 @@ export function DocumentName({ value, onChange, placeholder, editable = true }: 
   const { t } = useTranslation();
   const resolvedPlaceholder = placeholder ?? t('titleBar.untitled');
   const displayName = stripExtension(value) ?? '';
+  const [focused, setFocused] = useState(false);
 
   if (!editable) {
     return (
-      <span className="text-base font-normal text-[color:var(--doc-text-on-surface,#1f2937)] px-2 py-0 min-w-[100px] max-w-[300px] truncate leading-tight">
+      <span className="text-base font-normal text-[color:var(--doc-text-on-surface,#1f2937)] px-2 py-0 min-w-[100px] max-w-[360px] truncate leading-tight">
         {displayName || resolvedPlaceholder}
       </span>
     );
   }
+  // Google Docs-style auto-sizing title field. An invisible sizer mirrors the
+  // text so the field hugs short names and grows up to the max width for long
+  // ones; past the cap the input scrolls horizontally. The ellipsis ("…") is a
+  // CSS affordance only when the field is *not* focused — while editing or
+  // renaming, the full name is always shown (and remains the real value), so a
+  // truncated display never gets mistaken for a truncated name.
+  const sizerText = displayName || resolvedPlaceholder;
   return (
-    <input
-      type="text"
-      value={displayName}
-      onChange={(e) => {
-        const raw = e.target.value;
-        onChange?.(raw.endsWith('.docx') ? raw : raw + '.docx');
-      }}
-      placeholder={resolvedPlaceholder}
-      className="text-base font-normal text-[color:var(--doc-text-on-surface,#1f2937)] bg-transparent border-0 outline-none px-2 py-0 rounded hover:bg-[color:var(--doc-bg-hover,#f1f3f4)] focus:bg-[color:var(--doc-surface,white)] focus:ring-1 focus:ring-slate-300 min-w-[100px] max-w-[300px] truncate leading-tight"
-      aria-label={t('titleBar.documentNameAriaLabel')}
-    />
+    <span className="relative inline-flex items-center min-w-[100px] max-w-[360px] leading-tight">
+      <span aria-hidden className="invisible whitespace-pre px-2 text-base font-normal">
+        {sizerText || ' '}
+      </span>
+      <input
+        type="text"
+        value={displayName}
+        onChange={(e) => {
+          const raw = e.target.value;
+          onChange?.(raw.endsWith('.docx') ? raw : raw + '.docx');
+        }}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        placeholder={resolvedPlaceholder}
+        className={`absolute inset-0 w-full text-base font-normal text-[color:var(--doc-text-on-surface,#1f2937)] bg-transparent border-0 outline-none px-2 py-0 rounded hover:bg-[color:var(--doc-bg-hover,#f1f3f4)] focus:bg-[color:var(--doc-surface,white)] focus:ring-1 focus:ring-slate-300 leading-tight ${focused ? '' : 'truncate'}`}
+        aria-label={t('titleBar.documentNameAriaLabel')}
+      />
+    </span>
   );
 }
 


### PR DESCRIPTION
Long document names showed a "…" that looked baked into the name — it stayed while editing/renaming, so a truncated *display* read as a truncated *value*. The name field was a fixed-width input with a permanent `truncate` class, so it clipped even while focused.

The field now auto-sizes to its content (Google Docs style): an invisible sizer grows it up to a max width, and the ellipsis applies only when blurred. While editing, the full name is always shown and remains the real value.

Verified visually (short = snug, long-blurred = clean "…", long-editing = full text, no ellipsis) and with an e2e regression asserting the field grows with content and the input value never contains "…".