### PR TITLE
fix(ruler): anchor the vertical ruler to the left of the page

### DIFF
--- a/docx-editor/e2e/tests/vertical-ruler-position.spec.ts
+++ b/docx-editor/e2e/tests/vertical-ruler-position.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression: the vertical ruler must sit immediately to the left of the
+ * page, not floating against the content area's far-left edge.
+ *
+ * It used to render at `left: 0` of the editor content area while the page
+ * is centered ~265px to the right, leaving the ruler orphaned in the gutter
+ * and its margin markers meaningless. It now hangs off the page's left edge
+ * (Google Docs style) and stays a draggable margin control.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test.describe('Vertical ruler — sits beside the page and stays draggable', () => {
+  test('ruler hugs the page left edge and its margin marker drags content', async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.loadDocxFile('fixtures/example-with-image.docx');
+    await page.waitForSelector('.layout-page', { timeout: 30000 });
+
+    const ruler = page.locator('.docx-vertical-ruler').first();
+    await expect(ruler).toBeVisible();
+
+    const rb = await ruler.boundingBox();
+    const pb = await page.locator('.layout-page').first().boundingBox();
+    if (!rb || !pb) throw new Error('ruler/page box not measurable');
+
+    // Ruler is just left of the page (small gap), not stranded in the gutter.
+    const gap = pb.x - (rb.x + rb.width);
+    expect(gap).toBeGreaterThanOrEqual(0);
+    expect(gap).toBeLessThan(24);
+    // Top-aligned with the page.
+    expect(Math.abs(rb.y - pb.y)).toBeLessThan(4);
+
+    // The top-margin marker still drags and pushes content down.
+    const heading = page.locator('.layout-page').first().getByText('Example').first();
+    const before = await heading.boundingBox();
+    const marker = page.locator('.docx-ruler-marker-topMargin').first();
+    const mb = await marker.boundingBox();
+    if (!before || !mb) throw new Error('heading/marker box not measurable');
+
+    await page.mouse.move(mb.x + mb.width / 2, mb.y + mb.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(mb.x + mb.width / 2, mb.y + mb.height / 2 + 50, { steps: 8 });
+    await page.mouse.up();
+    await page.waitForTimeout(600);
+
+    const after = await heading.boundingBox();
+    if (!after) throw new Error('heading box not measurable after drag');
+    expect(after.y).toBeGreaterThan(before.y + 20);
+  });
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -7704,15 +7704,19 @@ body { background: white; }
                         }}
                         onContextMenu={handleEditorContextMenu}
                       >
-                        {/* Vertical Ruler - sits at the editor content's left
-                          edge so it scrolls horizontally with the page instead
-                          of pinning to the viewport (which would lay over the
-                          doc when the user scrolls right). */}
+                        {/* Vertical Ruler - hangs off the left edge of the
+                          centered page (Google Docs style) instead of floating
+                          against the content area's far-left edge. It reuses the
+                          horizontal ruler's centering (same padding + sidebar
+                          bias) so a page-width spacer lands exactly under the
+                          page, and the ruler is pinned to that spacer's left
+                          edge. */}
                         {showRulerEffective && !readOnlyProp && (
                           <div
                             style={{
                               position: 'absolute',
                               left: 0,
+                              right: 0,
                               top: 0,
                               // Above the inline HF editor (Z_INDEX.hfInlineEditor)
                               // so it stays readable on horizontal scroll.
@@ -7721,16 +7725,48 @@ body { background: white; }
                               // editor.css (24 viewport + 24 pages container);
                               // update both together or the ruler misaligns.
                               paddingTop: 48,
+                              // Same horizontal centering as the horizontal ruler
+                              // so the vertical ruler tracks the centered page
+                              // (and its comment-sidebar bias).
+                              paddingLeft: 20,
+                              paddingRight: 20 + (sidebarOpen ? SIDEBAR_DOCUMENT_SHIFT * 2 : 0),
+                              display: 'flex',
+                              justifyContent: 'center',
+                              // Only the ruler itself is interactive; the wrapper
+                              // must not swallow clicks over the gutter/page.
+                              pointerEvents: 'none',
+                              transition: 'padding 0.2s ease',
                             }}
                           >
-                            <VerticalRuler
-                              sectionProps={initialSectionProperties}
-                              zoom={state.zoom}
-                              unit={rulerUnit}
-                              editable={!readOnly}
-                              onTopMarginChange={handleTopMarginChange}
-                              onBottomMarginChange={handleBottomMarginChange}
-                            />
+                            {/* Invisible page-width spacer; the ruler is pinned
+                              to its left edge (right: 100%) so it sits just left
+                              of the page. */}
+                            <div
+                              style={{
+                                width: pageWidthPx * state.zoom,
+                                flexShrink: 0,
+                                position: 'relative',
+                              }}
+                            >
+                              <div
+                                style={{
+                                  position: 'absolute',
+                                  right: '100%',
+                                  top: 0,
+                                  marginRight: 6,
+                                  pointerEvents: 'auto',
+                                }}
+                              >
+                                <VerticalRuler
+                                  sectionProps={initialSectionProperties}
+                                  zoom={state.zoom}
+                                  unit={rulerUnit}
+                                  editable={!readOnly}
+                                  onTopMarginChange={handleTopMarginChange}
+                                  onBottomMarginChange={handleBottomMarginChange}
+                                />
+                              </div>
+                            </div>
                           </div>
                         )}
                         {/* Brighten highlight for the focused/expanded sidebar item */}


### PR DESCRIPTION
The vertical ruler rendered at `left: 0` of the editor content area while the page is centered ~265px to the right — it floated against the window's far-left edge, with its tick scale and margin markers disconnected from the document (the "vertical ruler is useless / not usable" report).

It now reuses the horizontal ruler's centering (same padding + comment-sidebar bias) and pins to the left edge of a page-width spacer, so it hugs the page (6px gap), top-aligned, tracking the page across zoom and sidebar shifts — the Google Docs layout. Margin-drag behaviour is unchanged.

Before: ruler at x=0, page at x=285 (265px gap). After: ruler at x=259, page at x=285 (6px gap), top-aligned; dragging the top-margin marker still pushes content down. Verified visually and with an e2e regression.