### PR TITLE
fix(ruler): scale vertical ruler top offset with zoom

### DIFF
--- a/docx-editor/e2e/tests/vertical-ruler-position.spec.ts
+++ b/docx-editor/e2e/tests/vertical-ruler-position.spec.ts
@@ -48,4 +48,33 @@ test.describe('Vertical ruler — sits beside the page and stays draggable', () 
     if (!after) throw new Error('heading box not measurable after drag');
     expect(after.y).toBeGreaterThan(before.y + 20);
   });
+
+  test('stays aligned with the page top across zoom levels', async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.loadDocxFile('fixtures/example-with-image.docx');
+    await page.waitForSelector('.layout-page', { timeout: 30000 });
+
+    const measure = async () => {
+      const rb = await page.locator('.docx-vertical-ruler').first().boundingBox();
+      const pb = await page.locator('.layout-page').first().boundingBox();
+      if (!rb || !pb) throw new Error('ruler/page box not measurable');
+      return { gap: pb.x - (rb.x + rb.width), topDelta: rb.y - pb.y };
+    };
+    const setZoom = async (label: string) => {
+      await page.locator('[aria-label^="Zoom:"]').first().click();
+      await page.getByRole('option', { name: label }).first().click();
+      await page.waitForTimeout(500);
+    };
+
+    // The page's top padding and width both scale with zoom; the ruler must
+    // track both, so the gap and the top alignment stay constant.
+    for (const z of ['50%', '200%', '75%', '100%']) {
+      await setZoom(z);
+      const { gap, topDelta } = await measure();
+      expect(gap, `gap at ${z}`).toBeGreaterThanOrEqual(0);
+      expect(gap, `gap at ${z}`).toBeLessThan(24);
+      expect(Math.abs(topDelta), `top alignment at ${z}`).toBeLessThan(6);
+    }
+  });
 });

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -7722,9 +7722,11 @@ body { background: white; }
                               // so it stays readable on horizontal scroll.
                               zIndex: Z_INDEX.ruler,
                               // Must match `.paged-editor__pages` padding-top in
-                              // editor.css (24 viewport + 24 pages container);
-                              // update both together or the ruler misaligns.
-                              paddingTop: 48,
+                              // editor.css (24 viewport + 24 pages container).
+                              // That padding scales with zoom, so the ruler's
+                              // top offset has to scale too or it drifts off the
+                              // page top at non-100% zoom.
+                              paddingTop: 48 * state.zoom,
                               // Same horizontal centering as the horizontal ruler
                               // so the vertical ruler tracks the centered page
                               // (and its comment-sidebar bias).


### PR DESCRIPTION
Follow-up to #27. The vertical ruler's wrapper used a fixed `paddingTop: 48` to align its 0-mark with the page top, but that padding scales with zoom — so at non-100% the ruler drifted off the page top (+24px at 50%, −48px at 200%) while staying horizontally aligned. Scaling the offset by `state.zoom` keeps it pinned to the page top at every zoom level.

Verified: `topAlign` is now 0 at 50/75/100/200% (was +24 / −48 before). Regression test extended to cover zoom.