### PR TITLE
fix(ruler): freeze viewport scroll during margin-marker drag

### DIFF
--- a/docx-editor/e2e/tests/vertical-ruler-position.spec.ts
+++ b/docx-editor/e2e/tests/vertical-ruler-position.spec.ts
@@ -49,6 +49,41 @@ test.describe('Vertical ruler — sits beside the page and stays draggable', () 
     expect(after.y).toBeGreaterThan(before.y + 20);
   });
 
+  test('dragging a margin marker does not scroll the viewport', async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.loadDocxFile('fixtures/example-with-image.docx');
+    await page.waitForSelector('.layout-page', { timeout: 30000 });
+
+    const scrollTop = () =>
+      page.evaluate(() => {
+        let n: HTMLElement | null = document.querySelector('.layout-page');
+        while (n) {
+          if (/(auto|scroll)/.test(getComputedStyle(n).overflowY)) return n.scrollTop;
+          n = n.parentElement;
+        }
+        return -1;
+      });
+
+    const marker = page.locator('.docx-ruler-marker-topMargin').first();
+    const mb = await marker.boundingBox();
+    if (!mb) throw new Error('marker not measurable');
+
+    const before = await scrollTop();
+    // Drag the top-margin marker down: the page reflows, but the viewport must
+    // hold still (regression: it used to chase the reflow and scroll +120px).
+    await page.mouse.move(mb.x + mb.width / 2, mb.y + mb.height / 2);
+    await page.mouse.down();
+    for (const dy of [10, 20, 30, 40]) {
+      await page.mouse.move(mb.x + mb.width / 2, mb.y + mb.height / 2 + dy, { steps: 3 });
+      await page.waitForTimeout(80);
+    }
+    const during = await scrollTop();
+    await page.mouse.up();
+
+    expect(Math.abs(during - before)).toBeLessThan(12);
+  });
+
   test('stays aligned with the page top across zoom levels', async ({ page }) => {
     const editor = new EditorPage(page);
     await editor.goto();

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -1961,6 +1961,10 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   const docxInputRef = useRef<HTMLInputElement>(null);
   const editorContentRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // True while a ruler margin marker is being dragged. Threaded to PagedEditor
+  // so its post-reflow scroll-restore freezes the viewport instead of chasing
+  // the moved content (which made the page scroll out from under the marker).
+  const marginDraggingRef = useRef(false);
   const toolbarWrapperRef = useRef<HTMLDivElement>(null);
   const toolbarRoRef = useRef<ResizeObserver | null>(null);
   const [toolbarHeight, setToolbarHeight] = useState(0);
@@ -7667,6 +7671,9 @@ body { background: white; }
                           onFirstLineIndentChange={handleFirstLineIndentChange}
                           tabStops={state.paragraphTabs}
                           onTabStopRemove={handleTabStopRemove}
+                          onDragStateChange={(d) => {
+                            marginDraggingRef.current = d;
+                          }}
                         />
                       </div>
                     )}
@@ -7766,6 +7773,9 @@ body { background: white; }
                                   editable={!readOnly}
                                   onTopMarginChange={handleTopMarginChange}
                                   onBottomMarginChange={handleBottomMarginChange}
+                                  onDragStateChange={(d) => {
+                                    marginDraggingRef.current = d;
+                                  }}
                                 />
                               </div>
                             </div>
@@ -7802,6 +7812,7 @@ body { background: white; }
                           hfEditMode={hfEditPosition}
                           onBodyClick={handleBodyClick}
                           zoom={state.zoom}
+                          marginDraggingRef={marginDraggingRef}
                           wordCompat={wordCompat}
                           showFormattingMarks={showFormattingMarks}
                           readOnly={readOnly}

--- a/docx-editor/packages/react/src/components/ui/HorizontalRuler.tsx
+++ b/docx-editor/packages/react/src/components/ui/HorizontalRuler.tsx
@@ -35,6 +35,9 @@ export interface HorizontalRulerProps {
   onIndentLeftChange?: (indentTwips: number) => void;
   onIndentRightChange?: (indentTwips: number) => void;
   unit?: 'inch' | 'cm';
+  /** Fired with `true` when a margin/indent marker drag starts and `false`
+   *  when it ends, so the host can freeze the editor scroll during the drag. */
+  onDragStateChange?: (dragging: boolean) => void;
   className?: string;
   style?: CSSProperties;
   tabStops?: TabStop[] | null;
@@ -92,6 +95,7 @@ export function HorizontalRuler({
   onIndentLeftChange,
   onIndentRightChange,
   unit = 'inch',
+  onDragStateChange,
   className = '',
   style,
   tabStops,
@@ -196,8 +200,17 @@ export function HorizontalRuler({
         startRightIndentTwips: indentRight,
       };
       setDragging(marker);
+      onDragStateChange?.(true);
     },
-    [editable, leftMarginTwips, rightMarginTwips, effectiveFirstLineIndent, indentLeft, indentRight]
+    [
+      editable,
+      leftMarginTwips,
+      rightMarginTwips,
+      effectiveFirstLineIndent,
+      indentLeft,
+      indentRight,
+      onDragStateChange,
+    ]
   );
 
   // Referentially stable (reads everything from refs) so the mousemove
@@ -289,7 +302,8 @@ export function HorizontalRuler({
     setDragValue(null);
     setDragPositionPx(null);
     dragAnchorRef.current = null;
-  }, []);
+    onDragStateChange?.(false);
+  }, [onDragStateChange]);
 
   useEffect(() => {
     if (dragging) {

--- a/docx-editor/packages/react/src/components/ui/VerticalRuler.tsx
+++ b/docx-editor/packages/react/src/components/ui/VerticalRuler.tsx
@@ -33,6 +33,9 @@ export interface VerticalRulerProps {
   onBottomMarginChange?: (marginTwips: number) => void;
   /** Unit to display (inches or cm) */
   unit?: 'inch' | 'cm';
+  /** Fired with `true` when a margin marker drag starts and `false` when it
+   *  ends, so the host can freeze the editor scroll position during the drag. */
+  onDragStateChange?: (dragging: boolean) => void;
   /** Additional CSS class name */
   className?: string;
   /** Additional inline styles */
@@ -69,6 +72,7 @@ export function VerticalRuler({
   onTopMarginChange,
   onBottomMarginChange,
   unit = 'inch',
+  onDragStateChange,
   className = '',
   style,
 }: VerticalRulerProps): React.ReactElement {
@@ -132,8 +136,9 @@ export function VerticalRuler({
         startBottomMarginTwips: bottomMarginTwips,
       };
       setDragging(marker);
+      onDragStateChange?.(true);
     },
-    [editable, topMarginTwips, bottomMarginTwips]
+    [editable, topMarginTwips, bottomMarginTwips, onDragStateChange]
   );
 
   // Handle drag. Referentially stable (reads everything from refs) so the
@@ -176,7 +181,8 @@ export function VerticalRuler({
   const handleDragEnd = useCallback(() => {
     setDragging(null);
     dragAnchorRef.current = null;
-  }, []);
+    onDragStateChange?.(false);
+  }, [onDragStateChange]);
 
   // Add/remove document event listeners
   useEffect(() => {

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -303,6 +303,13 @@ export interface PagedEditorProps {
   /** Emit the new zoom value after a phone pinch-zoom gesture. The
    *  host (DocxEditor) is expected to feed it back via the `zoom` prop. */
   onZoomChange?: (zoom: number) => void;
+  /** True while a ruler margin marker is being dragged. When set, the
+   *  scroll-restore after the reflow freezes the exact scroll position
+   *  instead of re-anchoring to content — otherwise the margin change
+   *  reflows the page and the viewport chases it, so the page appears to
+   *  scroll out from under the marker as you drag. A ref (not a prop
+   *  value) so toggling it mid-drag doesn't re-render the editor. */
+  marginDraggingRef?: React.RefObject<boolean>;
   /** Whether comments sidebar is open (shifts document left). */
   commentsSidebarOpen?: boolean;
   /** Sidebar overlay rendered inside the scroll container (scrolls with document). */
@@ -1373,6 +1380,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       selectionFormatting,
       onFormat,
       onZoomChange,
+      marginDraggingRef,
       commentsSidebarOpen = false,
       sidebarOverlay,
       scrollContainerRef: scrollContainerRefProp,
@@ -1412,6 +1420,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       scrollTopSnapshot: number | null;
       domAnchorPmStart: number | null;
       domAnchorOffsetInScroller: number;
+      /** When set, restore the exact captured scrollTop and skip the
+       *  ratio/DOM-anchor logic (used during ruler margin drags). */
+      freeze?: boolean;
     } | null>(null);
     const pendingIncrementalScrollSnapshotWrittenAtRef = useRef(0);
     const hiddenPMRef = useRef<HiddenProseMirrorRef>(null);
@@ -1947,19 +1958,25 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             }
 
             if (scrollParent?.isConnected) {
+              // While a ruler margin marker is being dragged, freeze the exact
+              // pre-reflow scroll position. The margin change reflows the whole
+              // page; the ratio/DOM-anchor restore would chase the moved content
+              // and scroll the viewport out from under the marker.
+              const freeze = marginDraggingRef?.current === true;
               let ratioForRestore = scrollRestoreRatioPre;
               if (renderPagesKind === 'incremental') {
                 const maxPost = Math.max(1, scrollParent.scrollHeight - scrollParent.clientHeight);
                 ratioForRestore = scrollParent.scrollTop / maxPost;
               }
               const scrollTopSnapshot =
-                renderPagesKind === 'incremental' ? scrollParent.scrollTop : null;
+                renderPagesKind === 'incremental' || freeze ? scrollParent.scrollTop : null;
               pendingScrollRestoreRef.current = {
                 renderKind: renderPagesKind,
                 ratio: ratioForRestore,
                 scrollTopSnapshot,
                 domAnchorPmStart,
                 domAnchorOffsetInScroller,
+                freeze,
               };
               if (renderPagesKind === 'incremental' && scrollTopSnapshot != null) {
                 pendingIncrementalScrollSnapshotWrittenAtRef.current = performance.now();
@@ -2048,8 +2065,14 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         getScrollContainer() ?? (pagesEl ? findVerticalScrollParentOrRoot(pagesEl) : null);
       if (!pagesEl || !scrollParent?.isConnected) return;
 
-      const { renderKind, ratio, scrollTopSnapshot, domAnchorPmStart, domAnchorOffsetInScroller } =
-        pending;
+      const {
+        renderKind,
+        ratio,
+        scrollTopSnapshot,
+        domAnchorPmStart,
+        domAnchorOffsetInScroller,
+        freeze,
+      } = pending;
 
       const applyRatio = () => {
         const maxAfter = Math.max(1, scrollParent.scrollHeight - scrollParent.clientHeight);
@@ -2057,7 +2080,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       };
 
       const applyIncrementalSnapshot = (): boolean => {
-        if (renderKind !== 'incremental' || scrollTopSnapshot == null) return false;
+        // `freeze` (ruler drag) restores the exact scrollTop regardless of
+        // renderKind so the page holds still under the dragged marker.
+        if ((renderKind !== 'incremental' && !freeze) || scrollTopSnapshot == null) return false;
         const maxAfter = Math.max(1, scrollParent.scrollHeight - scrollParent.clientHeight);
         scrollParent.scrollTop = Math.min(Math.max(0, scrollTopSnapshot), maxAfter);
         return true;


### PR DESCRIPTION
User report: "when dragged up, page scrolls down" — the vertical ruler's margin drag was unusable because the page scrolled out from under the marker.

**Cause:** dragging a margin marker reflows the page; PagedEditor's post-reflow scroll-restore then re-anchored to content (ratio / DOM-anchor), so the viewport chased the moved content. Measured: drag top-margin up 40px → viewport jumped **+120px**, content leapt 160px.

**Fix:** thread a `marginDraggingRef` from the ruler drag handlers (vertical + horizontal) into the scroll-restore. While a drag is active, restore the **exact** pre-reflow `scrollTop` instead of the ratio/anchor path. Page holds still; the margin applies under the cursor.

Verified (Playwright): drag up and down both keep `scrollTop` at 0 (was +120); content shifts by exactly the margin delta; ruler stays at its position. e2e regression added; 1250 unit + smoke + 21 ruler/indent e2e green.