### PR TITLE
fix(layout): behind-doc objects render above the page background

### DIFF
--- a/docx-editor/e2e/tests/behind-doc-visible.spec.ts
+++ b/docx-editor/e2e/tests/behind-doc-visible.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression: "behind text" (behind-doc) anchored objects must render above
+ * the page background, not vanish behind it.
+ *
+ * Each page is painted with an opaque background. Behind-doc shapes/text-boxes
+ * are painted at z-index:-1; if no ancestor establishes a stacking context the
+ * -1 child escapes to the root's negative layer and paints *behind* the page
+ * background, so real content (e.g. the SDS appearance box 外观与性状/状/颜色)
+ * silently disappeared. The page now sets `isolation: isolate` to contain it.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test.describe('Behind-doc objects render above the page background', () => {
+  test('page establishes a stacking context and behind-doc text is visible', async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.loadDocxFile('fixtures/sds-real-world.docx');
+    await page.waitForSelector('.layout-page', { timeout: 40000 });
+    await page.waitForTimeout(1500);
+
+    // The fix: every page isolates so z-index:-1 content stays contained.
+    const isolation = await page
+      .locator('.layout-page')
+      .first()
+      .evaluate((el) => getComputedStyle(el).isolation);
+    expect(isolation).toBe('isolate');
+
+    // Structural guarantee: the behind-doc appearance-box label lives in a
+    // z-index:-1 text-box that is a descendant of the isolated page, so it is
+    // contained within the page's stacking context and paints above the page
+    // background (rather than escaping to the root's negative layer behind it).
+    const contained = await page.evaluate(() => {
+      const els = [...document.querySelectorAll('.layout-page *')] as HTMLElement[];
+      const label = els.find(
+        (e) => e.children.length === 0 && e.textContent?.trim().startsWith('外观') === true
+      );
+      if (!label) return 'label-not-found';
+      // nearest behind-doc (negative z-index) ancestor
+      let n: HTMLElement | null = label;
+      let behind: HTMLElement | null = null;
+      while (n && !n.classList.contains('layout-page')) {
+        if (parseInt(getComputedStyle(n).zIndex, 10) < 0) behind = n;
+        n = n.parentElement;
+      }
+      if (!behind) return 'not-behind-doc';
+      const page = behind.closest('.layout-page') as HTMLElement | null;
+      if (!page) return 'not-in-page';
+      return getComputedStyle(page).isolation === 'isolate' ? 'contained' : 'escapes';
+    });
+    expect(contained).toBe('contained');
+  });
+});

--- a/docx-editor/packages/core/src/layout-painter/renderPage.ts
+++ b/docx-editor/packages/core/src/layout-painter/renderPage.ts
@@ -306,6 +306,13 @@ function applyPageStyles(
   element.style.height = `${height}px`;
   element.style.backgroundColor = options.backgroundColor ?? '#ffffff';
   element.style.overflow = 'hidden';
+  // Establish a stacking context on the page so behind-doc objects (anchored
+  // shapes / text-boxes painted at z-index:-1, e.g. "behind text" VML frames)
+  // stay contained within the page and render ABOVE its background. Without it,
+  // no ancestor forms a stacking context, so a z-index:-1 child escapes to the
+  // root's negative layer and paints behind the page's opaque background —
+  // making real behind-doc content (not just watermarks) silently vanish.
+  element.style.isolation = 'isolate';
 
   // Page-level default (11pt Calibri). Must use the same chain as canvas
   // measurement in measureContainer.ts, otherwise unbreakable runs that lack


### PR DESCRIPTION
**Bug:** "behind text" anchored objects (VML text-boxes/shapes at z-index:-1) silently disappeared. No ancestor of the page formed a stacking context, so the -1 child escaped to the root's negative layer and painted *behind* the page's opaque white background. Real content was lost — the SDS appearance box (外观与性状 / 状 / 颜色 + the statement line) rendered as blank space.

**Fix:** `isolation: isolate` on the page (in `applyPageStyles`) contains behind-doc content within the page's stacking context — it now paints above the background but below text (correct Word "behind text" order). Watermarks / behind-images benefit identically.

**Verified:** the appearance box now renders (screenshot confirmed live from the built code, not injection). Full VF re-run: no page-count change; SDS proxy 60.6→60.4 — expected, since newly-*visible* cramped box ink scores as more disagreement than blank space did. Recovering dropped content is the correct visual outcome. 1250 unit + smoke + build green; e2e regression added (`behind-doc-visible.spec.ts`).