### PR TITLE
fix(release): Docker Hub README sync is continue-on-error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,14 @@ jobs:
         # quickstart / deployment instructions visitors see on
         # GitHub. Skipped on prereleases — the docker hub copy
         # tracks the latest production release.
+        #
+        # continue-on-error: the description API needs account-level
+        # permissions the registry push token may lack (it returned 403
+        # Forbidden on v0.0.3). The image is already published by this
+        # point, so a failed description sync must NOT fail the release
+        # or block the GitHub Release job. Set the description manually
+        # on Docker Hub if this keeps 403-ing.
+        continue-on-error: true
         if: steps.ver.outputs.prerelease == 'false'
         uses: peter-evans/dockerhub-description@v4
         with:


### PR DESCRIPTION
v0.0.3's image built + pushed fine (`casualoffice/docs:0.0.3` + `:latest`), but the **Sync README to Docker Hub** step 403'd (the registry token can push images but lacks permission to edit the repo description via the Docker Hub API). That failed the docker job and **skipped the Create GitHub Release** job.

The description sync is cosmetic and runs after the image is already published, so mark it `continue-on-error: true` — a failed sync no longer fails the release or blocks the GitHub Release. Set the Docker Hub description manually if it keeps 403-ing.