### PR TITLE
fix(styles): docDefaults must not be overridden by built-in Normal

### DIFF
--- a/docx-editor/packages/core/src/prosemirror/styles/styleResolver.test.ts
+++ b/docx-editor/packages/core/src/prosemirror/styles/styleResolver.test.ts
@@ -58,9 +58,13 @@ describe('StyleResolver', () => {
   });
 
   describe('resolveParagraphStyle', () => {
-    test('returns docDefaults merged with built-in Normal when no styleId provided', () => {
+    test('uses docDefaults (not the built-in Normal) when the doc has no Normal style', () => {
+      // A document with its own docDefaults but no Normal style: docDefaults
+      // ARE the paragraph defaults (ECMA-376 §17.7.2). The built-in Normal
+      // (8pt after / 1.08 line) must NOT override them — doing so compressed
+      // spacing vs Word/LibreOffice on every doc that relies on docDefaults.
       const docDefaults: DocDefaults = {
-        pPr: { lineSpacing: 240, spaceAfter: 160 },
+        pPr: { lineSpacing: 312, spaceAfter: 120 },
         rPr: { fontSize: 22 },
       };
 
@@ -72,10 +76,19 @@ describe('StyleResolver', () => {
       const resolver = createStyleResolver(styleDefinitions);
       const result = resolver.resolveParagraphStyle(null);
 
-      // Built-in Normal style overrides docDefaults for lineSpacing (259) and spaceAfter (160)
+      expect(result.paragraphFormatting?.lineSpacing).toBe(312);
+      expect(result.paragraphFormatting?.spaceAfter).toBe(120);
+      expect(result.runFormatting?.fontSize).toBe(22);
+    });
+
+    test('falls back to the built-in Normal only when there are no docDefaults', () => {
+      // Truly bare document: no Normal style AND no docDefaults → Word's
+      // built-in Normal (8pt after / 1.08x line) is the correct fallback.
+      const resolver = createStyleResolver({ styles: [] });
+      const result = resolver.resolveParagraphStyle(null);
+
       expect(result.paragraphFormatting?.lineSpacing).toBe(259);
       expect(result.paragraphFormatting?.spaceAfter).toBe(160);
-      expect(result.runFormatting?.fontSize).toBe(22);
     });
 
     test('applies Normal style when no styleId and Normal exists', () => {

--- a/docx-editor/packages/core/src/prosemirror/styles/styleResolver.ts
+++ b/docx-editor/packages/core/src/prosemirror/styles/styleResolver.ts
@@ -280,7 +280,17 @@ export class StyleResolver {
     }
     // Fall back to "Normal" for paragraph styles
     if (type === 'paragraph') {
-      return this.stylesById.get('Normal') ?? BUILTIN_NORMAL_STYLE;
+      const normal = this.stylesById.get('Normal');
+      if (normal) return normal;
+      // No Normal style in the document. If it defines its own
+      // `docDefaults`, THOSE are the paragraph defaults (ECMA-376
+      // §17.7.2) — substituting Word's built-in Normal (8pt after /
+      // 1.08 line) here would merge OVER and override the document's
+      // explicit docDefaults, compressing spacing vs Word/LibreOffice on
+      // every doc that relies on docDefaults without a Normal style.
+      // Only use the built-in when the document provides no paragraph
+      // defaults at all.
+      return this.docDefaults?.pPr ? undefined : BUILTIN_NORMAL_STYLE;
     }
     return undefined;
   }


### PR DESCRIPTION
**Phase 2 of the VF-to-80 initiative (docs/internal/21) — first systematic fix.**

Measuring the app's own templates revealed normal documents render at only 50-70 vs LibreOffice. Root cause (headless-probed): a document with **no Normal style** but its **own docDefaults** (e.g. `w:after=120`, `w:line=288`) had its defaults overridden — `findDefaultStyle` fell back to Word's built-in Normal (`160`/`259`) and merged it *over* the docDefaults, compressing every paragraph's spacing.

Per ECMA-376 §17.7.2, when there's no Normal style the docDefaults **are** the paragraph defaults. Fix: only substitute the built-in Normal when the document has *neither* a Normal style *nor* docDefaults.

**Guarded result:** representative template VF mean **58.5 → 63.4** (broad per-doc gains: press-release +19, syllabus +10, recipe +7, memo +8); stress corpus unchanged (no regression); round-trip stays **pristine**; **1251 unit + smoke green**. Render-only — no model/round-trip/collab impact.

Test updated to assert the correct ECMA behavior + new coverage for the truly-bare fallback.