### PR TITLE
fix(layout): paragraph spacing is spaceBefore + spaceAfter (not max)

### DIFF
--- a/docx-editor/packages/core/src/layout-engine/index.ts
+++ b/docx-editor/packages/core/src/layout-engine/index.ts
@@ -162,7 +162,10 @@ function computeColumnRegionHeight(
       spaceBefore = getSpacingBefore(block as ParagraphBlock);
       spaceAfter = getSpacingAfter(block as ParagraphBlock);
     }
-    const effectiveBefore = Math.max(spaceBefore, colTrailing[col]);
+    // Sum prev-after + this-before (Word/LibreOffice behavior), matching the
+    // paginator's addFragment — see the note there. Must stay in sync or the
+    // region-height estimate disagrees with the painted layout.
+    const effectiveBefore = spaceBefore + colTrailing[col];
     colHeights[col] += effectiveBefore + height;
     colTrailing[col] = spaceAfter;
   }

--- a/docx-editor/packages/core/src/layout-engine/integration.test.ts
+++ b/docx-editor/packages/core/src/layout-engine/integration.test.ts
@@ -971,7 +971,7 @@ describe('Layout Engine - Contextual Spacing', () => {
 
     const frags = layout.pages[0].fragments;
     const gap = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap).toBe(13); // max(13, 5)
+    expect(gap).toBe(18); // 13 + 5 (Word adds spaceAfter + spaceBefore)
   });
 
   test('does NOT suppress spacing when styles differ', () => {
@@ -998,7 +998,7 @@ describe('Layout Engine - Contextual Spacing', () => {
     const frags = layout.pages[0].fragments;
     // Different styles — spacing should NOT be suppressed
     const gap = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap).toBe(13); // max(13, 5)
+    expect(gap).toBe(18); // 13 + 5 (Word adds spaceAfter + spaceBefore)
   });
 
   test('does NOT suppress when only one paragraph has contextualSpacing', () => {
@@ -1024,7 +1024,7 @@ describe('Layout Engine - Contextual Spacing', () => {
 
     const frags = layout.pages[0].fragments;
     const gap = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap).toBe(13); // max(13, 5)
+    expect(gap).toBe(18); // 13 + 5 (Word adds spaceAfter + spaceBefore)
   });
 
   test('suppresses spacing in a chain of 3+ same-style paragraphs', () => {
@@ -1102,17 +1102,17 @@ describe('Layout Engine - Contextual Spacing', () => {
     const frags = layout.pages[0].fragments;
     expect(frags.length).toBe(4);
 
-    // Normal → Bullet: no contextualSpacing, max(13, 5)
+    // Normal → Bullet: no contextualSpacing, 13 + 5 (Word sums)
     const gap0to1 = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap0to1).toBe(13);
+    expect(gap0to1).toBe(18);
 
     // Bullet → Bullet: both contextual, same style → suppressed
     const gap1to2 = frags[2].y - (frags[1].y + frags[1].height);
     expect(gap1to2).toBe(0);
 
-    // Bullet → Normal: Normal lacks contextualSpacing, max(13, 5)
+    // Bullet → Normal: Normal lacks contextualSpacing, 13 + 5 (Word sums)
     const gap2to3 = frags[3].y - (frags[2].y + frags[2].height);
-    expect(gap2to3).toBe(13);
+    expect(gap2to3).toBe(18);
   });
 
   test('does NOT suppress when styleId is undefined', () => {
@@ -1139,7 +1139,7 @@ describe('Layout Engine - Contextual Spacing', () => {
     const frags = layout.pages[0].fragments;
     // Without styleId, contextual spacing should NOT be applied
     const gap = frags[1].y - (frags[0].y + frags[0].height);
-    expect(gap).toBe(10); // max(10, 5)
+    expect(gap).toBe(15); // 10 + 5 (Word adds spaceAfter + spaceBefore)
   });
 });
 

--- a/docx-editor/packages/core/src/layout-engine/paginator.ts
+++ b/docx-editor/packages/core/src/layout-engine/paginator.ts
@@ -277,9 +277,15 @@ export function createPaginator(options: PaginatorOptions) {
     spaceBefore: number = 0,
     spaceAfter: number = 0
   ): { state: PageState; x: number; y: number } {
-    // Word collapses adjacent paragraphs' spaceAfter / next.spaceBefore to
-    // the larger of the two (CSS-style margin-collapse), not the sum.
-    const effectiveSpaceBefore = Math.max(spaceBefore, getCurrentState().trailingSpacing);
+    // Word/LibreOffice ADD a paragraph's spaceBefore to the previous
+    // paragraph's spaceAfter (this is the well-known Word "extra space
+    // between paragraphs" — NOT CSS-style margin-collapse). Summing matches
+    // the reference renderer; max() compressed every body→heading transition
+    // by the smaller of the two values (e.g. a 6pt body-after lost against a
+    // 10pt heading-before), accumulating ~1 line of drift per page.
+    // Contextual-spacing suppression (same-style paragraphs) is applied
+    // upstream by zeroing the relevant side, so it still works under summing.
+    const effectiveSpaceBefore = spaceBefore + getCurrentState().trailingSpacing;
     const totalHeight = effectiveSpaceBefore + height;
 
     // Ensure we have space


### PR DESCRIPTION
**Phase 2 of VF-to-80 (docs/internal/21) — the big systematic lever.**

The paginator collapsed inter-paragraph spacing with `Math.max(spaceBefore, prevSpaceAfter)` (CSS margin-collapse). Word/LibreOffice **add** them — the well-known Word 'extra space between paragraphs'. The reference render confirms it: every body→heading gap was short by exactly `min(after, before)` (e.g. 6pt body-after lost against a 10pt heading-before), accumulating ~1 line of drift per page and mis-paginating content.

Fix: sum `spaceBefore + prevSpaceAfter` in both the paginator and the region-height estimator (must stay in sync). Contextual-spacing suppression is unaffected (it zeroes the relevant side upstream).

**Guarded result (pairs with #37 docDefaults):** representative template VF **63.4 → 76.7** — broad per-doc gains (essay 32→83, recipe→87, meeting-notes→91, most templates now 72-91). Stress corpus unchanged; round-trip **pristine**; **1251 unit + smoke green**. Render-only. Updated 5 contextual-spacing tests that asserted the old `max()` to the correct sums (e.g. `max(13,5)=13` → `13+5=18`).