### PR TITLE
fix(layout): empty paragraphs keep inherited spacing (clears VF 80 on templates)

### DIFF
--- a/docx-editor/packages/core/src/layout-engine/index.ts
+++ b/docx-editor/packages/core/src/layout-engine/index.ts
@@ -172,27 +172,22 @@ function computeColumnRegionHeight(
   return Math.max(0, ...colHeights);
 }
 
-function isEmptyParagraph(block: ParagraphBlock): boolean {
-  if (block.runs.length === 0) return true;
-  if (block.runs.length !== 1) return false;
-  const r = block.runs[0];
-  return r.kind === 'text' && ((r as { text?: string }).text ?? '') === '';
-}
-
 /**
- * Word collapses style-inherited spacing on empty paragraphs (only direct
- * formatting survives). `spacingExplicit` tracks which side was set inline.
+ * Empty paragraphs keep their inherited before/after spacing — Word and
+ * LibreOffice both render an empty separator paragraph at full height
+ * (line + before + after). Previously we zeroed style-inherited spacing on
+ * empty paragraphs, which compressed every empty-line separator by its
+ * inherited spacing (e.g. the 6 blank lines in a business letter each lost
+ * 6pt, ~1 line of drift). The narrow "trailing empty paragraph after a
+ * table is zero-height" case (#381) is handled separately in the
+ * header/footer normalization path, not here.
  */
 function getSpacingBefore(block: ParagraphBlock): number {
-  const value = block.attrs?.spacing?.before ?? 0;
-  if (isEmptyParagraph(block) && !block.attrs?.spacingExplicit?.before) return 0;
-  return value;
+  return block.attrs?.spacing?.before ?? 0;
 }
 
 function getSpacingAfter(block: ParagraphBlock): number {
-  const value = block.attrs?.spacing?.after ?? 0;
-  if (isEmptyParagraph(block) && !block.attrs?.spacingExplicit?.after) return 0;
-  return value;
+  return block.attrs?.spacing?.after ?? 0;
 }
 
 /**


### PR DESCRIPTION
**Phase 2 of VF-to-80 (docs/internal/21) — the fix that clears 80 on the representative corpus.**

The layout engine zeroed *style-inherited* spacing on empty paragraphs (only inline-explicit spacing survived). Word and LibreOffice both render an empty separator paragraph at full height (line + before + after), so this compressed every blank-line separator by its inherited spacing — e.g. a business letter's 6 blank lines each lost 6pt (~1 line of drift), tanking the score on letter-style docs. The narrow '#381 trailing empty paragraph after a table is zero-height' case is handled separately in the header/footer normalization path, not here.

**Guarded result (pairs with #37 + #38):** representative template VF **76.7 → 82.8 — above the 80 bar**. Targeted laggards nailed it: **letter 57→95, cover-letter 65→94**; most templates now 76-95. Stress corpus unchanged (no regression); round-trip **pristine**; **1251 unit + smoke green**. Render-only.