### PR TITLE
ci(vf): enforce representative visual-fidelity floor (>= 80)

### DIFF
--- a/.github/workflows/visual-fidelity.yml
+++ b/.github/workflows/visual-fidelity.yml
@@ -1,0 +1,99 @@
+name: Visual fidelity (representative)
+
+# Enforces the visual-fidelity floor on the *representative* corpus — the app's
+# own templates (letters, resumes, reports, memos), i.e. the documents people
+# actually edit. The mean cleared 80/100 once the paragraph-spacing fixes
+# landed (see docs/internal/21); this gate keeps it there so a future layout or
+# style change can't silently regress real-document fidelity.
+#
+# How it works: LibreOffice renders each fixture to a PNG reference (ground
+# truth), the editor renders the same docs via a headless dev server, and
+# diff.py scores ink-IoU + row-profile agreement. VF_FLOOR fails the run if the
+# mean dips below the bar.
+#
+# Heavier than the unit CI (LibreOffice + Playwright + per-page rendering), so
+# it's scoped to PRs/pushes that touch the layout/style code or the corpus, plus
+# manual dispatch — not every PR.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docx-editor/packages/core/**'
+      - 'docx-editor/scripts/visual-fidelity/**'
+      - 'docx-editor/e2e/fixtures/repr-*.docx'
+  pull_request:
+    paths:
+      - 'docx-editor/packages/core/**'
+      - 'docx-editor/scripts/visual-fidelity/**'
+      - 'docx-editor/e2e/fixtures/repr-*.docx'
+  workflow_dispatch:
+    inputs:
+      floor:
+        description: 'Minimum mean as a 0..1 fraction'
+        required: false
+        default: '0.80'
+
+concurrency:
+  group: vf-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  representative:
+    name: Representative corpus floor (>= 80)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: docx-editor
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
+      - name: Install editor deps
+        run: bun install --frozen-lockfile
+
+      # The reference renderer shells out to LibreOffice (DOCX → PDF) and the
+      # editor renderer drives headless Chromium; both apt installs hit the same
+      # 403ing Microsoft/azure repo that breaks `playwright install --with-deps`,
+      # so drop those sources first (matches ci.yml).
+      - name: Drop broken Microsoft apt repo
+        run: sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure* 2>/dev/null || true
+
+      - name: Install LibreOffice (reference renderer)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libreoffice
+          soffice --version
+
+      - name: Install Python render/diff deps
+        run: python3 -m pip install --quiet --break-system-packages PyMuPDF numpy Pillow
+
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+
+      # The editor imports @eigenpal/docx-core from its built dist, so the dev
+      # server must serve freshly-built core (with the PR's changes), not a stale
+      # build. run.mjs starts its own dev server when BASE_URL is unset.
+      - name: Build core + react
+        run: bun run build
+
+      - name: Run representative visual fidelity (enforce floor)
+        env:
+          VF_GROUP: representative
+          VF_FLOOR: ${{ github.event.inputs.floor || '0.80' }}
+        run: node scripts/visual-fidelity/run.mjs
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: visual-fidelity-representative-report
+          path: |
+            docx-editor/visual-fidelity-out/visual-fidelity-report.md
+            docx-editor/visual-fidelity-out/visual-fidelity-report.json
+          retention-days: 14

--- a/.github/workflows/visual-fidelity.yml
+++ b/.github/workflows/visual-fidelity.yml
@@ -70,6 +70,18 @@ jobs:
           sudo apt-get install -y --no-install-recommends libreoffice
           soffice --version
 
+      # Both renderers must use the SAME fonts or they disagree on line breaks
+      # and the score collapses (CI scored 64.8 vs 82.8 locally purely from font
+      # substitution). Carlito is metric-compatible with Calibri; Liberation
+      # with Arial / Times New Roman / Courier New — exactly what LibreOffice
+      # substitutes to and what the editor's fallback stacks target. Installing
+      # them system-wide covers both LibreOffice and headless Chromium.
+      - name: Install metric-compatible fonts
+        run: |
+          sudo apt-get install -y --no-install-recommends \
+            fonts-crosextra-carlito fonts-liberation fonts-dejavu-core
+          fc-cache -f >/dev/null 2>&1 || true
+
       - name: Install Python render/diff deps
         run: python3 -m pip install --quiet --break-system-packages PyMuPDF numpy Pillow
 

--- a/docs/internal/21-vf-to-80-initiative.md
+++ b/docs/internal/21-vf-to-80-initiative.md
@@ -100,12 +100,23 @@ stayed 52.8 throughout (no regression). All three were genuine correctness bugs,
 found by measuring rather than guessing — and render-only, so round-trip and Yjs
 collab were never at risk (the load-bearing insight in §0 held).
 
-The `representative` group + its fixtures are checked in so 82.8 is reproducible
-(`VF_GROUP=representative node scripts/visual-fidelity/run.mjs`). Remaining:
-**Phase 5** — wire the representative tier into CI and raise the floor toward 0.80
-so it can't silently regress; and the **stress corpus** (52.8) still needs the
-deferred table-row-metrics work (its own worst-case floor, separate from the
-representative overall).
+The `representative` group + its fixtures are checked in so the result is
+reproducible (`VF_GROUP=representative node scripts/visual-fidelity/run.mjs`).
+
+**Phase 5 — DONE.** `.github/workflows/visual-fidelity.yml` renders the
+representative corpus (LibreOffice reference + headless editor) and fails the run
+if the mean drops below `VF_FLOOR=0.80` (`diff.py` gained floor support). The
+**canonical CI baseline is 87.6/100** — higher than the local 82.8 because CI
+pins the metric-compatible fonts (Carlito = Calibri, Liberation = Arial/Times/
+Courier) that LibreOffice substitutes to, so editor and reference agree even more
+tightly than on a dev Mac. The floor sits at the 0.80 credibility bar with ~7.6pt
+of headroom; tighten later if desired. Real-document fidelity can no longer
+silently regress.
+
+Remaining (optional): the **stress corpus** (52.8) still needs the deferred
+table-row-metrics work — its own worst-case floor, separate from the
+representative overall — and a Phase-3 line-height calibration could push the
+representative *above* 87.6 (risky shared change; only if warranted).
 
 ## 4. Non-negotiables
 

--- a/docx-editor/scripts/visual-fidelity/diff.py
+++ b/docx-editor/scripts/visual-fidelity/diff.py
@@ -20,7 +20,7 @@ which is exactly what the project did not have before.
 
 Usage: python3 diff.py <out_dir>
 """
-import sys, pathlib, json, re
+import os, sys, pathlib, json, re
 from collections import defaultdict
 import numpy as np
 from PIL import Image
@@ -157,5 +157,15 @@ report = out / "visual-fidelity-report.md"
 report.write_text("\n".join(lines))
 (out / "visual-fidelity-report.json").write_text(json.dumps(rows, indent=2, default=float))
 print(f"[diff] wrote {report}")
-print(f"[diff] {len(scored)} scored, mean "
-      f"{(sum(r['final'] for r in scored)/len(scored)) if scored else 0:.1f}/100")
+mean = (sum(r["final"] for r in scored) / len(scored)) if scored else 0.0
+print(f"[diff] {len(scored)} scored, mean {mean:.1f}/100")
+
+# Optional CI floor: VF_FLOOR is a 0..1 fraction (e.g. 0.80). Fail the run if
+# the mean dips below it, so a checked-in fidelity bar can't silently regress.
+floor_env = os.environ.get("VF_FLOOR")
+if floor_env:
+    floor = float(floor_env) * 100.0
+    if mean < floor:
+        print(f"[diff] FAIL: mean {mean:.1f} < floor {floor:.1f} (VF_FLOOR={floor_env})")
+        sys.exit(1)
+    print(f"[diff] OK: mean {mean:.1f} >= floor {floor:.1f} (VF_FLOOR={floor_env})")


### PR DESCRIPTION
**Phase 5 of VF-to-80 (docs/internal/21) — makes the 82.8 permanent.**

- `diff.py`: optional `VF_FLOOR` (0..1) — exits non-zero if the mean dips below it (back-compatible; no floor = no enforcement).
- New `visual-fidelity.yml` workflow: renders the representative template corpus (LibreOffice reference + headless editor via the dev server), scores ink-IoU + row-profile, and **fails if the mean drops under 80/100** (`VF_FLOOR=0.80`).

Scoped (paths + manual dispatch) to PRs/pushes that touch `packages/core`, the VF scripts, or the `repr-*` fixtures — not every PR — since it pulls LibreOffice + Playwright (~10 min). Builds core first so the dev server serves the PR's code.

Verified locally: floor passes at 0.80 (mean 82.8), fails at 0.95, and `run.mjs` propagates the non-zero exit. Real-document fidelity can no longer silently regress.