### PR TITLE
fix(collab): carry drawing envelope in PM (no more dropped drawings on edit/collab)

### DIFF
--- a/docx-editor/packages/core/src/docx/coedit-envelope-loss.test.ts
+++ b/docx-editor/packages/core/src/docx/coedit-envelope-loss.test.ts
@@ -49,9 +49,13 @@ describe('co-editing fidelity — envelope loss across the CRDT/PM boundary (aud
     const outNoSeed = serializeDocument(rebuiltNoSeed);
     const outWithSeed = serializeDocument(rebuiltWithSeed);
 
-    // The loss: the envelope is gone from a from-PM rebuild — and holding the
-    // seed model does NOT save it, because the body is rebuilt from PM.
-    expect(outNoSeed).not.toContain(ENVELOPE);
-    expect(outWithSeed).not.toContain(ENVELOPE);
+    // FIXED: the drawing envelope now rides through the PM document (carried on
+    // the shape/textBox node attrs in `toProseDoc`, restored in `fromProseDoc`),
+    // so a from-PM rebuild re-emits it verbatim — with OR without the seed. This
+    // is what makes drawings survive a structural edit, a collab peer joining
+    // from the Y.Doc, and a server-side snapshot. This file is now the
+    // regression guard for that.
+    expect(outNoSeed).toContain(ENVELOPE);
+    expect(outWithSeed).toContain(ENVELOPE);
   });
 });

--- a/docx-editor/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -1014,6 +1014,13 @@ function createShapeRun(node: PMNode): Run {
     };
   }
 
+  // Restore the original OOXML envelope so the serializer re-emits the drawing
+  // verbatim (the rawXml invariant: when set, model-based emission is skipped).
+  // This is what makes drawings survive a from-PM rebuild — structural edit,
+  // collab peer, or server snapshot — instead of being dropped.
+  if (attrs.rawXml) shape.rawXml = attrs.rawXml;
+  if (attrs.envelopeKey) shape.envelopeKey = attrs.envelopeKey;
+
   const shapeContent: ShapeContent = { type: 'shape', shape };
 
   return {
@@ -1684,6 +1691,12 @@ function convertPMTextBox(node: PMNode): Paragraph {
       },
     },
   };
+
+  // Restore the original OOXML envelope so the serializer re-emits this drawing
+  // verbatim (rawXml invariant) — the core of surviving a from-PM rebuild from a
+  // structural edit / collab peer / server snapshot.
+  if (attrs.rawXml) shape.rawXml = attrs.rawXml;
+  if (attrs.envelopeKey) shape.envelopeKey = attrs.envelopeKey;
 
   // Convert fill color back
   if (attrs.fillColor) {

--- a/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1935,6 +1935,11 @@ function convertShape(shape: Shape): PMNode {
     posRelFromV: posV?.relativeTo ?? null,
     posAlignH: posH?.alignment ?? null,
     posAlignV: posV?.alignment ?? null,
+    // Carry the original OOXML envelope so a from-PM rebuild (structural edit,
+    // collab peer, server snapshot) re-emits the drawing verbatim rather than
+    // dropping it. Survives Yjs intact (verified).
+    rawXml: shape.rawXml ?? null,
+    envelopeKey: shape.envelopeKey ?? null,
   });
 }
 
@@ -1995,6 +2000,10 @@ function extractTextBoxesFromParagraph(paragraph: Paragraph): TextBox[] {
                   ? shape.textBody.content
                   : [{ type: 'paragraph', content: [] }],
               margins: shape.textBody.margins,
+              // Carry the original OOXML envelope so a from-PM rebuild re-emits
+              // this drawing verbatim instead of dropping it (collab/snapshot).
+              rawXml: shape.rawXml,
+              envelopeKey: shape.envelopeKey,
             });
           }
         }
@@ -2084,6 +2093,10 @@ function convertTextBox(textBox: TextBox, styleResolver: StyleResolver | null): 
       posRelFromV: posV?.relativeTo ?? null,
       posAlignH: posH?.alignment ?? null,
       posAlignV: posV?.alignment ?? null,
+      // Original OOXML envelope — re-emitted verbatim on a from-PM rebuild so
+      // the drawing survives structural edits / collab peers / server snapshots.
+      rawXml: textBox.rawXml ?? null,
+      envelopeKey: textBox.envelopeKey ?? null,
     },
     contentNodes
   );

--- a/docx-editor/packages/core/src/prosemirror/extensions/nodes/ShapeExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/nodes/ShapeExtension.ts
@@ -64,6 +64,10 @@ export interface ShapeAttrs {
   glowColor?: string;
   /** Glow radius in pixels */
   glowRadius?: number;
+  /** Original OOXML envelope (VML/DrawingML) for verbatim re-emission on save. */
+  rawXml?: string;
+  /** Dedupe key for shapes sharing one source envelope. */
+  envelopeKey?: string;
 }
 
 /**
@@ -161,6 +165,12 @@ export const ShapeExtension = createNodeExtension({
       shadowOffsetY: { default: null },
       glowColor: { default: null },
       glowRadius: { default: null },
+      // The shape's original OOXML envelope (VML/DrawingML), carried through
+      // PM + Yjs so a save/edit/peer/snapshot re-emits the drawing verbatim
+      // instead of dropping it on a from-PM rebuild. `envelopeKey` dedupes
+      // shapes that share one source envelope (serializer emits it once).
+      rawXml: { default: null },
+      envelopeKey: { default: null },
     },
     parseDOM: [
       {

--- a/docx-editor/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -82,6 +82,10 @@ export interface TextBoxAttrs {
    */
   posAlignH?: string;
   posAlignV?: string;
+  /** Original OOXML envelope for verbatim re-emission on save. */
+  rawXml?: string;
+  /** Dedupe key for shapes sharing one source envelope. */
+  envelopeKey?: string;
 }
 
 export const TextBoxExtension = createNodeExtension({
@@ -115,6 +119,10 @@ export const TextBoxExtension = createNodeExtension({
       posRelFromV: { default: null },
       posAlignH: { default: null },
       posAlignV: { default: null },
+      // Original OOXML envelope (VML/DrawingML), carried through PM + Yjs so a
+      // from-PM rebuild re-emits the drawing verbatim instead of dropping it.
+      rawXml: { default: null },
+      envelopeKey: { default: null },
     },
     parseDOM: [
       {

--- a/docx-editor/packages/core/src/types/content.ts
+++ b/docx-editor/packages/core/src/types/content.ts
@@ -856,6 +856,13 @@ export interface TextBox {
    * - `normAutofit` — shrink text to fit (rare; renderer treats as fixed).
    */
   autoFit?: 'spAutoFit' | 'noAutofit' | 'normAutofit';
+  /**
+   * Original OOXML envelope (VML/DrawingML) for a text-box-bearing shape, so a
+   * from-PM rebuild re-emits the drawing verbatim. Same `rawXml`/`envelopeKey`
+   * contract as `Shape` / `Image`.
+   */
+  rawXml?: string;
+  envelopeKey?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
**Pillar A of the collab architecture (docs/internal/22, #42) — the core no-drops fix.**

Raw-XML drawing envelopes (VML/DrawingML shapes + text boxes — SDS hazard boxes, letterhead logos, page dividers) lived only on the Document model, not in ProseMirror. So any rebuild *from* PM dropped every drawing: a structural edit that forces a full repack, a collab peer joining from the Y.Doc, or a server-side snapshot. `coedit-envelope-loss.test.ts` pinned that loss.

**Fix:** carry `rawXml` + `envelopeKey` on the shape/textBox PM node attrs — `toProseDoc` sets them (incl. the shape→textBox extraction path), `fromProseDoc` restores them, the serializer's existing `rawXml` invariant re-emits verbatim. Verified the envelope now survives the from-PM rebuild (seedless **and** seeded), and the attrs ride through Yjs intact (6 fixtures byte-identical across `prosemirrorToYDoc → yDocToProsemirror`).

Drawings now survive **any** save/edit/peer/snapshot. The proving test flips from pinning the loss to guarding preservation. Round-trip **pristine**; **1251 unit + typecheck + lint green**. Image `rawXml` left as YAGNI (unused — images preserve via relationship IDs).