### PR TITLE
feat(collab): wire docs to shared Hocuspocus collab server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "collab"]
+	path = collab
+	url = git@github.com:CasualOffice/collab.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,31 @@ services:
       - go-mod-cache:/go
     restart: unless-stopped
 
+  # Shared CasualOffice collab server (Hocuspocus + Yjs), vendored as a
+  # git submodule at ./collab. Holds one authoritative Y.Doc per room so
+  # a fresh peer syncs from server state and the server can snapshot /
+  # version on its own — the forward path that replaces the Go gateway's
+  # relay-only collab. Run in DOCS mode here (CASUAL_FILE_EXT=.docx); the
+  # sheet app deploys the same image with .xlsx. A CasualEditor host
+  # points its `backend` at ws://localhost:1234/yjs to use it.
+  collab-dev:
+    profiles: ["dev"]
+    build:
+      context: ./collab
+      dockerfile: Dockerfile
+    container_name: casual-collab-dev
+    environment:
+      PORT: "1234"
+      HOST: "0.0.0.0"
+      CASUAL_FILE_EXT: ".docx"
+      CASUAL_STORAGE: "local"
+      CASUAL_LOCAL_PATH: "/data"
+    ports:
+      - "1234:1234"
+    volumes:
+      - ./data/collab:/data
+    restart: unless-stopped
+
 volumes:
   editor-node-modules:
   go-mod-cache:

--- a/docs/internal/23-collab-server-migration.md
+++ b/docs/internal/23-collab-server-migration.md
@@ -1,0 +1,77 @@
+# 23 — Collab server migration (shared Hocuspocus + Yjs)
+
+Status: **in progress** — server extracted + docs client wired + path proven; deploy
+cutover staged. Continues pillar C of [22-collab-scale-persistence](./22-collab-scale-persistence.md).
+
+## Decision
+
+Replace the Go gateway's **relay-only** collaboration role with a shared, real-Yjs
+server that holds one authoritative `Y.Doc` per room. Rather than build a Go CRDT
+(experimental, no mature Y.Xml support) we **lifted the sheet app's existing
+Hocuspocus server** into a standalone repo and made it product-agnostic, so a single
+codebase serves both Docs and Sheets.
+
+- Repo: **`github.com/CasualOffice/collab`** — Hocuspocus + Yjs + auth + file
+  persistence (memory / local / s3 / postgres) + WOPI + snapshots/versioning.
+- Vendored into this repo as a **git submodule** at `./collab`.
+- **Format-agnostic**: `src/host/format.ts` derives storage keys, download
+  Content-Types and default filenames from `CASUAL_FILE_EXT`
+  (docs → `.docx`, sheets → `.xlsx`, default `.xlsx`). The server stores opaque
+  OOXML bytes; all `.docx` knowledge stays in the editor client.
+
+## Why this resolves pillar C (and D)
+
+Hocuspocus maintains the authoritative `Y.Doc`, so:
+
+- **New-peer sync** comes from server state, not a peer re-upload.
+- **Snapshots on drain / versioning** are produced server-side (`onStoreDocument`,
+  opaque version strings + `If-Match`) — no Bun worker in the prod image.
+- The [#43 envelope-in-PM fix](./22-collab-scale-persistence.md) makes the docs
+  `Y.Doc` self-sufficient, so these server snapshots preserve drawings.
+
+## Client change
+
+`packages/react/src/collab/useCollab.ts` now uses `HocuspocusProvider`
+(`@hocuspocus/provider`, optional peer dep) instead of `y-websocket`'s
+`WebsocketProvider`. The hook's public API is unchanged, so `CasualEditor`
+consumers are unaffected. The room name travels in the Hocuspocus handshake, so
+`backend` is the bare ws endpoint (e.g. `ws://localhost:1234/yjs`), not a path
+prefix. Anonymous `write` works by default (the server reads share tokens from the
+`?share=` query, not the Hocuspocus `token`).
+
+The `examples/vite` demo keeps its **own** `useCollab` copy on the Go gateway, so the
+existing y-websocket demo is untouched by this change.
+
+## Proven
+
+Headless test against the server in docs mode (`CASUAL_FILE_EXT=.docx`):
+
+1. Two `HocuspocusProvider` peers on one room — edits in A converge to B. **PASS**
+2. Both peers dropped, a **fresh** peer joins — receives the content from the
+   server's authoritative `Y.Doc`. **PASS** (server-held state → pillar C).
+
+## Run locally
+
+```bash
+# Option A — submodule via docker-compose (dev profile)
+git submodule update --init
+docker compose --profile dev up   # collab-dev on :1234 (docs mode)
+
+# Option B — directly
+cd collab && npm install && CASUAL_FILE_EXT=.docx npm run dev
+```
+
+A `CasualEditor` host points `backend` at `ws://localhost:1234/yjs`.
+
+## Staged / follow-ups
+
+- **Deploy cutover** — pair the production `backend` switch with deploying a collab
+  instance; until then the live demo stays on the Go gateway.
+- **Sheets onto the same server** — point the sheet app at the vendored submodule
+  (its server is the source of this extraction, so behaviour is unchanged at the
+  `.xlsx` default).
+- **Cosmetics** — a couple of "sheet server" / "workbook" log + comment strings and
+  the `room.xlsxSeed` field name remain in the collab repo; functional, generalize
+  later.
+- **Retire the Go gateway's collab role** once the cutover is verified; keep it for
+  REST/inline host during transition.

--- a/docx-editor/bun.lock
+++ b/docx-editor/bun.lock
@@ -103,6 +103,7 @@
         "sonner": "^2.0.7",
       },
       "devDependencies": {
+        "@hocuspocus/provider": "^2.15.0",
         "prosemirror-commands": "^1.5.2",
         "prosemirror-dropcursor": "^1.8.2",
         "prosemirror-history": "^1.4.0",
@@ -117,6 +118,7 @@
         "yjs": "^13.6.0",
       },
       "peerDependencies": {
+        "@hocuspocus/provider": "^2.15.0",
         "prosemirror-commands": "^1.5.2",
         "prosemirror-dropcursor": "^1.8.2",
         "prosemirror-history": "^1.4.0",
@@ -133,6 +135,7 @@
         "yjs": "^13.6.0",
       },
       "optionalPeers": [
+        "@hocuspocus/provider",
         "react",
         "react-dom",
         "y-prosemirror",
@@ -329,6 +332,10 @@
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.9.0", "", { "dependencies": { "@types/node": "25.9.1", "happy-dom": "20.9.0" } }, "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="],
 
+    "@hocuspocus/common": ["@hocuspocus/common@2.15.3", "", { "dependencies": { "lib0": "^0.2.87" } }, "sha512-Rzh1HF0a2o/tf90A3w2XNdXd9Ym3aQzMDfD3lAUONCX9B9QOdqdyiORrj6M25QEaJrEIbXFy8LtAFcL0wRdWzA=="],
+
+    "@hocuspocus/provider": ["@hocuspocus/provider@2.15.3", "", { "dependencies": { "@hocuspocus/common": "^2.15.3", "@lifeomic/attempt": "^3.0.2", "lib0": "^0.2.87", "ws": "^8.17.1" }, "peerDependencies": { "y-protocols": "^1.0.6", "yjs": "^13.6.8" } }, "sha512-oadN05m+KL4ylNKVo5YspNG4MXkT2Y+FUFzrgigpQeTjQibkPUwCNmUnkUxMgrGRgxb+O0lJCfirFIJMxedctA=="],
+
     "@huggingface/jinja": ["@huggingface/jinja@0.5.9", "", {}, "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw=="],
 
     "@huggingface/tokenizers": ["@huggingface/tokenizers@0.1.3", "", {}, "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="],
@@ -406,6 +413,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "3.1.2", "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@lifeomic/attempt": ["@lifeomic/attempt@3.1.0", "", {}, "sha512-QZqem4QuAnAyzfz+Gj5/+SLxqwCAw2qmt7732ZXodr6VDWGeYLG6w1i/vYLa55JQM9wRuBKLmXmiZ2P0LtE5rw=="],
 
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "7.29.2", "@types/node": "12.20.55", "find-up": "4.1.0", "fs-extra": "8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
@@ -1557,7 +1566,7 @@
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "6.2.3", "string-width": "7.2.0", "strip-ansi": "7.2.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
-    "ws": ["ws@6.2.4", "", { "dependencies": { "async-limiter": "1.0.1" } }, "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw=="],
+    "ws": ["ws@8.20.1", "", {}, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "xml-js": ["xml-js@1.6.11", "", { "dependencies": { "sax": "1.6.0" }, "bin": { "xml-js": "./bin/cli.js" } }, "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g=="],
 
@@ -1621,8 +1630,6 @@
 
     "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "happy-dom/ws": ["ws@8.20.1", "", {}, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
-
     "level-iterator-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "2.0.4", "string_decoder": "1.1.1", "util-deprecate": "1.0.2" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "6.2.3", "is-fullwidth-code-point": "5.1.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
@@ -1676,6 +1683,8 @@
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "10.6.0", "get-east-asian-width": "1.6.0", "strip-ansi": "7.2.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "y-websocket/ws": ["ws@6.2.4", "", { "dependencies": { "async-limiter": "1.0.1" } }, "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw=="],
 
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 

--- a/docx-editor/packages/react/package.json
+++ b/docx-editor/packages/react/package.json
@@ -88,6 +88,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
+    "@hocuspocus/provider": "^2.15.0",
     "prosemirror-commands": "^1.5.2",
     "prosemirror-dropcursor": "^1.8.2",
     "prosemirror-history": "^1.4.0",
@@ -104,6 +105,9 @@
     "yjs": "^13.6.0"
   },
   "peerDependenciesMeta": {
+    "@hocuspocus/provider": {
+      "optional": true
+    },
     "react": {
       "optional": true
     },
@@ -131,6 +135,7 @@
     "sonner": "^2.0.7"
   },
   "devDependencies": {
+    "@hocuspocus/provider": "^2.15.0",
     "prosemirror-commands": "^1.5.2",
     "prosemirror-dropcursor": "^1.8.2",
     "prosemirror-history": "^1.4.0",

--- a/docx-editor/packages/react/src/collab/useCollab.ts
+++ b/docx-editor/packages/react/src/collab/useCollab.ts
@@ -1,26 +1,28 @@
 /**
- * useCollab — bridges a Yjs Y.Doc + WebsocketProvider into the
+ * useCollab — bridges a Yjs Y.Doc + HocuspocusProvider into the
  * DocxEditor via `externalPlugins` + `externalContent`.
  *
  * Opt-in. The host imports this hook only when collab is wanted;
- * `yjs`, `y-websocket`, and `y-prosemirror` are optional peer
- * dependencies so SDK consumers who don't enable collab don't
+ * `yjs`, `@hocuspocus/provider`, and `y-prosemirror` are optional
+ * peer dependencies so SDK consumers who don't enable collab don't
  * pay the bundle weight.
  *
- * Wire shape: a stateless WS gateway speaking the standard
- * y-websocket binary protocol. `ySyncPlugin` populates ProseMirror
- * from the shared Y state; `yCursorPlugin` renders remote cursors
- * from awareness; `yUndoPlugin` scopes undo to the local user.
+ * Wire shape: the shared CasualOffice `collab` server (Hocuspocus +
+ * Yjs) holds one authoritative Y.Doc per room — so a fresh peer syncs
+ * from server state and the server can snapshot/version on its own.
+ * `ySyncPlugin` populates ProseMirror from the shared Y state;
+ * `yCursorPlugin` renders remote cursors from awareness; `yUndoPlugin`
+ * scopes undo to the local user.
  *
  * Lifecycle:
  *   - First call constructs Y.Doc + provider + plugins.
- *   - Provider opens a WS to `${backend}/doc/${room}`.
+ *   - Provider opens a WS to `backend` and joins room `name`.
  *   - When peers' awareness picks up users, remote cursors light up.
  *   - On unmount, provider is destroyed and the Y.Doc closed.
  */
 import { useEffect, useMemo, useState } from 'react';
 import * as Y from 'yjs';
-import { WebsocketProvider } from 'y-websocket';
+import { HocuspocusProvider } from '@hocuspocus/provider';
 import { ySyncPlugin, yCursorPlugin, yUndoPlugin } from 'y-prosemirror';
 import type { Plugin } from 'prosemirror-state';
 
@@ -43,7 +45,7 @@ export interface CollabState {
   /** Live snapshot of who's connected, including the local user. */
   peers: CollabPeer[];
   /** The Yjs awareness instance — exposed for advanced consumers. */
-  awareness: WebsocketProvider['awareness'];
+  awareness: HocuspocusProvider['awareness'];
   /**
    * Shared document metadata. Lives in the same Y.Doc as the
    * editor content so it travels over the same WS, with the same
@@ -63,11 +65,16 @@ export interface CollabState {
 export interface UseCollabOptions {
   /** Per-doc room identifier — typically the docID. */
   room: string;
-  /** Base ws:// or wss:// URL of the gateway. The hook appends
-   *  `/doc/${room}` so the gateway's existing routing works. */
+  /** Base ws:// or wss:// URL of the collab server (Hocuspocus).
+   *  Unlike the old y-websocket gateway, the room name travels in the
+   *  Hocuspocus handshake, so this is the bare endpoint with no path. */
   backend: string;
   /** Local user metadata published over awareness. */
   user: { name: string; color: string };
+  /** Optional auth token for the server's onAuthenticate hook.
+   *  Defaults to a truthy placeholder so the handshake completes even
+   *  when the server gates joins by role. */
+  token?: string;
 }
 
 /**
@@ -76,20 +83,32 @@ export interface UseCollabOptions {
  * DocxEditor alongside the returned plugins so the editor's own
  * loader doesn't overwrite the Yjs-populated PM state.
  */
-export function useCollab({ room, backend, user }: UseCollabOptions): CollabState {
+export function useCollab({ room, backend, user, token }: UseCollabOptions): CollabState {
   const { ydoc, provider, plugins, metaMap } = useMemo(() => {
     const ydoc = new Y.Doc();
-    // WebsocketProvider takes a *URL prefix* and appends `/${room}`.
-    // Gateway routes /doc/{docId}, so the prefix is `${backend}/doc`.
-    const provider = new WebsocketProvider(`${backend}/doc`, room, ydoc, {
-      connect: true,
+    // Hocuspocus carries the document name in the handshake (`name`),
+    // not the URL path — so `backend` is the bare ws endpoint. A
+    // truthy token lets the handshake complete past an onAuthenticate
+    // hook even for anonymous sessions.
+    const provider = new HocuspocusProvider({
+      url: backend,
+      name: room,
+      document: ydoc,
+      token: token ?? 'anon',
     });
     const fragment = ydoc.getXmlFragment('prosemirror');
-    const plugins = [ySyncPlugin(fragment), yCursorPlugin(provider.awareness), yUndoPlugin()];
+    // Hocuspocus creates awareness by default; guard the type union so
+    // the cursor plugin is only wired when it's actually present.
+    const awareness = provider.awareness;
+    const plugins = [
+      ySyncPlugin(fragment),
+      ...(awareness ? [yCursorPlugin(awareness)] : []),
+      yUndoPlugin(),
+    ];
     const metaMap = ydoc.getMap('meta');
     return { ydoc, provider, plugins, metaMap };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [room, backend]);
+  }, [room, backend, token]);
 
   const [status, setStatus] = useState<CollabStatus>('connecting');
   const [peers, setPeers] = useState<CollabPeer[]>([]);
@@ -98,14 +117,16 @@ export function useCollab({ room, backend, user }: UseCollabOptions): CollabStat
   // avatars + remote cursors. Re-runs on rename / recolor without
   // rebuilding the doc.
   useEffect(() => {
-    provider.awareness.setLocalStateField('user', user);
+    provider.awareness?.setLocalStateField('user', user);
   }, [provider, user.name, user.color]);
 
   useEffect(() => {
+    const awareness = provider.awareness;
+    if (!awareness) return;
     const refreshPeers = () => {
-      const localId = provider.awareness.clientID;
+      const localId = awareness.clientID;
       const out: CollabPeer[] = [];
-      provider.awareness.getStates().forEach((state, clientId) => {
+      awareness.getStates().forEach((state, clientId) => {
         if (!state.user) return;
         out.push({
           clientId,
@@ -123,12 +144,12 @@ export function useCollab({ room, backend, user }: UseCollabOptions): CollabStat
     const onStatus = (e: { status: CollabStatus }) => setStatus(e.status);
 
     provider.on('status', onStatus);
-    provider.awareness.on('change', refreshPeers);
+    awareness.on('change', refreshPeers);
     refreshPeers();
 
     return () => {
       provider.off('status', onStatus);
-      provider.awareness.off('change', refreshPeers);
+      awareness.off('change', refreshPeers);
     };
   }, [provider]);
 


### PR DESCRIPTION
Vendors the new **CasualOffice/collab** server (Hocuspocus + Yjs, lifted from the sheet app and made format-agnostic) as a submodule at \`./collab\`, and points the SDK's \`useCollab\` at it via \`HocuspocusProvider\`.

This gives docs a real server-side authoritative \`Y.Doc\` per room: new peers sync from server state, and snapshots/versioning are produced server-side — pillar C of \`docs/internal/22\`. The #43 envelope-in-PM fix makes the \`Y.Doc\` self-sufficient so those snapshots preserve drawings.

**Why this and not a Go CRDT:** mature pure-Go Yjs CRDTs don't support Y.Xml; the sheet app already runs a production Hocuspocus server. One product-agnostic codebase now serves both Docs and Sheets (format via \`CASUAL_FILE_EXT\`).

**Scope / safety**
- \`useCollab\` switches \`y-websocket\` → \`@hocuspocus/provider\` (optional peer dep). Public hook API unchanged, so \`CasualEditor\` consumers don't change.
- The \`examples/vite\` demo keeps its **own** y-websocket \`useCollab\` copy — the existing demo is untouched.
- Inert until a host points \`backend\` at the collab server. **Hold merge** until paired with a collab-server deploy.

**Proven** (headless, server in docs mode): two-peer convergence + a fresh peer syncing content from the server's authoritative \`Y.Doc\`.

**Verify:** format ✓ · typecheck ✓ · lint 0 errors ✓ · unit 330/330 ✓ · smoke ✓. Collab repo: 148/148 unit ✓.

Run locally: \`git submodule update --init && docker compose --profile dev up\` (collab-dev on :1234).