### PR TITLE
feat(collab): demo wiring + production deploy topology

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,10 @@ services:
     environment:
       VITE_COLLAB_ENABLED: "true"
       VITE_BACKEND: "http://localhost:8080"
+      # Collab CRDT runs on the shared collab server (Hocuspocus), a
+      # separate service from the REST gateway above. REST/share-link
+      # stays on :8080; the Y.Doc sync goes to the collab server.
+      VITE_COLLAB_BACKEND: "ws://localhost:1234/yjs"
     ports:
       - "5173:5173"
     volumes:

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -415,7 +415,13 @@ export function App() {
     const params = new URLSearchParams(window.location.search);
     const room = params.get('room');
     if (!room) return null;
-    let backend = params.get('backend');
+    // Collab WS endpoint. The shared CasualOffice collab server
+    // (Hocuspocus) is a SEPARATE service from the REST/share-link
+    // gateway, so resolve it on its own and let it differ from
+    // `backendHttp`. Order:
+    //   ?collab=ws(s)://…  →  VITE_COLLAB_BACKEND  →  ?backend=  →  same-origin
+    const env = (import.meta as { env?: Record<string, string> }).env?.VITE_COLLAB_BACKEND;
+    let backend = params.get('collab') || env || params.get('backend');
     if (!backend) {
       // Same-origin default — production: the Docker image
       // bundles the gateway and the static editor under one host,


### PR DESCRIPTION
Follow-up to the collab-server migration (#44). Makes the demo + a production deploy target the shared collab server.

**Demo wiring**
- The example's `useCollab` is a re-export of the SDK hook (now `HocuspocusProvider`), so the CRDT must target the collab server, not the y-websocket gateway.
- Collab WS resolves from `?collab=` → `VITE_COLLAB_BACKEND` → `?backend=` → same-origin **`/yjs`** (the Hocuspocus upgrade route). REST/seed stays on the gateway.
- `docker-compose` dev wires `editor-dev` → `collab-dev`.

**Production deploy** (`deploy/`)
- Caddy reverse proxy unifies both behind one origin: `/yjs` → collab (`:1234`), everything else → gateway (`:8080` REST + bundled SPA). So the SPA reaches collab same-origin — nothing host-specific baked into the build.
- `docker-compose.prod.yml` + `deploy/README.md` (topology, `/yjs` routing requirement, persistence, per-product format/Redis prefix, cutover steps).

**Also**: bumps the vendored `collab` submodule to product-neutral logs/config (`779fe3c`).

**Verified**: two-tab in-browser convergence + remote cursor + presence through the collab server. Gate: format ✓ · example typecheck ✓ · unit 330/330 ✓ · smoke ✓ · `compose config` valid.