### PR TITLE
feat(deploy): production topology for gateway + collab

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,15 @@
+# Unify the gateway + collab server behind one origin so the editor can
+# reach both same-origin (no per-host config baked into the SPA build):
+#
+#   /yjs, /yjs/*   ->  collab server (Hocuspocus WS upgrade route)
+#   everything else ->  gateway (REST /api/docs, seed/download, share-link,
+#                       and the bundled SPA)
+#
+# Set COLLAB_SITE_ADDRESS to a real hostname (e.g. doc.example.com) for
+# automatic HTTPS, or leave the :8080 default for local/proxied use.
+
+{$COLLAB_SITE_ADDRESS::8080} {
+	@collab path /yjs /yjs/*
+	reverse_proxy @collab collab:1234
+	reverse_proxy gateway:8080
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,62 @@
+# Production deploy — gateway + collab, unified same-origin
+
+The collab migration splits collaboration onto the shared
+[`collab`](../collab) server (Hocuspocus + Yjs). Production runs **two**
+services behind one origin:
+
+```
+            ┌─────────── Caddy (proxy) ───────────┐
+  client ──▶│  /yjs/*        → collab  :1234       │
+            │  everything    → gateway :8080       │
+            └──────────────────────────────────────┘
+                     │                  │
+              collab (CRDT)       gateway (REST + SPA)
+              Hocuspocus/Yjs      /api/docs, seed, share-link,
+              Y.Doc per room      bundled editor
+```
+
+The editor reaches collab at **same-origin `/yjs`** (the App.tsx
+same-origin default + `deploy/Caddyfile`), so nothing host-specific is
+baked into the SPA build.
+
+## Run
+
+```bash
+# from the repo root
+git submodule update --init                 # fetch the collab server
+docker compose -f docker-compose.prod.yml up -d --build
+# → http://localhost:8080
+```
+
+For a real domain with automatic HTTPS:
+
+```bash
+COLLAB_SITE_ADDRESS=doc.example.com \
+  docker compose -f docker-compose.prod.yml up -d --build
+# (uncomment the 80/443 ports in the proxy service)
+```
+
+## What matters
+
+- **`/yjs` routing is required.** Hocuspocus' WS upgrade lives at `/yjs`
+  on the collab server. The Caddyfile routes it; any other ingress
+  (nginx, a cloud LB, an existing reverse proxy) must do the same and
+  must pass WebSocket upgrades.
+- **SPA build has collab on.** The bundled image builds with
+  `VITE_COLLAB_ENABLED=true` (see `../Dockerfile`) and relies on the
+  same-origin `/yjs` default — no `VITE_COLLAB_BACKEND` needed when
+  proxied same-origin. Point it elsewhere only for split-origin setups.
+- **Persist the collab Y.Doc.** `CASUAL_STORAGE=local` (or `s3`/`postgres`)
+  so a collab restart doesn't drop live rooms. The gateway stays
+  stateless; document persistence is the host's (`GATEWAY_HOST`).
+- **Format per product.** Docs sets `CASUAL_FILE_EXT=.docx`; sheets
+  deploy the same image with `.xlsx`. On a shared Redis, give each a
+  distinct `CASUAL_REDIS_PREFIX`.
+
+## Cutover
+
+1. Deploy this topology alongside the current gateway-only stack.
+2. Verify collab (two browsers, one room) against the new origin.
+3. Flip DNS / the public origin to the proxy.
+4. Once stable, the gateway's legacy `/doc` y-websocket relay is unused
+   by the editor and can be retired (keep the gateway for REST/host).

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,70 @@
+# Production topology for the collab migration: the gateway (REST +
+# bundled SPA) and the shared collab server (Hocuspocus CRDT) behind a
+# Caddy reverse proxy that unifies them same-origin. The SPA reaches
+# collab at same-origin /yjs (see deploy/Caddyfile + the App.tsx
+# same-origin default), so nothing host-specific is baked into the build.
+#
+#   docker compose -f docker-compose.prod.yml up -d --build
+#
+# Set COLLAB_SITE_ADDRESS=doc.example.com for automatic HTTPS.
+# Run from the repo root (contexts are relative to it).
+
+services:
+  gateway:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: casual-editor:local
+    environment:
+      GATEWAY_ADDR: ":8080"
+      # Share-link mode by default; switch to local/wopi as needed.
+      GATEWAY_HOST: "inline"
+      LOG_FORMAT: "json"
+      ACCESS_LOG: "true"
+    expose:
+      - "8080"
+    restart: unless-stopped
+
+  collab:
+    build:
+      context: ./collab
+      dockerfile: Dockerfile
+    image: casual-collab:local
+    environment:
+      PORT: "1234"
+      HOST: "0.0.0.0"
+      # DOCS deployment — sheets deploy the same image with .xlsx.
+      CASUAL_FILE_EXT: ".docx"
+      # Persist Y.Doc room snapshots so a restart doesn't drop live docs.
+      CASUAL_STORAGE: "local"
+      CASUAL_LOCAL_PATH: "/data"
+      # For a shared Redis, set REDIS_URL + a per-product key prefix:
+      # REDIS_URL: "redis://redis:6379"
+      # CASUAL_REDIS_PREFIX: "casual-docs:room:"
+    volumes:
+      - ./data/collab:/data
+    expose:
+      - "1234"
+    restart: unless-stopped
+
+  proxy:
+    image: caddy:2
+    depends_on:
+      - gateway
+      - collab
+    environment:
+      COLLAB_SITE_ADDRESS: "${COLLAB_SITE_ADDRESS:-:8080}"
+    ports:
+      - "8080:8080"
+      # Uncomment for a real domain with automatic HTTPS:
+      # - "80:80"
+      # - "443:443"
+    volumes:
+      - ./deploy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    restart: unless-stopped
+
+volumes:
+  caddy-data:
+  caddy-config:

--- a/docs/internal/23-collab-server-migration.md
+++ b/docs/internal/23-collab-server-migration.md
@@ -65,8 +65,10 @@ A `CasualEditor` host points `backend` at `ws://localhost:1234/yjs`.
 
 ## Staged / follow-ups
 
-- **Deploy cutover** — pair the production `backend` switch with deploying a collab
-  instance; until then the live demo stays on the Go gateway.
+- **Deploy cutover** — production topology + Caddy reverse proxy (`/yjs` → collab,
+  else → gateway) is in [`deploy/`](../../deploy/README.md)
+  (`docker compose -f docker-compose.prod.yml up`). Pair the origin switch with
+  deploying a collab instance; until then the live demo stays on the Go gateway.
 - **Sheets onto the same server** — point the sheet app at the vendored submodule
   (its server is the source of this extraction, so behaviour is unchanged at the
   `.xlsx` default).

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -423,12 +423,13 @@ export function App() {
     const env = (import.meta as { env?: Record<string, string> }).env?.VITE_COLLAB_BACKEND;
     let backend = params.get('collab') || env || params.get('backend');
     if (!backend) {
-      // Same-origin default — production: the Docker image
-      // bundles the gateway and the static editor under one host,
-      // so the share URL doesn't need to carry the WS URL
-      // explicitly.
+      // Same-origin default — production: a reverse proxy routes
+      // `/yjs` to the collab server (Hocuspocus) and everything else
+      // to the gateway, so the share URL doesn't need to carry the WS
+      // URL explicitly. The `/yjs` path is required — that's the
+      // Hocuspocus upgrade route on the collab server.
       const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      backend = `${proto}//${window.location.host}`;
+      backend = `${proto}//${window.location.host}/yjs`;
     }
     return { room, backend };
   }, []);


### PR DESCRIPTION
Re-raises the production deploy work that didn't make the #45 squash (timing). Builds on the merged collab migration (#44, #45).

**`deploy/`**
- Caddy reverse proxy unifying both services behind one origin: `/yjs` → collab (Hocuspocus, `:1234`), everything else → gateway (`:8080` REST/seed/share-link + bundled SPA). The SPA reaches collab **same-origin** — nothing host-specific baked into the build.
- `docker-compose.prod.yml` (gateway + collab + Caddy, persistence + per-product format wired; `COLLAB_SITE_ADDRESS` → automatic HTTPS) + `README.md` (topology, `/yjs` routing requirement, persistence, shared-Redis prefixing, cutover steps).

**SPA fix**: the same-origin collab default now includes the required `/yjs` path (was bare host — would miss the Hocuspocus upgrade route on a proxied deploy).

**Validated**: ran collab + gateway + Caddy and confirmed routing through the proxy — `/health`/`/api/docs` → gateway, and a real **WS upgrade + two-peer Yjs sync through `/yjs`** → collab. Gate: example typecheck ✓ · smoke ✓ · `compose config` valid.