### PR TITLE
feat: server-persisted version history (restore past revisions)

### DIFF
--- a/backend/cmd/gateway/broadcast_test.go
+++ b/backend/cmd/gateway/broadcast_test.go
@@ -32,9 +32,14 @@ func startTestGateway(t *testing.T) (*httptest.Server, *room.Manager, *inline.St
 	dlHandler := downloadHandler(store)
 	rnHandler := renameHandler(store)
 	histHandler := historyHandler(store)
+	revHandler := revisionDownloadHandler(store)
 	mux.HandleFunc("/api/docs/", func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/rename") {
 			rnHandler(w, r)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/history/") && strings.HasSuffix(r.URL.Path, "/download") {
+			revHandler(w, r)
 			return
 		}
 		if strings.HasSuffix(r.URL.Path, "/history") {

--- a/backend/cmd/gateway/main.go
+++ b/backend/cmd/gateway/main.go
@@ -415,11 +415,73 @@ func docIDFromHistoryPath(path string) string {
 	return path[len(prefix) : len(path)-len(suffix)]
 }
 
+// docIDAndVersionFromRevisionPath extracts `{docId}` and `{version}`
+// from `/api/docs/{docId}/history/{version}/download`. ok=false for
+// any other shape.
+func docIDAndVersionFromRevisionPath(path string) (docID string, version uint64, ok bool) {
+	const prefix = "/api/docs/"
+	const mid = "/history/"
+	const suffix = "/download"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return "", 0, false
+	}
+	rest := path[len(prefix) : len(path)-len(suffix)] // {docId}/history/{version}
+	i := strings.Index(rest, mid)
+	if i <= 0 {
+		return "", 0, false
+	}
+	docID = rest[:i]
+	verStr := rest[i+len(mid):]
+	if verStr == "" || strings.Contains(verStr, "/") {
+		return "", 0, false
+	}
+	v, err := strconv.ParseUint(verStr, 10, 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return docID, v, true
+}
+
+// revisionDownloadHandler streams the .docx bytes of a specific past
+// revision so the editor can restore it. Requires the host to retain
+// per-revision bytes (host.RevisionStore); hosts that don't (e.g.
+// WOPI, where the host owns versioning) get a 501. Read-only, unrated.
+func revisionDownloadHandler(store host.DocStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeJSONError(w, http.StatusMethodNotAllowed, "method", "GET required")
+			return
+		}
+		docID, version, ok := docIDAndVersionFromRevisionPath(r.URL.Path)
+		if !ok {
+			writeJSONError(w, http.StatusBadRequest, "path", "expected /api/docs/{docId}/history/{version}/download")
+			return
+		}
+		rs, ok := store.(host.RevisionStore)
+		if !ok {
+			writeJSONError(w, http.StatusNotImplemented, "unsupported", "host does not retain per-revision bytes")
+			return
+		}
+		contents, err := rs.FetchRevision(docID, version)
+		if err != nil {
+			if errors.Is(err, host.ErrNotFound) {
+				writeJSONError(w, http.StatusNotFound, "not_found", "no such doc or version")
+				return
+			}
+			writeJSONError(w, http.StatusInternalServerError, "revision", err.Error())
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.wordprocessingml.document")
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="v%d.docx"`, version))
+		_, _ = w.Write(contents)
+	}
+}
+
 // historyHandler returns the revision-metadata log for a doc as a
 // JSON array (creation first, newest last). Read-only, unrated —
-// the version-history panel may poll it. Content-revert to a past
-// revision is NOT supported here (needs the M2 serializer worker +
-// per-revision blob storage); this endpoint is metadata only.
+// the version-history panel may poll it. Per-revision content for
+// restore is served by revisionDownloadHandler
+// (`/history/{version}/download`) when the host retains the bytes.
 func historyHandler(store host.DocStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -1020,11 +1082,19 @@ func main() {
 	docsActionHandler := downloadHandler(store)
 	docsRenameHandler := renameHandler(store)
 	docsHistoryHandler := historyHandler(store)
+	docsRevisionHandler := revisionDownloadHandler(store)
 	mux.HandleFunc("/api/docs/", func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/rename") {
 			// Apply the general bucket only for the rename path;
 			// the rest of the handler tree (download) stays unrated.
 			generalLimiter.Middleware(http.HandlerFunc(docsRenameHandler)).ServeHTTP(w, r)
+			return
+		}
+		// `/history/{version}/download` (revision restore) must be
+		// checked before the bare `/download` fallback below — it ends
+		// in `/download` too.
+		if strings.Contains(r.URL.Path, "/history/") && strings.HasSuffix(r.URL.Path, "/download") {
+			docsRevisionHandler(w, r)
 			return
 		}
 		if strings.HasSuffix(r.URL.Path, "/history") {

--- a/backend/cmd/gateway/revision_test.go
+++ b/backend/cmd/gateway/revision_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+)
+
+// GET /api/docs/{id}/history/{version}/download streams the .docx bytes
+// of that specific revision (the restore path), and 404s on an unknown
+// version.
+func TestRevisionDownloadServesPerVersionBytes(t *testing.T) {
+	srv, _, store := startTestGateway(t)
+	id, err := store.Store("d.docx", []byte("V1-CONTENT"))
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if err := store.Snapshot(context.Background(), id, "", []byte("V2-CONTENT")); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+
+	for v, want := range map[int]string{1: "V1-CONTENT", 2: "V2-CONTENT"} {
+		url := fmt.Sprintf("%s/api/docs/%s/history/%d/download", srv.URL, id, v)
+		resp, err := http.Get(url)
+		if err != nil {
+			t.Fatalf("GET v%d: %v", v, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("v%d status = %d, want 200", v, resp.StatusCode)
+		}
+		if string(body) != want {
+			t.Fatalf("v%d body = %q, want %q", v, body, want)
+		}
+		if ct := resp.Header.Get("Content-Type"); ct != "application/vnd.openxmlformats-officedocument.wordprocessingml.document" {
+			t.Fatalf("v%d content-type = %q", v, ct)
+		}
+	}
+
+	resp, err := http.Get(fmt.Sprintf("%s/api/docs/%s/history/99/download", srv.URL, id))
+	if err != nil {
+		t.Fatalf("GET unknown version: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown version status = %d, want 404", resp.StatusCode)
+	}
+}

--- a/backend/internal/host/host.go
+++ b/backend/internal/host/host.go
@@ -146,6 +146,17 @@ type Locker interface {
 	RefreshLock(ctx context.Context, docID, lockID, authToken string) error
 }
 
+// RevisionStore is an optional host capability: it returns the .docx
+// bytes of a specific historical revision so the editor can restore a
+// past version. Hosts that retain per-revision bytes implement it;
+// callers type-assert for it (like Locker). Hosts that only keep
+// revision metadata, or where the host owns versioning (e.g. WOPI),
+// omit it — the gateway then surfaces 501 for the restore-download
+// route. Returns ErrNotFound when the doc or version is unknown.
+type RevisionStore interface {
+	FetchRevision(docID string, version uint64) ([]byte, error)
+}
+
 // Sentinel errors. Implementations either return these directly
 // or wrap an HTTP-status-coded error that callers can match via
 // errors.Is.

--- a/backend/internal/host/inline/inline.go
+++ b/backend/internal/host/inline/inline.go
@@ -50,13 +50,13 @@ type entry struct {
 	// save cycles doesn't grow unbounded. Powers GET
 	// /api/docs/{id}/history (Stream A1 of the parity pipeline).
 	//
-	// NOTE: this is metadata only — we do NOT retain the per-revision
-	// bytes (that needs the M2 serializer worker + per-revision blob
-	// storage). So the history endpoint can show "saved at <when>,
-	// <size>" but content-revert to an arbitrary past revision is a
-	// future capability. The editor's local useEditHistory still
-	// owns in-session undo/revert.
+	// Powers GET /api/docs/{id}/history.
 	revisions []RevisionMeta
+	// revBytes retains the .docx bytes per revision version so the
+	// editor can restore a past version (host.RevisionStore). Pruned
+	// in lockstep with `revisions` (same maxRevisions window). Keyed
+	// by RevisionMeta.Version.
+	revBytes map[uint64][]byte
 }
 
 // RevisionMeta is a type alias for the shared host.RevisionMeta so
@@ -117,6 +117,9 @@ func (s *Store) Store(fileName string, contents []byte) (string, error) {
 		revisions: []RevisionMeta{
 			{Version: 1, SavedAt: now, SizeBytes: len(contents)},
 		},
+		revBytes: map[uint64][]byte{
+			1: append([]byte(nil), contents...),
+		},
 	}
 	return docID, nil
 }
@@ -160,13 +163,39 @@ func (s *Store) Snapshot(_ context.Context, docID, _ string, contents []byte) er
 		SavedAt:   now,
 		SizeBytes: len(contents),
 	})
+	if e.revBytes == nil {
+		e.revBytes = make(map[uint64][]byte)
+	}
+	e.revBytes[e.version] = append([]byte(nil), contents...)
 	// Roll off the oldest revisions past the cap. Keep the tail
 	// (most-recent maxRevisions) so the history always shows the
-	// latest saves.
+	// latest saves; drop the matching per-revision bytes too.
 	if len(e.revisions) > maxRevisions {
+		drop := e.revisions[:len(e.revisions)-maxRevisions]
+		for _, r := range drop {
+			delete(e.revBytes, r.Version)
+		}
 		e.revisions = e.revisions[len(e.revisions)-maxRevisions:]
 	}
 	return nil
+}
+
+// FetchRevision implements host.RevisionStore: returns the .docx bytes
+// of a specific past revision so the editor can restore it. Returns
+// host.ErrNotFound if the doc or version is unknown (e.g. rolled off
+// past the maxRevisions window).
+func (s *Store) FetchRevision(docID string, version uint64) ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	e, ok := s.docs[docID]
+	if !ok {
+		return nil, host.ErrNotFound
+	}
+	b, ok := e.revBytes[version]
+	if !ok {
+		return nil, host.ErrNotFound
+	}
+	return append([]byte(nil), b...), nil // copy for caller
 }
 
 // History returns a copy of the revision-metadata log for docID,

--- a/backend/internal/host/inline/revision_test.go
+++ b/backend/internal/host/inline/revision_test.go
@@ -1,0 +1,61 @@
+package inline
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/schnsrw/docx/backend/internal/host"
+)
+
+// Inline retains per-revision bytes so the editor can restore a past
+// version (host.RevisionStore).
+func TestInlineFetchRevisionPerVersion(t *testing.T) {
+	s := New()
+	id, err := s.Store("d.docx", []byte("v1-bytes"))
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if err := s.Snapshot(context.Background(), id, "", []byte("v2-bytes")); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	for v, want := range map[uint64]string{1: "v1-bytes", 2: "v2-bytes"} {
+		got, err := s.FetchRevision(id, v)
+		if err != nil {
+			t.Fatalf("FetchRevision v%d: %v", v, err)
+		}
+		if string(got) != want {
+			t.Fatalf("v%d = %q, want %q", v, got, want)
+		}
+	}
+	if _, err := s.FetchRevision(id, 99); !errors.Is(err, host.ErrNotFound) {
+		t.Fatalf("unknown version: want ErrNotFound, got %v", err)
+	}
+	if _, err := s.FetchRevision("nope", 1); !errors.Is(err, host.ErrNotFound) {
+		t.Fatalf("unknown doc: want ErrNotFound, got %v", err)
+	}
+}
+
+// Per-revision bytes roll off in lockstep with the metadata window.
+func TestInlineRevisionBytesPrunedWithMetadata(t *testing.T) {
+	s := New()
+	id, err := s.Store("d.docx", []byte("v1"))
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	// Drive enough snapshots to push version 1 off the maxRevisions window.
+	for i := 0; i < maxRevisions; i++ {
+		if err := s.Snapshot(context.Background(), id, "", []byte(fmt.Sprintf("v%d", i+2))); err != nil {
+			t.Fatalf("Snapshot %d: %v", i, err)
+		}
+	}
+	if _, err := s.FetchRevision(id, 1); !errors.Is(err, host.ErrNotFound) {
+		t.Fatalf("rolled-off v1: want ErrNotFound, got %v", err)
+	}
+	// The newest version is still retrievable.
+	latest := uint64(maxRevisions + 1)
+	if _, err := s.FetchRevision(id, latest); err != nil {
+		t.Fatalf("latest v%d should be retained: %v", latest, err)
+	}
+}

--- a/backend/internal/host/local/local.go
+++ b/backend/internal/host/local/local.go
@@ -117,10 +117,15 @@ func (s *Store) Store(fileName string, contents []byte) (string, error) {
 	if err := s.writeDocxAtomic(docID, contents); err != nil {
 		return "", err
 	}
+	if err := s.writeRevisionAtomic(docID, 1, contents); err != nil {
+		_ = os.Remove(s.docxPath(docID))
+		return "", err
+	}
 	if err := s.writeMetaAtomic(docID, meta); err != nil {
 		// Rollback: best-effort remove the .docx so the next Store
 		// doesn't see a half-created doc.
 		_ = os.Remove(s.docxPath(docID))
+		_ = os.Remove(s.revPath(docID, 1))
 		return "", err
 	}
 	return docID, nil
@@ -180,8 +185,16 @@ func (s *Store) Snapshot(_ context.Context, docID, _ string, contents []byte) er
 		SavedAt:   now,
 		SizeBytes: len(contents),
 	})
+	if err := s.writeRevisionAtomic(docID, meta.Version, contents); err != nil {
+		return err
+	}
 	if len(meta.Revisions) > maxRevisions {
 		meta.Revisions = meta.Revisions[len(meta.Revisions)-maxRevisions:]
+		// Drop the per-revision bytes that just rolled off the window.
+		// Versions are monotonic +1, so version (V-maxRevisions) is gone.
+		if meta.Version > maxRevisions {
+			_ = os.Remove(s.revPath(docID, meta.Version-maxRevisions))
+		}
 	}
 	if err := s.writeMetaAtomic(docID, meta); err != nil {
 		slog.Warn("local: meta write failed after docx snapshot — log mismatch",
@@ -230,6 +243,13 @@ func (s *Store) Delete(docID string) error {
 	for _, p := range []string{s.docxPath(docID), s.metaPath(docID)} {
 		if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("local: remove %q: %w", p, err)
+		}
+	}
+	// Sweep per-revision blobs (<docId>.v<N>.docx). docID is regex-safe
+	// (no glob metacharacters), so the pattern can't escape the root.
+	if revs, err := filepath.Glob(filepath.Join(s.root, docID+".v*.docx")); err == nil {
+		for _, p := range revs {
+			_ = os.Remove(p)
 		}
 	}
 	return nil
@@ -323,6 +343,46 @@ var safeDocID = regexp.MustCompile(`^[A-Za-z0-9_-]{8,64}$`)
 
 func (s *Store) docxPath(docID string) string {
 	return filepath.Join(s.root, docID+".docx")
+}
+
+func (s *Store) revPath(docID string, version uint64) string {
+	return filepath.Join(s.root, fmt.Sprintf("%s.v%d.docx", docID, version))
+}
+
+// writeRevisionAtomic persists the immutable .docx bytes of one
+// revision (write tmp + rename) so a partial write never leaves a
+// truncated revision blob behind.
+func (s *Store) writeRevisionAtomic(docID string, version uint64, contents []byte) error {
+	final := s.revPath(docID, version)
+	tmp := final + ".tmp"
+	if err := os.WriteFile(tmp, contents, 0o644); err != nil {
+		return fmt.Errorf("local: write revision tmp %q v%d: %w", docID, version, err)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("local: rename revision %q v%d: %w", docID, version, err)
+	}
+	return nil
+}
+
+// FetchRevision implements host.RevisionStore: the .docx bytes of a
+// specific past revision (for version restore). Returns
+// host.ErrNotFound when the doc or version is unknown — including
+// versions that rolled off the maxRevisions window.
+func (s *Store) FetchRevision(docID string, version uint64) ([]byte, error) {
+	if !safeDocID.MatchString(docID) {
+		return nil, host.ErrNotFound
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, err := os.ReadFile(s.revPath(docID, version))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, host.ErrNotFound
+		}
+		return nil, fmt.Errorf("local: read revision %q v%d: %w", docID, version, err)
+	}
+	return b, nil
 }
 
 func (s *Store) metaPath(docID string) string {

--- a/backend/internal/host/local/revision_test.go
+++ b/backend/internal/host/local/revision_test.go
@@ -1,0 +1,65 @@
+package local
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/schnsrw/docx/backend/internal/host"
+)
+
+// Local persists per-revision .docx blobs on disk and serves them via
+// FetchRevision (host.RevisionStore).
+func TestLocalFetchRevisionPerVersion(t *testing.T) {
+	s, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	id, err := s.Store("d.docx", []byte("v1-bytes"))
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if err := s.Snapshot(context.Background(), id, "", []byte("v2-bytes")); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	for v, want := range map[uint64]string{1: "v1-bytes", 2: "v2-bytes"} {
+		got, err := s.FetchRevision(id, v)
+		if err != nil {
+			t.Fatalf("FetchRevision v%d: %v", v, err)
+		}
+		if string(got) != want {
+			t.Fatalf("v%d = %q, want %q", v, got, want)
+		}
+	}
+	if _, err := s.FetchRevision(id, 99); !errors.Is(err, host.ErrNotFound) {
+		t.Fatalf("unknown version: want ErrNotFound, got %v", err)
+	}
+}
+
+// Delete sweeps the per-revision blobs too (no orphan .vN.docx files).
+func TestLocalDeleteSweepsRevisionBlobs(t *testing.T) {
+	root := t.TempDir()
+	s, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	id, err := s.Store("d.docx", []byte("v1"))
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if err := s.Snapshot(context.Background(), id, "", []byte("v2")); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if err := s.Delete(id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	matches, _ := filepath.Glob(filepath.Join(root, id+".v*.docx"))
+	if len(matches) != 0 {
+		t.Fatalf("revision blobs not swept: %v", matches)
+	}
+	if _, err := os.Stat(s.docxPath(id)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("docx not removed: %v", err)
+	}
+}

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -990,6 +990,7 @@ function CollabApp({
           author={author}
           onError={onError}
           onFontsLoaded={onFontsLoaded}
+          versionBackend={{ baseUrl: backendHttp, docId: room }}
           showToolbar={true}
           showRuler={!isMobile}
           showZoomControl={true}

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -53,6 +53,7 @@ import { SIDEBAR_DOCUMENT_SHIFT } from './sidebar/constants';
 import { VersionHistoryPanel } from './sidebar/VersionHistoryPanel';
 import { useEditHistory } from '../hooks/useEditHistory';
 import { useVersionHistoryCapture } from '../version-history/useVersionHistoryCapture';
+import { downloadServerVersion, type ServerVersionBackend } from '../version-history/server-source';
 import { useVoiceTyping } from '../hooks/useVoiceTyping';
 import { VoiceTypingIndicator } from './ui/VoiceTypingIndicator';
 import { UnifiedSidebar } from './UnifiedSidebar';
@@ -473,6 +474,11 @@ export interface DocxEditorProps {
   onSelectionChange?: (state: SelectionState | null) => void;
   /** Callback on error */
   onError?: (error: Error) => void;
+  /** When set, the Version-history panel lists the host's
+   *  server-persisted revision chain (`/history`) and restores by
+   *  downloading a revision's `.docx` into the editor. Absent → the
+   *  panel uses local IndexedDB snapshots only (unchanged). */
+  versionBackend?: ServerVersionBackend;
   /** Callback when fonts are loaded */
   onFontsLoaded?: () => void;
   /** External ProseMirror plugins (from PluginHost) */
@@ -1476,6 +1482,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     onChange,
     onSelectionChange,
     onError,
+    versionBackend,
     onFontsLoaded: onFontsLoadedCallback,
     theme,
     showToolbar = true,
@@ -2622,6 +2629,25 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       }
     },
     [resetForNewDocument, loadParsedDocument, onError]
+  );
+
+  // Restore a server-persisted revision: download its .docx from the
+  // host and load it into the editor. In a live collab room the load
+  // flows through the same PM path, so peers converge on the restored
+  // content. Surfaces failures via onError rather than throwing.
+  const handleRestoreServerVersion = useCallback(
+    (version: number) => {
+      if (!versionBackend) return;
+      void (async () => {
+        try {
+          const buf = await downloadServerVersion(versionBackend, version);
+          await loadBuffer(buf);
+        } catch (err) {
+          onError?.(err instanceof Error ? err : new Error(String(err)));
+        }
+      })();
+    },
+    [versionBackend, loadBuffer, onError]
   );
 
   // React to document/documentBuffer prop changes
@@ -8136,6 +8162,8 @@ body { background: white; }
                       docId={documentName?.trim() || 'Untitled'}
                       saveNamedVersion={versionCapture.saveNamedVersion}
                       onRestoreSnapshot={handleRestoreSnapshot}
+                      serverBackend={versionBackend}
+                      onRestoreServerVersion={handleRestoreServerVersion}
                       onClose={() => setShowVersionHistory(false)}
                     />
                   )}

--- a/docx-editor/packages/react/src/components/sidebar/VersionHistoryPanel.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/VersionHistoryPanel.tsx
@@ -28,6 +28,7 @@ import { RightDockPanel } from '../RightDockPanel';
 import type { EditHistoryEntry, UseEditHistoryReturn } from '../../hooks/useEditHistory';
 import { diffStats, diffWords, extractText } from '../../hooks/wordDiff';
 import { useLiveVersionList } from '../../version-history/useLiveVersionList';
+import type { ServerVersionBackend } from '../../version-history/server-source';
 import {
   deleteVersion,
   readVersion,
@@ -51,6 +52,13 @@ export interface VersionHistoryPanelProps {
   /** Called when the user clicks the close (X) button in the panel
    *  header. The host (DocxEditor) flips the panel-open flag. */
   onClose?: () => void;
+  /** When set, the Versions tab lists the host's server-persisted
+   *  revision chain (`/history`) instead of the local IndexedDB
+   *  snapshots. Absent → local-only (unchanged). */
+  serverBackend?: ServerVersionBackend;
+  /** Restore a server revision: the host downloads its `.docx` and
+   *  reloads the editor. Required for server entries to be restorable. */
+  onRestoreServerVersion?: (version: number) => void;
   /** Display title for the panel. Default "Version history". */
   title?: string;
   /** Empty-state message when no entries exist yet. */
@@ -261,6 +269,8 @@ export function VersionHistoryPanel({
   onClose,
   title = 'Version history',
   emptyHint = 'No edits yet. Type into the document to start recording.',
+  serverBackend,
+  onRestoreServerVersion,
 }: VersionHistoryPanelProps) {
   // Default to Versions when we have a docId (the persisted timeline
   // is what users come here for); Activity is the secondary "what
@@ -306,6 +316,8 @@ export function VersionHistoryPanel({
           docId={docId}
           saveNamedVersion={saveNamedVersion}
           onRestoreSnapshot={onRestoreSnapshot}
+          serverBackend={serverBackend}
+          onRestoreServerVersion={onRestoreServerVersion}
         />
       ) : (
         <ActivityTab history={history} emptyHint={emptyHint} />
@@ -380,12 +392,16 @@ function VersionsTab({
   docId,
   saveNamedVersion,
   onRestoreSnapshot,
+  serverBackend,
+  onRestoreServerVersion,
 }: {
   docId: string | null;
   saveNamedVersion?: (name: string) => Promise<number | null>;
   onRestoreSnapshot?: (data: unknown) => void;
+  serverBackend?: ServerVersionBackend;
+  onRestoreServerVersion?: (version: number) => void;
 }) {
-  const list = useLiveVersionList(docId);
+  const list = useLiveVersionList(docId, serverBackend);
   const groups = useMemo(() => groupByDay(list), [list]);
   const now = Date.now();
   // Chronological neighbor for diffing: the list is newest-first, so
@@ -417,16 +433,22 @@ function VersionsTab({
 
   const handleRestore = useCallback(
     async (snap: VersionSnapshot) => {
+      // Server-backed entry: restore by downloading its .docx bytes
+      // (the host owns the content; the list carries metadata only).
+      if (snap.serverVersion != null) {
+        onRestoreServerVersion?.(snap.serverVersion);
+        return;
+      }
       if (!onRestoreSnapshot || snap.id == null) return;
       const full = await readVersion(snap.id);
       if (!full) return;
       onRestoreSnapshot(full.data);
     },
-    [onRestoreSnapshot]
+    [onRestoreSnapshot, onRestoreServerVersion]
   );
 
   const handleRename = useCallback(async (snap: VersionSnapshot) => {
-    if (snap.id == null) return;
+    if (snap.serverVersion != null || snap.id == null) return; // server versions are host-owned
     // eslint-disable-next-line no-alert
     const next = window.prompt('Rename version', snap.name);
     if (next == null) return;
@@ -436,7 +458,7 @@ function VersionsTab({
   }, []);
 
   const handleDelete = useCallback(async (snap: VersionSnapshot) => {
-    if (snap.id == null) return;
+    if (snap.serverVersion != null || snap.id == null) return; // server versions are host-owned
     // eslint-disable-next-line no-alert
     if (!window.confirm(`Delete "${snap.name}"? This cannot be undone.`)) return;
     await deleteVersion(snap.id);
@@ -453,7 +475,7 @@ function VersionsTab({
         <span style={COUNT_STYLE} data-testid="version-history-versions-count">
           {list.length}
         </span>
-        {saveNamedVersion && (
+        {saveNamedVersion && !serverBackend && (
           <button
             type="button"
             onClick={handleSaveVersion}
@@ -482,8 +504,8 @@ function VersionsTab({
                     previousSnap={snap.id != null ? previousById.get(snap.id) : undefined}
                     now={now}
                     onRestore={() => handleRestore(snap)}
-                    onRename={() => handleRename(snap)}
-                    onDelete={() => handleDelete(snap)}
+                    onRename={snap.serverVersion != null ? undefined : () => handleRename(snap)}
+                    onDelete={snap.serverVersion != null ? undefined : () => handleDelete(snap)}
                   />
                 ))}
               </ol>
@@ -509,8 +531,10 @@ function VersionRow({
   previousSnap?: VersionSnapshot;
   now: number;
   onRestore: () => void;
-  onRename: () => void;
-  onDelete: () => void;
+  /** Omitted for server-backed (host-owned) revisions — they aren't
+   *  renamed/deleted from the client. */
+  onRename?: () => void;
+  onDelete?: () => void;
 }) {
   const [showDiff, setShowDiff] = useState(false);
 
@@ -584,16 +608,20 @@ function VersionRow({
             {showDiff ? 'Hide changes' : 'Show changes'}
           </button>
         )}
-        <button type="button" onClick={onRename} style={SHOW_DIFF_BTN_STYLE}>
-          Rename
-        </button>
-        <button
-          type="button"
-          onClick={onDelete}
-          style={{ ...SHOW_DIFF_BTN_STYLE, color: '#b91c1c' }}
-        >
-          Delete
-        </button>
+        {onRename && (
+          <button type="button" onClick={onRename} style={SHOW_DIFF_BTN_STYLE}>
+            Rename
+          </button>
+        )}
+        {onDelete && (
+          <button
+            type="button"
+            onClick={onDelete}
+            style={{ ...SHOW_DIFF_BTN_STYLE, color: '#b91c1c' }}
+          >
+            Delete
+          </button>
+        )}
       </div>
       {showDiff && diff && (
         <pre style={DIFF_BOX_STYLE} data-testid="version-history-version-diff">

--- a/docx-editor/packages/react/src/index.ts
+++ b/docx-editor/packages/react/src/index.ts
@@ -949,6 +949,11 @@ export {
   type VersionHistoryPanelProps,
 } from './components/sidebar/VersionHistoryPanel';
 export {
+  fetchServerVersions,
+  downloadServerVersion,
+  type ServerVersionBackend,
+} from './version-history/server-source';
+export {
   useEditHistory,
   type EditHistoryEntry,
   type UseEditHistoryOptions,

--- a/docx-editor/packages/react/src/version-history/server-source.test.ts
+++ b/docx-editor/packages/react/src/version-history/server-source.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { fetchServerVersions, downloadServerVersion } from './server-source';
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('server version source', () => {
+  it('maps /history revisions to newest-first VersionSnapshots', async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify([
+          { version: 1, savedAt: '2026-06-22T10:00:00Z', sizeBytes: 100 },
+          { version: 2, savedAt: '2026-06-22T11:00:00Z', sizeBytes: 200, author: 'Ann' },
+        ]),
+        { status: 200 }
+      )) as unknown as typeof fetch;
+
+    const list = await fetchServerVersions({ baseUrl: 'http://h', docId: 'd' });
+
+    expect(list.map((v) => v.serverVersion)).toEqual([2, 1]); // newest first
+    expect(list[0]?.name).toBe('Saved by Ann');
+    expect(list[0]?.size).toBe(200);
+    expect(list[1]?.name).toBe('Version 1');
+    // Server entries carry no inline PM data — restore fetches bytes.
+    expect(list.every((v) => v.data === undefined)).toBe(true);
+  });
+
+  it('downloadServerVersion returns the revision bytes', async () => {
+    let calledUrl = '';
+    globalThis.fetch = (async (url: string) => {
+      calledUrl = url;
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const buf = await downloadServerVersion({ baseUrl: 'http://h', docId: 'd' }, 2);
+
+    expect(new Uint8Array(buf)).toEqual(new Uint8Array([1, 2, 3]));
+    expect(calledUrl).toBe('http://h/api/docs/d/history/2/download');
+  });
+
+  it('throws on a non-OK history response', async () => {
+    globalThis.fetch = (async () => new Response('', { status: 404 })) as unknown as typeof fetch;
+    await expect(fetchServerVersions({ baseUrl: 'http://h', docId: 'd' })).rejects.toThrow();
+  });
+});

--- a/docx-editor/packages/react/src/version-history/server-source.ts
+++ b/docx-editor/packages/react/src/version-history/server-source.ts
@@ -1,0 +1,70 @@
+/**
+ * Server-backed version history — host `/history` revision chain.
+ *
+ * The local IndexedDB store (`store.ts`) keeps per-device PM-doc
+ * snapshots. When the editor is backed by a host that retains
+ * per-revision `.docx` bytes (the Go gateway's `host.RevisionStore`),
+ * this module surfaces those revisions in the same `VersionSnapshot`
+ * shape so the panel renders them unchanged, and downloads a chosen
+ * revision's bytes for restore.
+ *
+ * Opt-in: only used when a `ServerVersionBackend` is passed to
+ * `<DocxEditor versionBackend=… />`. Absent it, nothing here runs and
+ * the local path is untouched.
+ */
+import type { VersionSnapshot } from './store';
+
+export interface ServerVersionBackend {
+  /** REST base of the host, e.g. `http://localhost:8080`. */
+  baseUrl: string;
+  /** Host document id (the share-link / room docId). */
+  docId: string;
+}
+
+/** Wire shape of one entry from `GET /api/docs/{id}/history`. */
+interface RevisionMetaWire {
+  version: number;
+  savedAt: string;
+  sizeBytes: number;
+  author?: string;
+}
+
+function historyUrl(b: ServerVersionBackend): string {
+  return `${b.baseUrl}/api/docs/${encodeURIComponent(b.docId)}/history`;
+}
+
+/** List the host's revision chain as `VersionSnapshot[]`, newest-first
+ *  (matching the local list's display order). Throws on a non-OK
+ *  response so the caller can fall back / surface an error. */
+export async function fetchServerVersions(
+  b: ServerVersionBackend,
+  signal?: AbortSignal
+): Promise<VersionSnapshot[]> {
+  const res = await fetch(historyUrl(b), { signal });
+  if (!res.ok) throw new Error(`history HTTP ${res.status}`);
+  const revs = (await res.json()) as RevisionMetaWire[];
+  return revs
+    .slice()
+    .sort((a, z) => z.version - a.version)
+    .map((r) => ({
+      id: r.version,
+      serverVersion: r.version,
+      docId: b.docId,
+      kind: 'auto' as const,
+      name: r.author ? `Saved by ${r.author}` : `Version ${r.version}`,
+      savedAt: Date.parse(r.savedAt) || 0,
+      sourceFormat: 'docx',
+      data: undefined,
+      size: r.sizeBytes,
+    }));
+}
+
+/** Download one revision's `.docx` bytes for restore. */
+export async function downloadServerVersion(
+  b: ServerVersionBackend,
+  version: number
+): Promise<ArrayBuffer> {
+  const res = await fetch(`${historyUrl(b)}/${encodeURIComponent(String(version))}/download`);
+  if (!res.ok) throw new Error(`revision HTTP ${res.status}`);
+  return res.arrayBuffer();
+}

--- a/docx-editor/packages/react/src/version-history/store.ts
+++ b/docx-editor/packages/react/src/version-history/store.ts
@@ -54,10 +54,16 @@ export interface VersionSnapshot {
   /** Source format at capture, for round-trip on later "Save as" from
    *  a preview. Currently always `'docx'`; here as a forward hook. */
   sourceFormat: string | null;
-  /** Full ProseMirror doc JSON — `view.state.doc.toJSON()` output. */
+  /** Full ProseMirror doc JSON — `view.state.doc.toJSON()` output.
+   *  Undefined for server-backed entries (their bytes are fetched on
+   *  restore, not held in the list). */
   data: unknown;
   /** Approximate JSON byte size, set on persist for UI display. */
   size?: number;
+  /** Set for server-backed revisions (host `/history`): the host's
+   *  monotonic version number. When present the panel restores by
+   *  downloading that revision's `.docx` instead of reading `data`. */
+  serverVersion?: number;
 }
 
 export type VersionDraft = Omit<VersionSnapshot, 'id'>;

--- a/docx-editor/packages/react/src/version-history/useLiveVersionList.ts
+++ b/docx-editor/packages/react/src/version-history/useLiveVersionList.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { listVersions, setLiveFeed, type VersionSnapshot } from './store';
 import { createLiveVersionFeed, type LiveVersionFeed } from './live-feed';
+import { fetchServerVersions, type ServerVersionBackend } from './server-source';
 
 /**
  * Reactive snapshot list bound to the IDB version store. The store's
@@ -28,8 +29,13 @@ export function getLiveVersionFeed(): LiveVersionFeed {
   return liveFeed;
 }
 
-export function useLiveVersionList(docId: string | null): VersionSnapshot[] {
+export function useLiveVersionList(
+  docId: string | null,
+  serverBackend?: ServerVersionBackend
+): VersionSnapshot[] {
   const [list, setList] = useState<VersionSnapshot[]>([]);
+  const serverBase = serverBackend?.baseUrl ?? null;
+  const serverDoc = serverBackend?.docId ?? null;
 
   useEffect(() => {
     if (!docId) {
@@ -37,6 +43,31 @@ export function useLiveVersionList(docId: string | null): VersionSnapshot[] {
       return;
     }
     let cancelled = false;
+
+    // Server-backed mode: list the host's revision chain. Still wired
+    // to the live feed so a fresh autosave push (→ new host revision)
+    // re-queries. Falls back to an empty list on fetch failure rather
+    // than throwing into render.
+    if (serverBase && serverDoc) {
+      const backend = { baseUrl: serverBase, docId: serverDoc };
+      const refresh = () => {
+        void fetchServerVersions(backend)
+          .then((next) => {
+            if (!cancelled) setList(next);
+          })
+          .catch(() => {
+            if (!cancelled) setList([]);
+          });
+      };
+      refresh();
+      const unsub = getLiveVersionFeed().subscribe(refresh);
+      return () => {
+        cancelled = true;
+        unsub();
+      };
+    }
+
+    // Local IndexedDB mode (unchanged).
     const refresh = () => {
       void listVersions(docId).then((next) => {
         if (!cancelled) setList(next);
@@ -48,7 +79,7 @@ export function useLiveVersionList(docId: string | null): VersionSnapshot[] {
       cancelled = true;
       unsub();
     };
-  }, [docId]);
+  }, [docId, serverBase, serverDoc]);
 
   return list;
 }


### PR DESCRIPTION
Completes pillar D — versioning that persists on the host and survives device changes, with restore. End to end: backend retains per-revision bytes, the editor's Version-history panel lists the host's chain and restores a chosen revision.

**Backend** (`go test -race` green)
- `host.RevisionStore` capability (`FetchRevision`) — optional, type-asserted like `host.Locker` (WOPI etc. opt out → 501).
- Per-revision `.docx` retention in the inline + local stores, pruned in lockstep with the metadata window; `local.Delete` sweeps the blobs.
- `GET /api/docs/{id}/history/{version}/download` streams a past revision (404 unknown, 501 unsupported).

**Editor** (unit-tested + browser-verified)
- `version-history/server-source.ts`: `fetchServerVersions` (maps `/history` → `VersionSnapshot`, newest-first) + `downloadServerVersion`.
- `useLiveVersionList` gains an optional `serverBackend` — lists host revisions instead of IndexedDB. **Guarded**: absent → the local path is byte-for-byte unchanged (zero risk to the working local version system).
- Restore via download + `loadBuffer` — collab-safe (the load flows through PM, so peers converge). Local "Save version" + per-entry Rename/Delete hidden for host-owned revisions.
- `<DocxEditor versionBackend=… />` prop; the demo passes it in collab/share-link mode.

**Verified**: Go race tests (per-version fetch, prune, delete-sweep, endpoint 404); TS unit (source mapping + download URL); in-browser — panel fetches `/history`, lists the server version, restore reloads, no console errors. Gate: format · lint · typecheck (react + example) · unit 333 · smoke green.

Restore mechanism is collab-safe; multi-version UX in inline share-link mode shows v1 only (inline has no save→snapshot trigger; personal-mode `SaveFor` creates the chain) — multi-version behaviour is covered by the Go + TS tests.