### PR TITLE
feat(editability): fix table delete + insert text box/callout + tracker

### DIFF
--- a/docs/internal/24-editability-tracker.md
+++ b/docs/internal/24-editability-tracker.md
@@ -1,0 +1,51 @@
+# 24 — Editability & insertion tracker
+
+Living tracker for the "we made it render but can't edit/insert it" gap. The
+visual-fidelity work was on the layout-painter (display); editability lives in the PM
+schema + the click→position mapping + selection/handles + insert commands. **Every row
+below is empirically verified (Playwright probe), not just code-read** — several audit
+claims were wrong (e.g. textbox text-editing already works).
+
+Ordering/prioritization is owned here, not by the user; the user reports issues ad-hoc
+and they get slotted in.
+
+## Status legend
+✅ done · 🟡 in progress · ⬜ todo · 🔬 needs verify
+
+## Done
+| Item | Notes |
+| --- | --- |
+| ✅ **Table delete** | Right-click "Delete table" was a no-op — missing `case 'deleteTable'` in the context-menu action switch (`DocxEditor.tsx`). Fixed + e2e. (user-reported) |
+| ✅ **Insert text box / callout** | No way to create a text box existed. `handleInsertTextBox` + Insert-menu entries; caret lands inside; callout = fill+outline variant. e2e. (user-reported) |
+| ✅ **Textbox text editing** | Already worked (DOM click path → inner paragraph `data-pm-start`); pinned with a guard test so it stays working. |
+
+## Todo — editing existing objects
+| Pri | Item | Impact | Notes / fix direction |
+| --- | --- | --- | --- |
+| P1 | ⬜ **Inline image resize** | High — can't resize the most common image type | Selecting an inline image shows the overlay but **0 resize handles** (handles gate on `displayMode !== 'inline'`). Render handles for inline + dispatch width/height. |
+| P1 | ⬜ **Textbox node select + delete** | High | Probe: Escape+Delete left 9→9. Click-to-enter works, but selecting the whole box (to delete/move) doesn't. Add a textBox node-select path (mirror `findImageElement`) + delete. |
+| P2 | ⬜ **Textbox move / resize** | Med | No drag/resize handles for textbox (only images have them). Add an overlay like `ImageSelectionOverlay`. |
+| P2 | ⬜ **Anchored position honored by layout** | High (shared) | Floating images + textboxes + shapes store `posOffsetH/V` but the layout engine ignores them (reverted `d8b85d1`). Drag-move updates attrs but a re-layout can reset. Needs hybrid cursor-advance + wrap-exclusion zones. |
+| P2 | ⬜ **Shape (rawXml) safety** | Med | rawXml shapes are preserve-only; editing silently rebuilds → loses VML. Make click-selectable + safely deletable; block in-place edit or patch only the textBody. |
+| P3 | ⬜ **Header/footer caret feedback** | Low | Double-click-to-edit works; caret not painted on the page-behind during edit. |
+| P3 | ⬜ **Footnote click-to-edit** | Low-Med | Clicking footnote text falls through to body (not in `page.fragments`). |
+| P3 | ⬜ **Floating image in table cell — click** | Low | `findImageElement` matches `layout-page-floating-image` but not `layout-cell-floating-image`. |
+| P3 | ⬜ **Image UI: dist-margins / rotate-flip / border / topAndBottom wrap** | Low | Attrs exist + round-trip; no UI to edit. |
+| P3 | ⬜ **Cell-range selection polish / col-resize width constraint** | Low | Multi-cell selection lacks anchor styling; col-resize can breach fixed table width. |
+
+## Todo — insertion (user's main ask: "only there, can't create")
+| Pri | Item | Impact | Notes / fix direction |
+| --- | --- | --- | --- |
+| ✅ | Insert **text box / callout** | — | done (above) |
+| P1 | ⬜ **Insert real shape / vector** | High | "Insert shape" today drops a **flat rasterized PNG** (`generateShape`→dataUrl→image node), not an editable vector. Make it a real `shape` node (resizable, optional text), or at minimum a proper drawing. |
+| P2 | ⬜ **Insert callout presets** | Low | Callout exists (styled textbox); could add shaped callouts (speech bubble) once real shapes land. |
+
+## Polish / debt
+| Item | Notes |
+| --- | --- |
+| ⬜ Text box menu icon | Used `shapes` as a placeholder for Text box/Callout; pick a proper icon (e.g. `format_shapes`) once confirmed in the iconMap. |
+| ⬜ Inline-image-resize for pasted/inserted images | Same fix as P1 inline resize. |
+
+## Verification rule
+Every fix lands with a Playwright e2e that drives the real UI (menu/click/drag) and
+asserts the document model changed — matching how these gaps were found.

--- a/docs/internal/24-editability-tracker.md
+++ b/docs/internal/24-editability-tracker.md
@@ -38,12 +38,12 @@ resize). Treat every row as **verified by Playwright probe**, not by reading cod
 | P3 | ⬜ **Image UI: dist-margins / rotate-flip / border / topAndBottom wrap** | Low | Attrs exist + round-trip; no UI to edit. |
 | P3 | ⬜ **Cell-range selection polish / col-resize width constraint** | Low | Multi-cell selection lacks anchor styling; col-resize can breach fixed table width. |
 
-## Todo — insertion (user's main ask: "only there, can't create")
-| Pri | Item | Impact | Notes / fix direction |
+## Insertion (user's main ask: "only there, can't create")
+| Pri | Item | Impact | Notes |
 | --- | --- | --- | --- |
-| ✅ | Insert **text box / callout** | — | done (above) |
-| P1 | ⬜ **Insert real shape / vector** | High | "Insert shape" today drops a **flat rasterized PNG** (`generateShape`→dataUrl→image node), not an editable vector. Make it a real `shape` node (resizable, optional text), or at minimum a proper drawing. |
-| P2 | ⬜ **Insert callout presets** | Low | Callout exists (styled textbox); could add shaped callouts (speech bubble) once real shapes land. |
+| ✅ | Insert **text box / callout** | — | done — editable, deletable (Backspace/Ctrl+A) |
+| ✅ | Insert **shape (rect/ellipse/line/arrow)** | — | **Works** — `generateShape` emits a **vector SVG** (not raster as the audit said), inserted as an image node: renders, selectable, **resizable** (4 handles), movable. Guarded by e2e. |
+| P3 | ⬜ **Native DrawingML shape + recolor** | Med (enhancement) | The inserted shape saves as an *image*, not a Word shape, and can't be recolored after insert. A real `shape`-node path needs **painter shape rendering** (none today — shapes only paint via the image path) + a resize overlay + fill UI. Larger build; deprioritized since insert-shape is already functional. |
 
 ## Polish / debt
 | Item | Notes |

--- a/docs/internal/24-editability-tracker.md
+++ b/docs/internal/24-editability-tracker.md
@@ -12,18 +12,23 @@ and they get slotted in.
 ## Status legend
 ✅ done · 🟡 in progress · ⬜ todo · 🔬 needs verify
 
-## Done
+## ⚠️ Audit caveat
+The initial code-reading audit was **unreliable** — 3 of its "broken" claims were
+actually working (textbox text-edit, inline-image resize handles, inline-image drag-
+resize). Treat every row as **verified by Playwright probe**, not by reading code.
+
+## Done / verified-working
 | Item | Notes |
 | --- | --- |
 | ✅ **Table delete** | Right-click "Delete table" was a no-op — missing `case 'deleteTable'` in the context-menu action switch (`DocxEditor.tsx`). Fixed + e2e. (user-reported) |
 | ✅ **Insert text box / callout** | No way to create a text box existed. `handleInsertTextBox` + Insert-menu entries; caret lands inside; callout = fill+outline variant. e2e. (user-reported) |
-| ✅ **Textbox text editing** | Already worked (DOM click path → inner paragraph `data-pm-start`); pinned with a guard test so it stays working. |
+| ✅ **Textbox text editing** | Already worked (DOM click path → inner paragraph `data-pm-start`); guard test pins it. |
+| ✅ **Inline image resize** | Already works — select shows 4 handles, drag resizes (333→256px). Audit's "no resize UI" was wrong; my first probe missed the target with raw coords. Guard test pins it. |
 
 ## Todo — editing existing objects
 | Pri | Item | Impact | Notes / fix direction |
 | --- | --- | --- | --- |
-| P1 | ⬜ **Inline image resize** | High — can't resize the most common image type | Selecting an inline image shows the overlay but **0 resize handles** (handles gate on `displayMode !== 'inline'`). Render handles for inline + dispatch width/height. |
-| P1 | ⬜ **Textbox node select + delete** | High | Probe: Escape+Delete left 9→9. Click-to-enter works, but selecting the whole box (to delete/move) doesn't. Add a textBox node-select path (mirror `findImageElement`) + delete. |
+| P1 | 🔬 **Textbox node select + delete** | High — you can insert one now but not easily remove it | Probe: Escape+Delete left 9→9. Click-to-enter works, selecting the whole box doesn't. Re-verifying gestures; if confirmed, add a textBox node-select path (mirror `findImageElement`) + delete. |
 | P2 | ⬜ **Textbox move / resize** | Med | No drag/resize handles for textbox (only images have them). Add an overlay like `ImageSelectionOverlay`. |
 | P2 | ⬜ **Anchored position honored by layout** | High (shared) | Floating images + textboxes + shapes store `posOffsetH/V` but the layout engine ignores them (reverted `d8b85d1`). Drag-move updates attrs but a re-layout can reset. Needs hybrid cursor-advance + wrap-exclusion zones. |
 | P2 | ⬜ **Shape (rawXml) safety** | Med | rawXml shapes are preserve-only; editing silently rebuilds → loses VML. Make click-selectable + safely deletable; block in-place edit or patch only the textBody. |

--- a/docs/internal/24-editability-tracker.md
+++ b/docs/internal/24-editability-tracker.md
@@ -28,7 +28,7 @@ resize). Treat every row as **verified by Playwright probe**, not by reading cod
 ## Todo — editing existing objects
 | Pri | Item | Impact | Notes / fix direction |
 | --- | --- | --- | --- |
-| P1 | 🔬 **Textbox node select + delete** | High — you can insert one now but not easily remove it | Probe: Escape+Delete left 9→9. Click-to-enter works, selecting the whole box doesn't. Re-verifying gestures; if confirmed, add a textBox node-select path (mirror `findImageElement`) + delete. |
+| P3 | ⬜ **Textbox click-to-select-as-node** (Word border-select) | Low — deletion already works | `Ctrl+A`→Delete already removes a box; **Backspace in an empty box now deletes it** too (✅, BaseKeymapExtension). Remaining nicety: click the box border to select the whole node (for move/resize); not blocking. |
 | P2 | ⬜ **Textbox move / resize** | Med | No drag/resize handles for textbox (only images have them). Add an overlay like `ImageSelectionOverlay`. |
 | P2 | ⬜ **Anchored position honored by layout** | High (shared) | Floating images + textboxes + shapes store `posOffsetH/V` but the layout engine ignores them (reverted `d8b85d1`). Drag-move updates attrs but a re-layout can reset. Needs hybrid cursor-advance + wrap-exclusion zones. |
 | P2 | ⬜ **Shape (rawXml) safety** | Med | rawXml shapes are preserve-only; editing silently rebuilds → loses VML. Make click-selectable + safely deletable; block in-place edit or patch only the textBody. |

--- a/docx-editor/e2e/tests/inline-image-resize.spec.ts
+++ b/docx-editor/e2e/tests/inline-image-resize.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Inline image resize — guard. Selecting an inline image shows the
+ * selection overlay with 4 corner handles; dragging one resizes it.
+ * (The audit claimed inline images had no resize UI; empirically they
+ * do — pinned so it stays working.)
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test('selecting an inline image shows resize handles and dragging resizes it', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/example-with-image.docx');
+  await page.waitForTimeout(1200);
+
+  const img = page.locator('[data-testid="docx-editor"] img.layout-run-image').first();
+  const b0 = await img.boundingBox();
+  if (!b0) throw new Error('no image');
+
+  await img.click({ position: { x: Math.round(b0.width / 2), y: Math.round(b0.height / 2) } });
+  await page.waitForTimeout(400);
+
+  // 4 corner handles present
+  await expect(page.locator('[data-handle]')).toHaveCount(4);
+
+  // Drag the SE handle inward → image shrinks.
+  const hb = await page.locator('[data-handle="se"]').first().boundingBox();
+  if (!hb) throw new Error('no handle');
+  await page.mouse.move(hb.x + hb.width / 2, hb.y + hb.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(hb.x - 80, hb.y - 80, { steps: 10 });
+  await page.mouse.up();
+  await page.waitForTimeout(500);
+
+  const b1 = await img.boundingBox();
+  expect(Math.abs((b1?.width ?? 0) - b0.width)).toBeGreaterThan(20);
+});

--- a/docx-editor/e2e/tests/insert-shape-resizable.spec.ts
+++ b/docx-editor/e2e/tests/insert-shape-resizable.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Insert → Shape produces a resizable vector shape (currently an
+ * SVG-image node — renders, selectable, resizable, movable). Guards
+ * that inserting a shape isn't inert. (A native DrawingML shape node
+ * with recolor is a tracked larger enhancement — see docs/internal/24.)
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test('Insert → Shape → Rectangle inserts a selectable, resizable shape', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.focus();
+  await editor.typeText('Body.');
+
+  const imgsBefore = await page.locator('[data-testid="docx-editor"] img.layout-run-image').count();
+
+  await page.getByRole('button', { name: 'Insert', exact: true }).click();
+  await page.waitForSelector('[role="menu"]', { state: 'visible' });
+  await page.getByRole('menuitem', { name: /^Shape$/ }).hover();
+  await page.waitForTimeout(300);
+  await page.getByRole('menuitem', { name: /Rectangle/i }).first().click();
+  await page.waitForTimeout(600);
+
+  const imgsAfter = await page.locator('[data-testid="docx-editor"] img.layout-run-image').count();
+  expect(imgsAfter).toBe(imgsBefore + 1);
+
+  // Select it → resize handles appear.
+  const shape = page.locator('[data-testid="docx-editor"] img.layout-run-image').last();
+  const box = await shape.boundingBox();
+  await shape.click({ position: { x: Math.round(box!.width / 2), y: Math.round(box!.height / 2) } });
+  await page.waitForTimeout(400);
+  await expect(page.locator('[data-handle]')).toHaveCount(4);
+});

--- a/docx-editor/e2e/tests/insert-textbox.spec.ts
+++ b/docx-editor/e2e/tests/insert-textbox.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+const TB = '[data-testid="docx-editor"] .layout-textbox';
+
+test('Insert → Text box adds an editable text box', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.focus();
+  await editor.typeText('Body paragraph.');
+  await page.waitForTimeout(300);
+
+  const before = await page.locator(TB).count();
+
+  await page.getByRole('button', { name: 'Insert', exact: true }).click();
+  await page.waitForSelector('[role="menu"]', { state: 'visible', timeout: 4000 });
+  await page.getByRole('menuitem', { name: /^Text box$/ }).click();
+  await page.waitForTimeout(600);
+
+  const after = await page.locator(TB).count();
+  expect(after).toBe(before + 1);
+
+  await page.keyboard.type('HELLO_TB');
+  await page.waitForTimeout(400);
+  const txt = (await page.locator(TB).last().innerText()).trim();
+  expect(txt).toContain('HELLO_TB');
+});

--- a/docx-editor/e2e/tests/table-delete.spec.ts
+++ b/docx-editor/e2e/tests/table-delete.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Table delete via the right-click context menu — regression.
+ *
+ * The "Delete table" item was surfaced in the cell right-click menu but
+ * the context-menu action switch had no `deleteTable` case, so clicking
+ * it did nothing (user-reported). This pins the behavior end-to-end.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+const TABLE = '[data-testid="docx-editor"] .layout-table';
+
+test('right-click → Delete table removes the table', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/repr-memo.docx');
+  await page.waitForSelector(TABLE, { timeout: 15000 });
+
+  const before = await page.locator(TABLE).count();
+  expect(before).toBeGreaterThan(0);
+
+  const cell = page.locator('[data-testid="docx-editor"] .layout-table-cell').first();
+  const box = await cell.boundingBox();
+  if (!box) throw new Error('no cell bounding box');
+
+  // Place the caret in a cell, then open the right-click menu there.
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+  await page.waitForTimeout(250);
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2, { button: 'right' });
+  await page.waitForTimeout(350);
+
+  await page.getByText('Delete table', { exact: false }).first().click();
+  await page.waitForTimeout(500);
+
+  const after = await page.locator(TABLE).count();
+  expect(after).toBe(before - 1);
+});

--- a/docx-editor/e2e/tests/textbox-backspace-delete.spec.ts
+++ b/docx-editor/e2e/tests/textbox-backspace-delete.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+const TB = '[data-testid="docx-editor"] .layout-textbox';
+test('Backspace in an empty text box deletes it', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.focus();
+  await editor.typeText('Body.');
+  await page.getByRole('button', { name: 'Insert', exact: true }).click();
+  await page.waitForSelector('[role="menu"]', { state: 'visible' });
+  await page.getByRole('menuitem', { name: /^Text box$/ }).click();
+  await page.waitForTimeout(500);
+  expect(await page.locator(TB).count()).toBe(1);
+  // caret is inside the new empty box → Backspace deletes it
+  await page.keyboard.press('Backspace');
+  await page.waitForTimeout(400);
+  expect(await page.locator(TB).count()).toBe(0);
+});

--- a/docx-editor/e2e/tests/textbox-editability.spec.ts
+++ b/docx-editor/e2e/tests/textbox-editability.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * Textbox EDITABILITY (not rendering) — P1.
+ *
+ * Rendering of textboxes is covered by textbox-rendering.spec.ts. This
+ * asserts the user can actually EDIT them: clicking inside a painted
+ * textbox must land the caret INSIDE the textbox's content so typing
+ * edits the textbox (not the body behind it).
+ *
+ * Fixture: 9 textboxes (`wps:txbx`). We scope to the painter via the
+ * `docx-editor` testid to avoid the dual-render DOM collision.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+const FIXTURE = 'fixtures/textbox-test.docx';
+const TB = '[data-testid="docx-editor"] .layout-textbox';
+
+test.describe('Textbox editability — click to enter + type', () => {
+  let editor: EditorPage;
+
+  test.beforeEach(async ({ page }) => {
+    editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.loadDocxFile(FIXTURE);
+    await page.waitForSelector(TB, { timeout: 15000 });
+  });
+
+  test('clicking a textbox lands the caret inside it so typing edits the textbox', async ({
+    page,
+  }) => {
+    const tb = page.locator(TB).first();
+    const box = await tb.boundingBox();
+    if (!box) throw new Error('no textbox bounding box');
+
+    // Click near the top of the textbox where its first line of text sits.
+    await page.mouse.click(box.x + box.width / 2, box.y + Math.min(16, box.height / 2));
+    await page.waitForTimeout(150);
+    await page.keyboard.type('ZZZ');
+    await page.waitForTimeout(450);
+
+    const after = (await tb.innerText()).trim();
+    expect(after).toContain('ZZZ');
+  });
+});

--- a/docx-editor/packages/core/src/prosemirror/extensions/features/BaseKeymapExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/features/BaseKeymapExtension.ts
@@ -74,6 +74,36 @@ const clearIndentOnBackspace: Command = (state, dispatch) => {
 };
 
 /**
+ * Backspace inside an EMPTY text box deletes the whole box (Word /
+ * Google Docs behavior). A text box is `isolating`, so the default
+ * `joinBackward` can't cross its boundary — without this, Backspace in
+ * an empty text box is a dead key. Only fires when the box holds a
+ * single empty paragraph and the caret is at its very start; a
+ * non-empty box falls through so its content deletes normally first.
+ */
+const deleteEmptyTextBoxOnBackspace: Command = (state, dispatch) => {
+  const sel = state.selection;
+  if (!sel.empty) return false;
+  const $from = sel.$from;
+  for (let d = $from.depth; d > 0; d--) {
+    const node = $from.node(d);
+    if (node.type.name === 'textBox') {
+      const onlyChildEmpty = node.childCount === 1 && (node.firstChild?.content.size ?? 0) === 0;
+      const atStart = $from.parentOffset === 0 && $from.index(d) === 0;
+      if (onlyChildEmpty && atStart) {
+        if (dispatch) {
+          const before = $from.before(d);
+          dispatch(state.tr.delete(before, before + node.nodeSize).scrollIntoView());
+        }
+        return true;
+      }
+      return false; // inside a non-empty box — let default handling run
+    }
+  }
+  return false;
+};
+
+/**
  * Custom Enter handler: splits the block, inherits style-related attrs,
  * clears paragraph borders, and preserves font marks on the new paragraph.
  *
@@ -257,7 +287,12 @@ export const BaseKeymapExtension = createExtension({
         ...baseKeymap,
         // Override some keys with better defaults
         Enter: splitBlockClearBorders,
-        Backspace: chainCommands(deleteSelection, clearIndentOnBackspace, joinBackward),
+        Backspace: chainCommands(
+          deleteSelection,
+          deleteEmptyTextBoxOnBackspace,
+          clearIndentOnBackspace,
+          joinBackward
+        ),
         Delete: chainCommands(deleteSelection, joinForward),
         'Mod-a': selectAll,
         Escape: selectParentNode,

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -5462,6 +5462,52 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     [getActiveEditorView, focusActiveEditor]
   );
 
+  // Insert a new, editable text box (or a styled "callout" variant) at
+  // the cursor. The textBox node is block-level with `(paragraph|table)+`
+  // content, so we seed it with one empty paragraph and drop the caret
+  // inside so the user can type immediately.
+  const handleInsertTextBox = useCallback(
+    (variant: 'plain' | 'callout' = 'plain') => {
+      const view = getActiveEditorView();
+      if (!view) return;
+      const { schema } = view.state;
+      const textBoxType = schema.nodes.textBox;
+      const paragraphType = schema.nodes.paragraph;
+      if (!textBoxType || !paragraphType) return;
+
+      const attrs =
+        variant === 'callout'
+          ? {
+              width: 260,
+              displayMode: 'block' as const,
+              fillColor: '#eff6ff',
+              outlineColor: '#3b82f6',
+              outlineWidth: 1,
+              outlineStyle: 'solid',
+            }
+          : { width: 240, displayMode: 'block' as const };
+
+      const node =
+        textBoxType.createAndFill(attrs, paragraphType.create()) ??
+        textBoxType.create(attrs, paragraphType.create());
+      const tr = view.state.tr.replaceSelectionWith(node);
+      // Place the caret inside the new text box's first paragraph. After
+      // replaceSelectionWith, the node sits where the selection was; its
+      // content starts 2 positions in (textBox open + paragraph open).
+      const insertedAt = tr.selection.from - node.nodeSize;
+      const inside = insertedAt + 2;
+      try {
+        tr.setSelection(TextSelection.create(tr.doc, inside));
+      } catch {
+        // Fall back to the default post-insert selection if the math is
+        // off for an unusual schema configuration.
+      }
+      view.dispatch(tr.scrollIntoView());
+      focusActiveEditor();
+    },
+    [getActiveEditorView, focusActiveEditor]
+  );
+
   const handleInsertCitation = useCallback(
     (formatted: string, url?: string) => {
       const view = getActiveEditorView();
@@ -7585,6 +7631,7 @@ body { background: white; }
                       spellcheckEnabled={spellOn}
                       onOpenCitations={handleOpenCitations}
                       onInsertShape={handleInsertShape}
+                      onInsertTextBox={handleInsertTextBox}
                       onSetColorTheme={handleSetColorTheme}
                       colorTheme={colorTheme}
                       isDirty={isDirty}
@@ -9200,6 +9247,18 @@ body { background: white; }
                       label: 'Shape · Arrow',
                       path: 'Insert',
                       run: () => handleInsertShape('arrow'),
+                    },
+                    {
+                      id: 'insert.textbox',
+                      label: 'Text box',
+                      path: 'Insert',
+                      run: () => handleInsertTextBox('plain'),
+                    },
+                    {
+                      id: 'insert.callout',
+                      label: 'Callout',
+                      path: 'Insert',
+                      run: () => handleInsertTextBox('callout'),
                     },
 
                     {

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -5108,6 +5108,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         case 'deleteColumn':
           pmDeleteColumn(view.state, view.dispatch);
           break;
+        case 'deleteTable':
+          // The right-click "Delete table" item (see context-menu items)
+          // routes here; without this case it fell through to a no-op,
+          // so the menu entry did nothing.
+          pmDeleteTable(view.state, view.dispatch);
+          break;
         case 'mergeCells':
           pmMergeCells(view.state, view.dispatch);
           break;

--- a/docx-editor/packages/react/src/components/TitleBar.tsx
+++ b/docx-editor/packages/react/src/components/TitleBar.tsx
@@ -277,6 +277,7 @@ export function MenuBar() {
     onOpenExplore,
     onOpenCitations,
     onInsertShape,
+    onInsertTextBox,
     onSetColorTheme,
     colorTheme,
     zoom,
@@ -841,6 +842,20 @@ export function MenuBar() {
                         ))}
                       </>
                     ),
+                  } as MenuEntry,
+                ]
+              : []),
+            ...(onInsertTextBox
+              ? [
+                  {
+                    icon: 'shapes',
+                    label: 'Text box',
+                    onClick: () => onInsertTextBox('plain'),
+                  } as MenuEntry,
+                  {
+                    icon: 'shapes',
+                    label: 'Callout',
+                    onClick: () => onInsertTextBox('callout'),
                   } as MenuEntry,
                 ]
               : []),

--- a/docx-editor/packages/react/src/components/Toolbar.tsx
+++ b/docx-editor/packages/react/src/components/Toolbar.tsx
@@ -361,6 +361,8 @@ export interface ToolbarProps {
   onOpenCitations?: () => void;
   /** Insert → Shape — inserts a default SVG of the chosen primitive (C2 v0). */
   onInsertShape?: (type: 'rectangle' | 'ellipse' | 'line' | 'arrow') => void;
+  /** Insert → Text box / Callout — inserts an editable text box at the cursor. */
+  onInsertTextBox?: (variant: 'plain' | 'callout') => void;
   /** File → "Email as attachment" — download + open mailto (F2). */
   onEmailAsAttachment?: () => void;
   /** View → Show formatting marks — toggles ¶ / → / ↵ overlay (F6). */


### PR DESCRIPTION
First batch of the editability/insertion workstream (docs/internal/24 tracker). Every gap below was **empirically verified** with a Playwright probe (several code-audit claims were wrong — e.g. textbox text-editing already works).

- **fix(table): Delete table** — the right-click "Delete table" item was a no-op (missing `case 'deleteTable'` in the context-menu action switch). User-reported. + e2e.
- **feat(insert): Text box / Callout** — there was no way to *create* a text box (only ones parsed from the .docx). `handleInsertTextBox` drops an editable block-level text box (caret lands inside); callout = fill+outline variant. Wired into the Insert menu. + e2e.
- **guard:** textbox text-editing already works (DOM click path) — pinned so it stays.
- **docs/internal/24** — living editability & insertion tracker (status + my prioritization).

Note: overlaps #49 on `DocxEditor/TitleBar/Toolbar`. If #49 lands first I'll rebase this (small + localized).

Gate: format · lint 0 errors · typecheck · 3 e2e pass · smoke.