### PR TITLE
polish(insert): proper Text box / Callout menu icons

### DIFF
--- a/docx-editor/packages/react/src/components/TitleBar.tsx
+++ b/docx-editor/packages/react/src/components/TitleBar.tsx
@@ -853,12 +853,12 @@ export function MenuBar() {
             ...(onInsertTextBox
               ? [
                   {
-                    icon: 'shapes',
+                    icon: 'edit_note',
                     label: 'Text box',
                     onClick: () => onInsertTextBox('plain'),
                   } as MenuEntry,
                   {
-                    icon: 'shapes',
+                    icon: 'chat_bubble_outline',
                     label: 'Callout',
                     onClick: () => onInsertTextBox('callout'),
                   } as MenuEntry,


### PR DESCRIPTION
Tail of the editability batch (#50) — the icon-polish commit landed after #50 was already merged, so it's surfaced here. Swaps the placeholder `shapes` icon for `edit_note` (Text box) + `chat_bubble_outline` (Callout). Verified the menu renders SVGs, not raw text.