### PR TITLE
feat(ux): contextual Format panel + on-selection chip (image)

### DIFF
--- a/docx-editor/e2e/tests/properties-panel.spec.ts
+++ b/docx-editor/e2e/tests/properties-panel.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Contextual Format/Properties panel — image entry via the selection chip.
+ *
+ * Verifies the agreed UX: selecting an object shows a "Format" chip; the
+ * chip (never auto-open) opens a panel that OVERLAYS the right margin
+ * (no canvas shift); the panel shows the object's properties.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+const PAGE = '[data-testid="docx-editor"] .layout-page';
+const PANEL = '[data-testid="properties-panel"]';
+
+test('image: Format chip opens a contextual panel without shifting the canvas', async ({
+  page,
+}) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/example-with-image.docx');
+  await page.waitForTimeout(1200);
+
+  const pageBox0 = await page.locator(PAGE).first().boundingBox();
+
+  const img = page.locator('[data-testid="docx-editor"] img.layout-run-image').first();
+  const ib = await img.boundingBox();
+  if (!ib) throw new Error('no image');
+  await img.click({ position: { x: Math.round(ib.width / 2), y: Math.round(ib.height / 2) } });
+  await page.waitForTimeout(300);
+
+  // Chip appears on selection; panel is NOT auto-opened.
+  await expect(page.locator('[data-testid="image-format-chip"]')).toBeVisible();
+  expect(await page.locator(PANEL).count()).toBe(0);
+
+  await page.locator('[data-testid="image-format-chip"]').click();
+  await page.waitForTimeout(400);
+
+  // Panel opens with the image section; canvas did not move.
+  await expect(page.locator(PANEL)).toBeVisible();
+  await expect(page.locator('[data-testid="properties-image-section"]')).toBeVisible();
+  const pageBox1 = await page.locator(PAGE).first().boundingBox();
+  expect(Math.abs((pageBox1?.x ?? 0) - (pageBox0?.x ?? 0))).toBeLessThan(2);
+
+  // Wrap options are present + clickable (the section drives the real
+  // setImageWrapType command; applying it is covered by image-wrap specs).
+  await expect(page.locator('[data-testid="properties-wrap-inline"]')).toBeVisible();
+  await expect(page.locator('[data-testid="properties-wrap-squareLeft"]')).toBeVisible();
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -51,6 +51,8 @@ import {
 } from './DocumentOutline';
 import { SIDEBAR_DOCUMENT_SHIFT } from './sidebar/constants';
 import { VersionHistoryPanel } from './sidebar/VersionHistoryPanel';
+import { PropertiesPanel, type PropertiesTargetKind } from './sidebar/PropertiesPanel';
+import { ImagePropertiesSection } from './sidebar/ImagePropertiesSection';
 import { useEditHistory } from '../hooks/useEditHistory';
 import { useVersionHistoryCapture } from '../version-history/useVersionHistoryCapture';
 import { downloadServerVersion, type ServerVersionBackend } from '../version-history/server-source';
@@ -1654,6 +1656,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // Comments + version-history are mutually exclusive — opening one
   // closes the other so the right rail doesn't double-stack panels.
   const [showVersionHistory, setShowVersionHistory] = useState(false);
+  const [showProperties, setShowProperties] = useState(false);
   const editHistory = useEditHistory({ author: 'You' });
 
   // Shared toggle handlers — used by both the toolbar buttons and the
@@ -2378,11 +2381,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // `handleToggleVersionHistory`'s historical behaviour — those two
   // share the right-margin slot).
   const openRightPanel = useCallback(
-    (which: 'writer' | 'chat' | 'history' | 'aiSuggestion' | 'none') => {
+    (which: 'writer' | 'chat' | 'history' | 'properties' | 'aiSuggestion' | 'none') => {
       setShowWritingAssistant(which === 'writer');
       setShowChatPanel(which === 'chat');
       setShowVersionHistory(which === 'history');
-      if (which === 'history') {
+      setShowProperties(which === 'properties');
+      if (which === 'history' || which === 'properties') {
         setShowCommentsSidebar(false);
         setExpandedSidebarItem(null);
       }
@@ -8323,6 +8327,43 @@ body { background: white; }
                     />
                   )}
 
+                  {showProperties &&
+                    (() => {
+                      // Contextual Format panel: shows the selected object's
+                      // properties. Kind derived from the live PM selection.
+                      const propsKind: PropertiesTargetKind | null = state.pmImageContext
+                        ? 'image'
+                        : state.pmTableContext?.isInTable
+                          ? 'table'
+                          : null;
+                      // OVERLAY, never push: unlike the flex-sibling panels,
+                      // the Format panel floats over the right desk margin so
+                      // toggling it mid-edit causes ZERO document reflow (no
+                      // canvas shift). It's a manual toggle (rail button), never
+                      // auto-opened on selection.
+                      return (
+                        <div
+                          style={{
+                            position: 'absolute',
+                            top: 0,
+                            right: 0,
+                            bottom: 0,
+                            zIndex: 25,
+                            boxShadow: '-4px 0 16px rgba(0,0,0,0.08)',
+                          }}
+                        >
+                          <PropertiesPanel kind={propsKind} onClose={() => openRightPanel('none')}>
+                            {propsKind === 'image' && state.pmImageContext && (
+                              <ImagePropertiesSection
+                                wrapType={state.pmImageContext.wrapType}
+                                onSetWrap={handleImageWrapType}
+                              />
+                            )}
+                          </PropertiesPanel>
+                        </div>
+                      );
+                    })()}
+
                   {/* Comments use the anchored-cards approach (UnifiedSidebar
                       paints a floating card next to each commented span).
                       There is intentionally no solid docked comments panel —
@@ -8358,6 +8399,10 @@ body { background: white; }
                       onToggleComments={handleToggleComments}
                       onToggleHistory={() =>
                         openRightPanel(showVersionHistory ? 'none' : 'history')
+                      }
+                      propertiesVisible={showProperties}
+                      onToggleProperties={() =>
+                        openRightPanel(showProperties ? 'none' : 'properties')
                       }
                       // Writer + chat rail toggles unwired — LLM
                       // gating. Restore: writerVisible={showWritingAssistant}

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -7997,6 +7997,7 @@ body { background: white; }
                           onBodyClick={handleBodyClick}
                           zoom={state.zoom}
                           marginDraggingRef={marginDraggingRef}
+                          onOpenImageProperties={() => openRightPanel('properties')}
                           wordCompat={wordCompat}
                           showFormattingMarks={showFormattingMarks}
                           readOnly={readOnly}

--- a/docx-editor/packages/react/src/components/PanelRail.tsx
+++ b/docx-editor/packages/react/src/components/PanelRail.tsx
@@ -36,6 +36,10 @@ export interface PanelRailProps {
   onToggleComments?: () => void;
   /** Toggle the version-history panel. */
   onToggleHistory?: () => void;
+  /** Whether the Format/Properties panel is open. */
+  propertiesVisible?: boolean;
+  /** Toggle the Format/Properties panel. */
+  onToggleProperties?: () => void;
   /** Whether the Writing Assistant sheet is open. */
   writerVisible?: boolean;
   /** Toggle the Writing Assistant sheet. */
@@ -133,6 +137,8 @@ export function PanelRail({
   onToggleOutline,
   onToggleComments,
   onToggleHistory,
+  propertiesVisible,
+  onToggleProperties,
   writerVisible,
   onToggleWriter,
   chatVisible,
@@ -141,7 +147,14 @@ export function PanelRail({
   const { t } = useTranslation();
   // No-op if nothing to toggle (host wired no panels) — render nothing
   // rather than an empty bar.
-  if (!onToggleOutline && !onToggleComments && !onToggleHistory && !onToggleWriter && !onToggleChat)
+  if (
+    !onToggleOutline &&
+    !onToggleComments &&
+    !onToggleHistory &&
+    !onToggleProperties &&
+    !onToggleWriter &&
+    !onToggleChat
+  )
     return null;
 
   const outlineShortcut = formatShortcut('Ctrl+Shift+H');
@@ -173,6 +186,15 @@ export function PanelRail({
           icon="history"
           active={!!historyVisible}
           onClick={onToggleHistory}
+        />
+      )}
+      {onToggleProperties && (
+        <RailButton
+          testId="rail-properties"
+          label={propertiesVisible ? 'Hide format panel' : 'Format'}
+          icon="tune"
+          active={!!propertiesVisible}
+          onClick={onToggleProperties}
         />
       )}
       {onToggleWriter && (

--- a/docx-editor/packages/react/src/components/TitleBar.tsx
+++ b/docx-editor/packages/react/src/components/TitleBar.tsx
@@ -853,12 +853,12 @@ export function MenuBar() {
             ...(onInsertTextBox
               ? [
                   {
-                    icon: 'shapes',
+                    icon: 'edit_note',
                     label: 'Text box',
                     onClick: () => onInsertTextBox('plain'),
                   } as MenuEntry,
                   {
-                    icon: 'shapes',
+                    icon: 'chat_bubble_outline',
                     label: 'Callout',
                     onClick: () => onInsertTextBox('callout'),
                   } as MenuEntry,

--- a/docx-editor/packages/react/src/components/sidebar/ImagePropertiesSection.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/ImagePropertiesSection.tsx
@@ -1,0 +1,99 @@
+/**
+ * Image section of the Format/Properties panel. First section built on the
+ * panel base — proves the pattern (contextual, grouped, live). Reuses the
+ * editor's existing image wrap command; size is shown read-only for now
+ * (resize is via the on-canvas handles). Future: editable W/H, position,
+ * border, recolor — all as groups in this same section.
+ */
+import type { CSSProperties } from 'react';
+
+const WRAP_OPTIONS = [
+  { value: 'inline', label: 'In line' },
+  { value: 'squareLeft', label: 'Wrap text — left' },
+  { value: 'squareRight', label: 'Wrap text — right' },
+  { value: 'behind', label: 'Behind text' },
+  { value: 'inFront', label: 'In front of text' },
+] as const;
+
+const GROUP_HEADER: CSSProperties = {
+  padding: '12px 16px 6px',
+  fontSize: 11,
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+  color: 'var(--doc-text-muted)',
+  fontWeight: 600,
+};
+
+const OPTION_BTN = (active: boolean): CSSProperties => ({
+  display: 'block',
+  width: '100%',
+  textAlign: 'left',
+  padding: '7px 16px',
+  fontSize: 13,
+  background: active ? 'var(--doc-primary-light, #e8f0fe)' : 'transparent',
+  color: active ? 'var(--doc-primary, #1a73e8)' : 'var(--doc-text, #202124)',
+  border: 'none',
+  cursor: 'pointer',
+});
+
+const SIZE_ROW: CSSProperties = {
+  padding: '6px 16px 14px',
+  fontSize: 13,
+  color: 'var(--doc-text, #202124)',
+};
+
+export interface ImagePropertiesSectionProps {
+  /** Current wrap mode of the selected image. */
+  wrapType: string;
+  /** Rendered width/height in px (read-only display). */
+  width?: number;
+  height?: number;
+  /** Apply a wrap mode (host wires this to setImageWrapType). */
+  onSetWrap: (value: string) => void;
+}
+
+export function ImagePropertiesSection({
+  wrapType,
+  width,
+  height,
+  onSetWrap,
+}: ImagePropertiesSectionProps) {
+  return (
+    <div data-testid="properties-image-section">
+      <div style={GROUP_HEADER}>Text wrapping</div>
+      <div role="group" aria-label="Text wrapping">
+        {WRAP_OPTIONS.map((o) => {
+          const active = wrapType === o.value;
+          return (
+            <button
+              key={o.value}
+              type="button"
+              role="menuitemradio"
+              aria-checked={active}
+              style={OPTION_BTN(active)}
+              data-testid={`properties-wrap-${o.value}`}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onSetWrap(o.value);
+              }}
+            >
+              {active ? '✓ ' : ''}
+              {o.label}
+            </button>
+          );
+        })}
+      </div>
+      {(width != null || height != null) && (
+        <>
+          <div style={GROUP_HEADER}>Size</div>
+          <div style={SIZE_ROW} data-testid="properties-image-size">
+            {Math.round(width ?? 0)} × {Math.round(height ?? 0)} px
+            <div style={{ fontSize: 11, color: 'var(--doc-text-muted)', marginTop: 2 }}>
+              Drag the corner handles on the image to resize.
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/docx-editor/packages/react/src/components/sidebar/PropertiesPanel.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/PropertiesPanel.tsx
@@ -1,0 +1,50 @@
+/**
+ * Format / Properties panel — the contextual right-rail home for editing
+ * the properties of the SELECTED object (image / table / shape): size,
+ * wrap, position, fill, borders, recolor, alt text.
+ *
+ * This is the agreed pattern (Collabora/LibreOffice sidebar, Word Format
+ * pane, Figma, Google-Docs "Image options"): one clean surface instead of
+ * scattering object-property controls across toolbar/menu/dialogs. Each
+ * object kind contributes a *section*; the host renders the active section
+ * as `children` based on `kind`. New per-object property UIs plug in here.
+ *
+ * Built on RightDockPanel so it shares the rail behavior (one panel at a
+ * time, slide-in, close-✕) with comments / version-history / outline.
+ */
+import type { ReactNode } from 'react';
+import { RightDockPanel } from '../RightDockPanel';
+import { MaterialSymbol } from '../ui/Icons';
+import { PanelState } from '../ui/PanelState';
+
+export type PropertiesTargetKind = 'image' | 'table' | 'shape';
+
+export interface PropertiesPanelProps {
+  /** The kind of object currently selected, or null when none is. */
+  kind: PropertiesTargetKind | null;
+  /** Close the panel (rail toggle off). */
+  onClose: () => void;
+  /** The active object's property section, chosen by the host from `kind`. */
+  children?: ReactNode;
+}
+
+export function PropertiesPanel({ kind, onClose, children }: PropertiesPanelProps) {
+  return (
+    <RightDockPanel
+      title="Format"
+      icon={<MaterialSymbol name="tune" size={18} />}
+      testId="properties-panel"
+      ariaLabel="Format properties"
+      onClose={onClose}
+    >
+      {kind && children ? (
+        children
+      ) : (
+        <PanelState
+          kind="empty"
+          message="Select an image, table, or shape to edit its properties."
+        />
+      )}
+    </RightDockPanel>
+  );
+}

--- a/docx-editor/packages/react/src/paged-editor/ImageSelectionOverlay.tsx
+++ b/docx-editor/packages/react/src/paged-editor/ImageSelectionOverlay.tsx
@@ -63,6 +63,10 @@ export interface ImageSelectionOverlayProps {
    *  paged-editor's contextmenu handler never fires for it — the parent wires
    *  this prop to route through to the same image-context-menu opener. */
   onContextMenu?: (e: React.MouseEvent) => void;
+  /** Open the contextual Format/Properties panel for this image. When set,
+   *  a small "Format" chip appears at the selection's top-left — the
+   *  intentional, object-specific entry to the panel (no auto-open). */
+  onOpenProperties?: () => void;
 }
 
 // =============================================================================
@@ -170,6 +174,7 @@ export function ImageSelectionOverlay({
   onDragStart,
   onDragEnd,
   onContextMenu,
+  onOpenProperties,
 }: ImageSelectionOverlayProps): React.ReactElement | null {
   const [isResizing, setIsResizing] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
@@ -504,6 +509,47 @@ export function ImageSelectionOverlay({
         >
           {resizeWidth} × {resizeHeight}
         </div>
+      )}
+
+      {/* "Format" chip — the intentional, object-specific entry to the
+          contextual Format panel (Google-Docs "Image options" model).
+          Hidden mid-resize/drag so it never gets in the way. */}
+      {onOpenProperties && !isResizing && !isDragging && (
+        <button
+          type="button"
+          data-testid="image-format-chip"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onOpenProperties();
+          }}
+          style={{
+            position: 'absolute',
+            left,
+            top: top - 30,
+            height: 24,
+            display: 'inline-flex',
+            alignItems: 'center',
+            padding: '0 10px',
+            fontSize: 12,
+            fontWeight: 500,
+            color: '#fff',
+            background: ACCENT_COLOR,
+            border: 'none',
+            borderRadius: 6,
+            cursor: 'pointer',
+            boxShadow: '0 1px 4px rgba(0,0,0,0.25)',
+            pointerEvents: 'auto',
+            zIndex: 16,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          Format
+        </button>
       )}
     </div>
   );

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -310,6 +310,9 @@ export interface PagedEditorProps {
    *  scroll out from under the marker as you drag. A ref (not a prop
    *  value) so toggling it mid-drag doesn't re-render the editor. */
   marginDraggingRef?: React.RefObject<boolean>;
+  /** Open the contextual Format panel for the selected image (the
+   *  overlay's "Format" chip calls this). */
+  onOpenImageProperties?: () => void;
   /** Whether comments sidebar is open (shifts document left). */
   commentsSidebarOpen?: boolean;
   /** Sidebar overlay rendered inside the scroll container (scrolls with document). */
@@ -1381,6 +1384,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       onFormat,
       onZoomChange,
       marginDraggingRef,
+      onOpenImageProperties,
       commentsSidebarOpen = false,
       sidebarOverlay,
       scrollContainerRef: scrollContainerRefProp,
@@ -4399,6 +4403,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             onDragStart={handleImageDragStart}
             onDragEnd={handleImageDragEnd}
             onContextMenu={handlePagesContextMenu}
+            onOpenProperties={onOpenImageProperties}
           />
 
           {/* Table quick action insert button */}


### PR DESCRIPTION
Builds the **base for the contextual Format/Properties panel** — the agreed home for object-property editing (Collabora/Word/Figma/Google-Docs "Image options" model), so future per-object property UIs (shape recolor, table props, image border/rotate) plug into one clean surface instead of scattering.

**Honors the UX constraints you set:**
- **Chip on selection** — selecting an image shows a "Format" chip; clicking it opens the panel for that object. Intentional + object-specific.
- **Never auto-open** — clicking an object does not pop the panel (verified).
- **Overlay, never push** — the panel floats over the right desk margin, so toggling it mid-edit causes **zero document reflow / no canvas shift** (verified: page X unchanged). Unlike the flex-sibling panels that shrink the canvas.

**Pieces:** `PropertiesPanel` (RightDockPanel-based) + `ImagePropertiesSection` (wrap + size); `ImageSelectionOverlay` "Format" chip → `PagedEditor.onOpenImageProperties` → `openRightPanel('properties')`; one-panel-at-a-time via the existing panel manager; rail toggle as a secondary entry.

**Next sections** (plug into the same panel): image border/rotate/recolor, table properties, shape recolor. Minor polish noted: the panel briefly loses image context when a property change re-anchors the node (keep selection through edits).

e2e: chip appears, no auto-open, opens panel with the image section, no canvas shift. Gate: typecheck · format · lint 0 errors · smoke.