### PR TITLE
feat(ux): Format panel via on-object chip — image (icon picker) + table

### DIFF
--- a/docx-editor/e2e/tests/properties-panel.spec.ts
+++ b/docx-editor/e2e/tests/properties-panel.spec.ts
@@ -1,51 +1,66 @@
 /**
- * Contextual Format/Properties panel — COMPLETE end-to-end flow.
+ * Contextual Format/Properties panel — COMPLETE end-to-end flow for BOTH
+ * object kinds, driving the REAL entry point (the on-object "Format" chip)
+ * and asserting the feature actually works, not just that testids exist:
  *
- * Asserts the whole feature works, not just that testids exist:
- *  1. opens via the rail (manual, no auto-open),
- *  2. behaves like the history panel — a flex sibling that the page makes
- *     room for (page right edge shrinks), NOT an overlay covering the doc,
- *  3. a property change actually APPLIES to the document (wrap inline -> behind
- *     moves the image into the floating layer),
- *  4. closing releases the room.
+ *  IMAGE
+ *   1. selecting an image shows the on-object chip (no auto-open of the panel),
+ *   2. clicking the chip opens the panel beside the doc — a flex sibling the
+ *      page makes room for (right edge shrinks), NOT an overlay over the doc,
+ *   3. the panel shows the IMAGE section (not the empty placeholder),
+ *   4. a wrap change actually APPLIES (inline -> behind moves the image into
+ *      the floating layer).
+ *
+ *  TABLE  (the case the old image-only test never covered — which is how a
+ *          broken/empty table panel shipped)
+ *   5. clicking inside a table shows the table chip,
+ *   6. clicking it opens the panel showing the TABLE section (not empty),
+ *   7. a table op actually APPLIES (delete row reduces the cell count).
+ *
+ *  ONE-AT-A-TIME
+ *   8. opening version history from the rail closes the properties panel
+ *      (only one right-side surface open at once).
  */
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { EditorPage } from '../helpers/editor-page';
 
 const PAGE = '[data-testid="docx-editor"] .layout-page';
 const PANEL = '[data-testid="properties-panel"]';
+const IMG_CHIP = '[data-testid="image-format-chip"]';
+const TABLE_CHIP = '[data-testid="table-format-chip"]';
 const INLINE_IMG = '[data-testid="docx-editor"] img.layout-run-image';
 const FLOATING_IMG =
   '[data-testid="docx-editor"] .layout-page-floating-image, [data-testid="docx-editor"] .layout-block-image';
+const CELL = '[data-testid="docx-editor"] .layout-table-cell';
 
-test('Format panel: opens beside the doc (no overlay), applies a property, closes', async ({
-  page,
-}) => {
+const pageRight = async (page: Page) => {
+  const b = await page.locator(PAGE).first().boundingBox();
+  return (b?.x ?? 0) + (b?.width ?? 0);
+};
+
+test('Format panel: image chip → panel beside doc, wrap applies', async ({ page }) => {
   const editor = new EditorPage(page);
   await editor.goto();
   await editor.waitForReady();
   await editor.loadDocxFile('fixtures/example-with-image.docx');
   await page.waitForTimeout(1200);
 
-  const pageRight = async () => {
-    const b = await page.locator(PAGE).first().boundingBox();
-    return (b?.x ?? 0) + (b?.width ?? 0);
-  };
-  const rightClosed = await pageRight();
+  const rightClosed = await pageRight(page);
 
-  // 1. select image, open the panel via the rail (no auto-open before this)
+  // 1. select the image — the chip appears, the panel does NOT auto-open
   const img = page.locator(INLINE_IMG).first();
   const ib = await img.boundingBox();
   await img.click({ position: { x: Math.round(ib!.width / 2), y: Math.round(ib!.height / 2) } });
   await page.waitForTimeout(300);
+  await expect(page.locator(IMG_CHIP)).toBeVisible();
   expect(await page.locator(PANEL).count()).toBe(0); // no auto-open
-  await page.locator('[data-testid="rail-properties"]').click();
-  await page.waitForTimeout(400);
 
-  // 2. panel + section visible; page MADE ROOM (flex sibling, not an overlay)
+  // 2. click the chip → panel opens, page MADE ROOM (flex sibling, not overlay)
+  await page.locator(IMG_CHIP).click();
+  await page.waitForTimeout(400);
   await expect(page.locator(PANEL)).toBeVisible();
   await expect(page.locator('[data-testid="properties-image-section"]')).toBeVisible();
-  const rightOpen = await pageRight();
+  const rightOpen = await pageRight(page);
   expect(rightOpen).toBeLessThan(rightClosed - 50); // page shrank to make room
 
   // panel must not cover the image content
@@ -53,17 +68,67 @@ test('Format panel: opens beside the doc (no overlay), applies a property, close
   const imgBox = await img.boundingBox();
   expect((imgBox?.x ?? 0) + (imgBox?.width ?? 0)).toBeLessThan(panelBox?.x ?? 0);
 
-  // 3. property actually APPLIES: inline -> behind moves it to the floating layer
+  // 4. wrap actually APPLIES: inline -> behind moves it to the floating layer
   const inlineBefore = await page.locator(INLINE_IMG).count();
   const floatBefore = await page.locator(FLOATING_IMG).count();
   await page.locator('[data-testid="properties-wrap-behind"]').click();
-  await page.waitForTimeout(600);
-  expect(await page.locator(INLINE_IMG).count()).toBe(inlineBefore - 1);
-  expect(await page.locator(FLOATING_IMG).count()).toBe(floatBefore + 1);
+  await page.waitForTimeout(700);
+  const inlineAfter = await page.locator(INLINE_IMG).count();
+  const floatAfter = await page.locator(FLOATING_IMG).count();
+  expect(inlineAfter).toBe(inlineBefore - 1);
+  expect(floatAfter).toBe(floatBefore + 1);
+});
 
-  // 4. close releases the room
-  await page.locator('[data-testid="rail-properties"]').click();
+test('Format panel: table chip → table section (not empty), delete row applies', async ({
+  page,
+}) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/with-tables.docx');
+  await page.waitForTimeout(1400);
+
+  // 5. click inside a table cell → the table chip appears
+  const cell = page.locator(CELL).first();
+  await cell.click({ position: { x: 12, y: 10 } });
+  await page.waitForTimeout(400);
+  await expect(page.locator(TABLE_CHIP)).toBeVisible();
+  expect(await page.locator(PANEL).count()).toBe(0); // no auto-open
+
+  // 6. click it → panel shows the TABLE section, NOT the empty placeholder
+  await page.locator(TABLE_CHIP).click();
+  await page.waitForTimeout(400);
+  await expect(page.locator(PANEL)).toBeVisible();
+  await expect(page.locator('[data-testid="properties-table-section"]')).toBeVisible();
+  await expect(page.locator(PANEL)).not.toContainText('Select an image, table, or shape');
+
+  // 7. a table op actually APPLIES: delete row reduces the cell count
+  const cellsBefore = await page.locator(CELL).count();
+  await page.locator('[data-testid="properties-table-deleteRow"]').click();
+  await page.waitForTimeout(600);
+  const cellsAfter = await page.locator(CELL).count();
+  expect(cellsAfter).toBeLessThan(cellsBefore);
+});
+
+test('Format panel: only one right-side surface open at a time', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/example-with-image.docx');
+  await page.waitForTimeout(1200);
+
+  // open the Format panel via the image chip
+  const img = page.locator(INLINE_IMG).first();
+  const ib = await img.boundingBox();
+  await img.click({ position: { x: Math.round(ib!.width / 2), y: Math.round(ib!.height / 2) } });
   await page.waitForTimeout(300);
-  expect(await page.locator(PANEL).count()).toBe(0);
-  expect(await pageRight()).toBeGreaterThan(rightOpen + 50);
+  await page.locator(IMG_CHIP).click();
+  await page.waitForTimeout(300);
+  await expect(page.locator(PANEL)).toBeVisible();
+
+  // opening version history from the rail must CLOSE the properties panel
+  await page.locator('[data-testid="rail-history"]').click();
+  await page.waitForTimeout(400);
+  await expect(page.locator('[data-testid="version-history-panel"]')).toBeVisible();
+  await expect(page.locator(PANEL)).toHaveCount(0);
 });

--- a/docx-editor/examples/vite/vite.config.ts
+++ b/docx-editor/examples/vite/vite.config.ts
@@ -1,8 +1,34 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import { copyFileSync, existsSync } from 'fs';
 
 const monorepoRoot = path.resolve(__dirname, '../..');
+
+// GitHub Pages has no SPA rewrite: a hard refresh on a deep client route
+// (e.g. /document/<id>) hits Pages' own 404 because there's no file there.
+// Emitting a 404.html that is a byte-for-byte copy of index.html makes Pages
+// serve the SPA shell for any unmatched path; the client router then reads
+// the preserved URL and renders the right route. (The Docker/gateway deploy
+// already does this server-side via staticHandler's index.html fallback —
+// this brings the Pages demo to parity.)
+function spaFallback404(): Plugin {
+  let outDir = 'dist';
+  return {
+    name: 'spa-fallback-404',
+    apply: 'build',
+    configResolved(config) {
+      outDir = path.resolve(config.root, config.build.outDir);
+    },
+    closeBundle() {
+      const index = path.join(outDir, 'index.html');
+      const notFound = path.join(outDir, '404.html');
+      if (existsSync(index)) {
+        copyFileSync(index, notFound);
+      }
+    },
+  };
+}
 
 async function fetchGitHubStars(): Promise<number | null> {
   try {
@@ -16,7 +42,7 @@ async function fetchGitHubStars(): Promise<number | null> {
 export default defineConfig(async () => {
   const stars = await fetchGitHubStars();
   return {
-    plugins: [react()],
+    plugins: [react(), spaFallback404()],
     root: __dirname,
     resolve: {
       // Force a single React + React-DOM copy across the workspace. After

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -53,6 +53,7 @@ import { SIDEBAR_DOCUMENT_SHIFT } from './sidebar/constants';
 import { VersionHistoryPanel } from './sidebar/VersionHistoryPanel';
 import { PropertiesPanel, type PropertiesTargetKind } from './sidebar/PropertiesPanel';
 import { ImagePropertiesSection } from './sidebar/ImagePropertiesSection';
+import { TablePropertiesSection } from './sidebar/TablePropertiesSection';
 import { useEditHistory } from '../hooks/useEditHistory';
 import { useVersionHistoryCapture } from '../version-history/useVersionHistoryCapture';
 import { downloadServerVersion, type ServerVersionBackend } from '../version-history/server-source';
@@ -870,6 +871,8 @@ interface EditorState {
     borderWidth: number | null;
     borderColor: string | null;
     borderStyle: string | null;
+    width: number | null;
+    height: number | null;
   } | null;
 }
 
@@ -1677,10 +1680,15 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       if (next && commentsCountRef.current === 0) {
         toast.info('No comments yet. Select text and click "Add comment" to start a thread.');
       }
+      // One right-side surface at a time: opening comments closes the rest.
+      if (next) {
+        setShowVersionHistory(false);
+        setShowProperties(false);
+        setShowOutline(false);
+      }
       return next;
     });
     setExpandedSidebarItem(null);
-    setShowVersionHistory(false);
   }, []);
   const handleToggleVersionHistory = useCallback(() => {
     setShowVersionHistory((v) => {
@@ -1688,6 +1696,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       if (next) {
         setShowCommentsSidebar(false);
         setExpandedSidebarItem(null);
+        setShowProperties(false);
+        setShowOutline(false);
       }
       return next;
     });
@@ -2386,9 +2396,13 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       setShowChatPanel(which === 'chat');
       setShowVersionHistory(which === 'history');
       setShowProperties(which === 'properties');
-      if (which === 'history' || which === 'properties') {
+      // Only ONE right-side surface is ever open: outline (TOC), comments,
+      // properties, history. Opening any of the docked panels closes the
+      // others (outline included — it was previously left open alongside).
+      if (which !== 'none') {
         setShowCommentsSidebar(false);
         setExpandedSidebarItem(null);
+        setShowOutline(false);
       }
       if (which !== 'aiSuggestion') setAiSuggestion(null);
     },
@@ -2962,6 +2976,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
             borderWidth: (selectedNode.attrs.borderWidth as number) ?? null,
             borderColor: (selectedNode.attrs.borderColor as string) ?? null,
             borderStyle: (selectedNode.attrs.borderStyle as string) ?? null,
+            width: (selectedNode.attrs.width as number) ?? null,
+            height: (selectedNode.attrs.height as number) ?? null,
           };
         }
       }
@@ -3702,6 +3718,11 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         if (view) {
           setHeadingInfos(collectHeadings(view.state.doc));
         }
+        // One right-side surface at a time: opening the outline closes the rest.
+        setShowCommentsSidebar(false);
+        setExpandedSidebarItem(null);
+        setShowVersionHistory(false);
+        setShowProperties(false);
       }
       return !prev;
     });
@@ -3806,6 +3827,30 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       focusActiveEditor();
     },
     [getActiveEditorView, focusActiveEditor, state.pmImageContext, state.zoom]
+  );
+
+  // Set explicit image width/height from the Format panel's size inputs.
+  // Same node-markup path the resize handles use, so the painted pages and
+  // round-trip stay consistent. Re-selects the image so the panel keeps it.
+  const handleImageSetSize = useCallback(
+    (width: number, height: number) => {
+      const view = getActiveEditorView();
+      if (!view || !state.pmImageContext) return;
+      const pos = state.pmImageContext.pos;
+      const node = view.state.doc.nodeAt(pos);
+      if (!node || node.type.name !== 'image') return;
+      const w = Math.max(8, Math.min(2000, Math.round(width)));
+      const h = Math.max(8, Math.min(2000, Math.round(height)));
+      const tr = view.state.tr.setNodeMarkup(pos, undefined, {
+        ...node.attrs,
+        width: w,
+        height: h,
+      });
+      view.dispatch(tr);
+      pagedEditorRef.current?.setSelection(pos);
+      focusActiveEditor();
+    },
+    [getActiveEditorView, focusActiveEditor, state.pmImageContext]
   );
 
   // Handle image transform (rotate/flip)
@@ -8078,6 +8123,7 @@ body { background: white; }
                           pluginOverlays={pluginOverlays}
                           onHyperlinkClick={handleHyperlinkClick}
                           onContextMenu={handleContextMenu}
+                          onOpenProperties={() => openRightPanel('properties')}
                           commentsSidebarOpen={sidebarOpen}
                           onAnchorPositionsChange={setAnchorPositions}
                           onTotalPagesChange={(totalPages) => {
@@ -8343,8 +8389,14 @@ body { background: white; }
                           {propsKind === 'image' && state.pmImageContext && (
                             <ImagePropertiesSection
                               wrapType={state.pmImageContext.wrapType}
+                              width={state.pmImageContext.width}
+                              height={state.pmImageContext.height}
                               onSetWrap={handleImageWrapType}
+                              onSetSize={handleImageSetSize}
                             />
+                          )}
+                          {propsKind === 'table' && (
+                            <TablePropertiesSection onAction={handleTableAction} />
                           )}
                         </PropertiesPanel>
                       );

--- a/docx-editor/packages/react/src/components/sidebar/ImagePropertiesSection.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/ImagePropertiesSection.tsx
@@ -1,22 +1,102 @@
 /**
- * Image section of the Format/Properties panel. First section built on the
- * panel base — proves the pattern (contextual, grouped, live). Reuses the
- * editor's existing image wrap command; size is shown read-only for now
- * (resize is via the on-canvas handles). Future: editable W/H, position,
- * border, recolor — all as groups in this same section.
+ * Image section of the Format/Properties panel — Google-Docs "Image options"
+ * model: text-wrapping as labeled icon tiles (the selected mode highlighted),
+ * plus editable width/height. One scannable surface instead of a wall of text
+ * options. Reuses the editor's existing wrap + resize commands; this is a
+ * presentation layer, not a new command path.
  */
-import type { CSSProperties } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 
-const WRAP_OPTIONS = [
-  { value: 'inline', label: 'In line' },
-  { value: 'squareLeft', label: 'Wrap text — left' },
-  { value: 'squareRight', label: 'Wrap text — right' },
-  { value: 'behind', label: 'Behind text' },
-  { value: 'inFront', label: 'In front of text' },
-] as const;
+interface WrapOption {
+  value: string;
+  label: string;
+  /** 24×24 icon path describing the wrap mode. */
+  icon: JSX.Element;
+}
+
+// Compact glyphs that read at a glance — text lines + a block standing for the
+// image, arranged to suggest each wrap relationship.
+const WRAP_OPTIONS: WrapOption[] = [
+  {
+    value: 'inline',
+    label: 'In line',
+    icon: (
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <rect x="3" y="9" width="6" height="6" rx="1" fill="currentColor" />
+        <path
+          d="M11 10h10M11 14h10"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    value: 'squareLeft',
+    label: 'Wrap left',
+    icon: (
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <rect x="3" y="6" width="8" height="8" rx="1" fill="currentColor" />
+        <path
+          d="M13 7h8M13 11h8M3 16h18M3 20h18"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    value: 'squareRight',
+    label: 'Wrap right',
+    icon: (
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <rect x="13" y="6" width="8" height="8" rx="1" fill="currentColor" />
+        <path
+          d="M3 7h8M3 11h8M3 16h18M3 20h18"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    value: 'behind',
+    label: 'Behind text',
+    icon: (
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <rect x="7" y="6" width="10" height="10" rx="1" fill="currentColor" opacity="0.35" />
+        <path
+          d="M3 8h18M3 12h18M3 16h18"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+      </svg>
+    ),
+  },
+  {
+    value: 'inFront',
+    label: 'In front',
+    icon: (
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path
+          d="M3 8h18M3 12h18M3 16h18"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          opacity="0.5"
+        />
+        <rect x="7" y="6" width="10" height="10" rx="1" fill="currentColor" />
+      </svg>
+    ),
+  },
+];
 
 const GROUP_HEADER: CSSProperties = {
-  padding: '12px 16px 6px',
+  padding: '14px 16px 8px',
   fontSize: 11,
   textTransform: 'uppercase',
   letterSpacing: '0.04em',
@@ -24,32 +104,63 @@ const GROUP_HEADER: CSSProperties = {
   fontWeight: 600,
 };
 
-const OPTION_BTN = (active: boolean): CSSProperties => ({
-  display: 'block',
-  width: '100%',
-  textAlign: 'left',
-  padding: '7px 16px',
-  fontSize: 13,
-  background: active ? 'var(--doc-primary-light, #e8f0fe)' : 'transparent',
+const TILE_GRID: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(5, 1fr)',
+  gap: 6,
+  padding: '0 12px',
+};
+
+const tile = (active: boolean): CSSProperties => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 4,
+  padding: '8px 2px 6px',
+  fontSize: 10.5,
+  lineHeight: 1.2,
+  textAlign: 'center',
   color: active ? 'var(--doc-primary, #1a73e8)' : 'var(--doc-text, #202124)',
-  border: 'none',
+  background: active ? 'var(--doc-primary-light, #e8f0fe)' : 'transparent',
+  border: active
+    ? '1.5px solid var(--doc-primary, #1a73e8)'
+    : '1.5px solid var(--doc-border, #dadce0)',
+  borderRadius: 8,
   cursor: 'pointer',
 });
 
 const SIZE_ROW: CSSProperties = {
-  padding: '6px 16px 14px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '4px 16px 6px',
+};
+
+const sizeInput: CSSProperties = {
+  width: 64,
+  padding: '6px 8px',
   fontSize: 13,
+  border: '1px solid var(--doc-border, #dadce0)',
+  borderRadius: 6,
+  background: 'var(--doc-surface, #fff)',
   color: 'var(--doc-text, #202124)',
+};
+
+const sizeLabel: CSSProperties = {
+  fontSize: 12,
+  color: 'var(--doc-text-muted)',
 };
 
 export interface ImagePropertiesSectionProps {
   /** Current wrap mode of the selected image. */
   wrapType: string;
-  /** Rendered width/height in px (read-only display). */
-  width?: number;
-  height?: number;
+  /** Current rendered width/height in px (drives the editable inputs). */
+  width?: number | null;
+  height?: number | null;
   /** Apply a wrap mode (host wires this to setImageWrapType). */
   onSetWrap: (value: string) => void;
+  /** Apply an explicit width/height (host wires this to setNodeMarkup). */
+  onSetSize?: (width: number, height: number) => void;
 }
 
 export function ImagePropertiesSection({
@@ -57,11 +168,46 @@ export function ImagePropertiesSection({
   width,
   height,
   onSetWrap,
+  onSetSize,
 }: ImagePropertiesSectionProps) {
+  // Local, editable copies so typing doesn't fight the live node attrs. They
+  // re-sync whenever the selected image (its size) changes underneath.
+  const [w, setW] = useState<string>(width != null ? String(Math.round(width)) : '');
+  const [h, setH] = useState<string>(height != null ? String(Math.round(height)) : '');
+  const [lockAspect, setLockAspect] = useState(true);
+
+  useEffect(() => {
+    setW(width != null ? String(Math.round(width)) : '');
+    setH(height != null ? String(Math.round(height)) : '');
+  }, [width, height]);
+
+  const aspect = width && height ? width / height : null;
+
+  const commitWidth = () => {
+    const nw = Number(w);
+    if (!Number.isFinite(nw) || nw <= 0 || !onSetSize) return;
+    const nh = lockAspect && aspect ? Math.round(nw / aspect) : Number(h) || nw;
+    setH(String(nh));
+    onSetSize(nw, nh);
+  };
+  const commitHeight = () => {
+    const nh = Number(h);
+    if (!Number.isFinite(nh) || nh <= 0 || !onSetSize) return;
+    const nw = lockAspect && aspect ? Math.round(nh * aspect) : Number(w) || nh;
+    setW(String(nw));
+    onSetSize(nw, nh);
+  };
+  const onKey = (e: React.KeyboardEvent, commit: () => void) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commit();
+    }
+  };
+
   return (
     <div data-testid="properties-image-section">
       <div style={GROUP_HEADER}>Text wrapping</div>
-      <div role="group" aria-label="Text wrapping">
+      <div style={TILE_GRID} role="group" aria-label="Text wrapping">
         {WRAP_OPTIONS.map((o) => {
           const active = wrapType === o.value;
           return (
@@ -70,28 +216,73 @@ export function ImagePropertiesSection({
               type="button"
               role="menuitemradio"
               aria-checked={active}
-              style={OPTION_BTN(active)}
+              aria-label={o.label}
+              title={o.label}
+              style={tile(active)}
               data-testid={`properties-wrap-${o.value}`}
               onMouseDown={(e) => {
                 e.preventDefault();
                 onSetWrap(o.value);
               }}
             >
-              {active ? '✓ ' : ''}
-              {o.label}
+              {o.icon}
+              <span>{o.label}</span>
             </button>
           );
         })}
       </div>
-      {(width != null || height != null) && (
+
+      {onSetSize && (width != null || height != null) && (
         <>
           <div style={GROUP_HEADER}>Size</div>
           <div style={SIZE_ROW} data-testid="properties-image-size">
-            {Math.round(width ?? 0)} × {Math.round(height ?? 0)} px
-            <div style={{ fontSize: 11, color: 'var(--doc-text-muted)', marginTop: 2 }}>
-              Drag the corner handles on the image to resize.
-            </div>
+            <label style={sizeLabel}>
+              W
+              <input
+                style={{ ...sizeInput, marginLeft: 6 }}
+                type="number"
+                min={8}
+                max={2000}
+                value={w}
+                data-testid="properties-image-width"
+                onChange={(e) => setW(e.target.value)}
+                onBlur={commitWidth}
+                onKeyDown={(e) => onKey(e, commitWidth)}
+              />
+            </label>
+            <label style={sizeLabel}>
+              H
+              <input
+                style={{ ...sizeInput, marginLeft: 6 }}
+                type="number"
+                min={8}
+                max={2000}
+                value={h}
+                data-testid="properties-image-height"
+                onChange={(e) => setH(e.target.value)}
+                onBlur={commitHeight}
+                onKeyDown={(e) => onKey(e, commitHeight)}
+              />
+            </label>
           </div>
+          <label
+            style={{
+              ...sizeLabel,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '0 16px 14px',
+              cursor: 'pointer',
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={lockAspect}
+              data-testid="properties-image-lock-aspect"
+              onChange={(e) => setLockAspect(e.target.checked)}
+            />
+            Lock aspect ratio
+          </label>
         </>
       )}
     </div>

--- a/docx-editor/packages/react/src/components/sidebar/TablePropertiesSection.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/TablePropertiesSection.tsx
@@ -1,0 +1,105 @@
+/**
+ * Table section of the Format/Properties panel. Surfaces the core table
+ * structure operations (insert / delete rows & columns, merge / split cells,
+ * delete table) in the contextual right rail — the same actions that were
+ * previously only reachable from the toolbar grid dropdown. Grouped like the
+ * Google-Docs table menu so the panel is the single home for object
+ * properties. Border / shading / cell-alignment groups plug in here next.
+ *
+ * Each button dispatches through the editor's existing `handleTableAction`,
+ * so behaviour is identical to the toolbar path — this is purely a relocation
+ * of the controls into the panel, not a new command surface.
+ */
+import type { CSSProperties } from 'react';
+import type { TableAction } from '../ui/TableToolbar';
+
+const GROUP_HEADER: CSSProperties = {
+  padding: '12px 16px 6px',
+  fontSize: 11,
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+  color: 'var(--doc-text-muted)',
+  fontWeight: 600,
+};
+
+const ROW_BTN = (danger: boolean): CSSProperties => ({
+  display: 'block',
+  width: '100%',
+  textAlign: 'left',
+  padding: '7px 16px',
+  fontSize: 13,
+  background: 'transparent',
+  color: danger ? 'var(--doc-danger, #d93025)' : 'var(--doc-text, #202124)',
+  border: 'none',
+  cursor: 'pointer',
+});
+
+interface Item {
+  action: Extract<TableAction, string>;
+  label: string;
+  danger?: boolean;
+}
+
+const GROUPS: { header: string; items: Item[] }[] = [
+  {
+    header: 'Rows',
+    items: [
+      { action: 'addRowAbove', label: 'Insert row above' },
+      { action: 'addRowBelow', label: 'Insert row below' },
+      { action: 'deleteRow', label: 'Delete row', danger: true },
+    ],
+  },
+  {
+    header: 'Columns',
+    items: [
+      { action: 'addColumnLeft', label: 'Insert column left' },
+      { action: 'addColumnRight', label: 'Insert column right' },
+      { action: 'deleteColumn', label: 'Delete column', danger: true },
+    ],
+  },
+  {
+    header: 'Cells',
+    items: [
+      { action: 'mergeCells', label: 'Merge cells' },
+      { action: 'splitCell', label: 'Split cell' },
+    ],
+  },
+  {
+    header: 'Table',
+    items: [{ action: 'deleteTable', label: 'Delete table', danger: true }],
+  },
+];
+
+export interface TablePropertiesSectionProps {
+  /** Dispatch a table action (host wires this to handleTableAction). */
+  onAction: (action: TableAction) => void;
+}
+
+export function TablePropertiesSection({ onAction }: TablePropertiesSectionProps) {
+  return (
+    <div data-testid="properties-table-section">
+      {GROUPS.map((group) => (
+        <div key={group.header}>
+          <div style={GROUP_HEADER}>{group.header}</div>
+          <div role="group" aria-label={group.header}>
+            {group.items.map((item) => (
+              <button
+                key={item.action}
+                type="button"
+                role="menuitem"
+                style={ROW_BTN(!!item.danger)}
+                data-testid={`properties-table-${item.action}`}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onAction(item.action);
+                }}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/docx-editor/packages/react/src/paged-editor/ImageSelectionOverlay.tsx
+++ b/docx-editor/packages/react/src/paged-editor/ImageSelectionOverlay.tsx
@@ -63,6 +63,9 @@ export interface ImageSelectionOverlayProps {
    *  paged-editor's contextmenu handler never fires for it — the parent wires
    *  this prop to route through to the same image-context-menu opener. */
   onContextMenu?: (e: React.MouseEvent) => void;
+  /** Open the Format panel for this image. Renders the on-object "Format"
+   *  chip at the selection's top-right corner when provided. */
+  onOpenProperties?: () => void;
 }
 
 // =============================================================================
@@ -170,6 +173,7 @@ export function ImageSelectionOverlay({
   onDragStart,
   onDragEnd,
   onContextMenu,
+  onOpenProperties,
 }: ImageSelectionOverlayProps): React.ReactElement | null {
   const [isResizing, setIsResizing] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
@@ -492,6 +496,57 @@ export function ImageSelectionOverlay({
         style={{ left: left - HANDLE_HALF, top: top + height - HANDLE_HALF }}
         onMouseDown={handleResizeStart}
       />
+
+      {/* On-object "Format" chip — top-right corner of the selection.
+          Opens the contextual Format panel for this image. Hidden while
+          actively resizing/dragging so it doesn't fight the gesture. */}
+      {onOpenProperties && !isResizing && !isDragging && (
+        <button
+          type="button"
+          data-testid="image-format-chip"
+          aria-label="Format image"
+          title="Format"
+          onMouseDown={(e) => {
+            // Don't let the mousedown reach the image body (would start a drag)
+            // or the hidden PM view (would move the caret).
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onOpenProperties();
+          }}
+          style={{
+            position: 'absolute',
+            left: left + width - 4,
+            top: top - 14,
+            transform: 'translateX(-100%)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            height: 26,
+            padding: '0 10px',
+            fontSize: 12,
+            fontWeight: 600,
+            lineHeight: '26px',
+            color: '#fff',
+            background: ACCENT_COLOR,
+            border: 'none',
+            borderRadius: 13,
+            boxShadow: '0 1px 4px rgba(0,0,0,0.3)',
+            cursor: 'pointer',
+            pointerEvents: 'auto',
+            zIndex: 21,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z" />
+          </svg>
+          Format
+        </button>
+      )}
 
       {/* Dimension indicator during resize */}
       {isResizing && (

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -39,6 +39,7 @@ import { usePinchZoom } from '../components/hooks/usePinchZoom';
 import { ImageSelectionOverlay, type ImageSelectionInfo } from './ImageSelectionOverlay';
 import { DecorationLayer } from './DecorationLayer';
 import { spellcheckPluginKey } from '@eigenpal/docx-core/prosemirror/extensions';
+import { getTableContext } from '@eigenpal/docx-core/prosemirror';
 
 // Layout engine
 import {
@@ -348,6 +349,10 @@ export interface PagedEditorProps {
      */
     spellcheck?: { from: number; to: number; word: string } | null;
   }) => void;
+  /** Open the contextual Format panel for the currently-selected object
+   *  (image or table). Wired to the on-object "Format" chip. The host
+   *  derives the panel's kind from its own selection context. */
+  onOpenProperties?: () => void;
   /** Callback with pre-computed Y positions for comment/tracked-change anchors (for sidebar positioning without DOM queries). */
   onAnchorPositionsChange?: (positions: Map<string, number>) => void;
   /**
@@ -1386,6 +1391,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       scrollContainerRef: scrollContainerRefProp,
       onHyperlinkClick,
       onContextMenu,
+      onOpenProperties,
       onAnchorPositionsChange,
       onTotalPagesChange,
       resolvedCommentIds,
@@ -1483,6 +1489,11 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     // Image selection state
     const [selectedImageInfo, setSelectedImageInfo] = useState<ImageSelectionInfo | null>(null);
     const isImageInteractingRef = useRef(false);
+
+    // Table "Format" chip — overlay-relative {x,y} of the top-right corner of
+    // the table containing the caret, or null when the caret isn't in a table.
+    // Mirrors the image chip; opens the same Format panel via onOpenProperties.
+    const [tableChipPos, setTableChipPos] = useState<{ x: number; y: number } | null>(null);
 
     /** Build ImageSelectionInfo from a DOM element with data-pm-start */
     const buildImageSelectionInfo = useCallback(
@@ -2321,6 +2332,48 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               }
             }
           }
+        }
+
+        // Table "Format" chip — anchor to the painted table containing the
+        // caret (top-right corner), mirroring the image chip. Cleared when the
+        // caret leaves any table. getTableContext is the authoritative
+        // in-table test; the DOM lookup only locates the painted box.
+        {
+          const pagesEl = pagesContainerRef.current;
+          const viewportEl = pagesEl?.parentElement;
+          let nextChip: { x: number; y: number } | null = null;
+          if (pagesEl && viewportEl) {
+            let inTable = false;
+            try {
+              inTable = getTableContext(state).isInTable;
+            } catch {
+              inTable = false;
+            }
+            if (inTable) {
+              // Painted cell enclosing the caret = greatest data-pm-start <= from.
+              const cells = pagesEl.querySelectorAll('.layout-table-cell[data-pm-start]');
+              let bestCell: HTMLElement | null = null;
+              let bestStart = -1;
+              for (const c of Array.from(cells)) {
+                const s = Number((c as HTMLElement).dataset.pmStart);
+                if (!Number.isNaN(s) && s <= from && s > bestStart) {
+                  bestStart = s;
+                  bestCell = c as HTMLElement;
+                }
+              }
+              const tableEl = bestCell?.closest('.layout-table') as HTMLElement | null;
+              if (tableEl) {
+                const tRect = tableEl.getBoundingClientRect();
+                const vRect = viewportEl.getBoundingClientRect();
+                nextChip = { x: tRect.right - vRect.left, y: tRect.top - vRect.top };
+              }
+            }
+          }
+          setTableChipPos((prev) => {
+            if (prev === nextChip) return prev;
+            if (prev && nextChip && prev.x === nextChip.x && prev.y === nextChip.y) return prev;
+            return nextChip;
+          });
         }
 
         if (!layout || blocks.length === 0) return;
@@ -4399,7 +4452,62 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             onDragStart={handleImageDragStart}
             onDragEnd={handleImageDragEnd}
             onContextMenu={handlePagesContextMenu}
+            onOpenProperties={onOpenProperties}
           />
+
+          {/* Table "Format" chip — top-right of the table containing the
+              caret. Opens the same contextual Format panel as the image chip
+              (host derives table vs image from its selection context). */}
+          {onOpenProperties && tableChipPos && isFocused && (
+            <button
+              type="button"
+              data-testid="table-format-chip"
+              aria-label="Format table"
+              title="Format"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onOpenProperties();
+              }}
+              style={{
+                position: 'absolute',
+                left: tableChipPos.x,
+                top: tableChipPos.y - 14,
+                transform: 'translateX(-100%)',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+                height: 26,
+                padding: '0 10px',
+                fontSize: 12,
+                fontWeight: 600,
+                lineHeight: '26px',
+                color: '#fff',
+                background: '#2563eb',
+                border: 'none',
+                borderRadius: 13,
+                boxShadow: '0 1px 4px rgba(0,0,0,0.3)',
+                cursor: 'pointer',
+                zIndex: 201,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z" />
+              </svg>
+              Format
+            </button>
+          )}
 
           {/* Table quick action insert button */}
           {tableInsertButton && (


### PR DESCRIPTION
Selecting an image or table shows a small **"Format" chip** at the object's top-right; clicking it opens the contextual Format panel. Nothing is dumped into the toolbar anymore. (Builds on the merged flex-sibling panel; this adds the real entry point + the table section + the image redesign.)

**Image panel** — Google-Docs "Image options": text-wrapping as labeled icon tiles (selected highlighted) + editable W×H with lock-aspect. Replaces the unreadable plain text list.

**Table panel** — grouped Rows / Columns / Cells / Table ops (insert/delete row & column, merge/split, delete table) instead of the empty placeholder.

**One right-side surface at a time** — outline / comments / properties / history are now mutually exclusive in both directions (opening any closes the rest).

**404 on hard-refresh** — a hard refresh on a deep route (`/document/<id>`) on GitHub Pages hit Pages' own 404. Now emits `404.html` as the SPA shell so the client router resolves the preserved URL. (The Docker/gateway deploy already had this via the `index.html` fallback.)

**Complete e2e** (drives the real chip flow, asserts behaviour not testids): image chip → panel beside doc (page makes room, no overlap) → wrap applies; table chip → table section (not empty) → delete row applies; only one right-side surface stays open. Both panels screenshot-verified.

Gate: typecheck · format · lint 0 errors · smoke · comments-sidebar · e2e — all green.