### PR TITLE
feat(ux): image Format panel — Arrange (rotate/flip) + Border + Alt text

### DIFF
--- a/docs/internal/24-editability-tracker.md
+++ b/docs/internal/24-editability-tracker.md
@@ -35,7 +35,8 @@ resize). Treat every row as **verified by Playwright probe**, not by reading cod
 | P3 | ⬜ **Header/footer caret feedback** | Low | Double-click-to-edit works; caret not painted on the page-behind during edit. |
 | P3 | ⬜ **Footnote click-to-edit** | Low-Med | Clicking footnote text falls through to body (not in `page.fragments`). |
 | P3 | ⬜ **Floating image in table cell — click** | Low | `findImageElement` matches `layout-page-floating-image` but not `layout-cell-floating-image`. |
-| P3 | ⬜ **Image UI: dist-margins / rotate-flip / border / topAndBottom wrap** | Low | Attrs exist + round-trip; no UI to edit. |
+| P3 | 🟡 **Image UI: rotate-flip / border / size** | Low | ✅ rotate/flip + border + editable W×H + alt text now in the **Format panel** image section, opened via the on-object Format chip (#55/#56). Border previously round-tripped but never **painted** — now wired through the flow-block → renderParagraph/renderImage (render-only, no serializer change). Remaining: dist-margins UI + `topAndBottom` wrap tile. |
+| — | **Format panel (image+table) shipped** | — | On-object Format chip → contextual panel (flex sibling, no overlap). Image = Google-Docs icon picker (wrap/size/arrange/border/alt); table = grouped Rows/Cols/Cells/Table ops. One right-side surface at a time. Complete image+table e2e. (#55, #56) |
 | P3 | ⬜ **Cell-range selection polish / col-resize width constraint** | Low | Multi-cell selection lacks anchor styling; col-resize can breach fixed table width. |
 
 ## Insertion (user's main ask: "only there, can't create")

--- a/docx-editor/e2e/tests/properties-panel.spec.ts
+++ b/docx-editor/e2e/tests/properties-panel.spec.ts
@@ -79,6 +79,41 @@ test('Format panel: image chip → panel beside doc, wrap applies', async ({ pag
   expect(floatAfter).toBe(floatBefore + 1);
 });
 
+test('Format panel: image Arrange (rotate) + Border apply to the document', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/example-with-image.docx');
+  await page.waitForTimeout(1200);
+
+  const img = page.locator(INLINE_IMG).first();
+  const ib = await img.boundingBox();
+  await img.click({ position: { x: Math.round(ib!.width / 2), y: Math.round(ib!.height / 2) } });
+  await page.waitForTimeout(300);
+  await page.locator(IMG_CHIP).click();
+  await page.waitForTimeout(400);
+  await expect(page.locator('[data-testid="properties-image-section"]')).toBeVisible();
+
+  const paintedImg = () => page.locator(INLINE_IMG).first();
+
+  // Rotate right → a rotate() transform appears on the painted image.
+  await page.locator('[data-testid="properties-image-rotateCW"]').click();
+  await page.waitForTimeout(500);
+  const transform = await paintedImg().evaluate(
+    (el) => (el as HTMLElement).style.transform || getComputedStyle(el).transform
+  );
+  expect(transform).not.toBe('');
+  expect(transform.toLowerCase()).toContain('rotate');
+
+  // Border "Medium" → painted image gains a visible border width.
+  await page.locator('[data-testid="properties-image-border-medium"]').click();
+  await page.waitForTimeout(500);
+  const borderW = await paintedImg().evaluate((el) =>
+    parseFloat(getComputedStyle(el as HTMLElement).borderTopWidth || '0')
+  );
+  expect(borderW).toBeGreaterThan(0);
+});
+
 test('Format panel: table chip → table section (not empty), delete row applies', async ({
   page,
 }) => {

--- a/docx-editor/packages/core/src/layout-bridge/toFlowBlocks.ts
+++ b/docx-editor/packages/core/src/layout-bridge/toFlowBlocks.ts
@@ -688,6 +688,9 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
         height: constrained.height,
         alt: attrs.alt as string | undefined,
         transform: attrs.transform as string | undefined,
+        borderWidth: attrs.borderWidth as number | undefined,
+        borderColor: attrs.borderColor as string | undefined,
+        borderStyle: attrs.borderStyle as string | undefined,
         // Preserve wrap attributes for proper rendering
         wrapType: attrs.wrapType as string | undefined,
         displayMode: attrs.displayMode as 'inline' | 'block' | 'float' | undefined,
@@ -790,6 +793,9 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
             height: sdtConstrained.height,
             alt: attrs.alt as string | undefined,
             transform: attrs.transform as string | undefined,
+            borderWidth: attrs.borderWidth as number | undefined,
+            borderColor: attrs.borderColor as string | undefined,
+            borderStyle: attrs.borderStyle as string | undefined,
             wrapType: attrs.wrapType as string | undefined,
             displayMode: attrs.displayMode as 'inline' | 'block' | 'float' | undefined,
             cssFloat: attrs.cssFloat as 'left' | 'right' | 'none' | undefined,
@@ -1490,6 +1496,9 @@ function convertImage(node: PMNode, startPos: number, pageContentHeight?: number
     height: constrained.height,
     alt: attrs.alt as string | undefined,
     transform: attrs.transform as string | undefined,
+    borderWidth: attrs.borderWidth as number | undefined,
+    borderColor: attrs.borderColor as string | undefined,
+    borderStyle: attrs.borderStyle as string | undefined,
     anchor: shouldAnchor
       ? {
           isAnchored: true,

--- a/docx-editor/packages/core/src/layout-engine/types.ts
+++ b/docx-editor/packages/core/src/layout-engine/types.ts
@@ -156,6 +156,10 @@ export type ImageRun = {
   alt?: string;
   /** CSS transform string (rotation, flip) */
   transform?: string;
+  /** Picture border (round-trips via image node attrs; painted by renderImage) */
+  borderWidth?: number;
+  borderColor?: string;
+  borderStyle?: string;
   /** Position for floating/anchored images */
   position?: ImageRunPosition;
   /** Wrap type from DOCX (inline, square, tight, through, topAndBottom, etc.) */
@@ -435,6 +439,10 @@ export type ImageBlock = {
   alt?: string;
   /** CSS transform string (rotation, flip) */
   transform?: string;
+  /** Picture border (round-trips via image node attrs; painted by renderImage) */
+  borderWidth?: number;
+  borderColor?: string;
+  borderStyle?: string;
   anchor?: {
     isAnchored?: boolean;
     offsetH?: number;

--- a/docx-editor/packages/core/src/layout-painter/renderImage.ts
+++ b/docx-editor/packages/core/src/layout-painter/renderImage.ts
@@ -148,6 +148,15 @@ export function renderImageFragment(
     imgEl.style.transform = block.transform;
   }
 
+  // Picture border (set via the Format panel; round-trips on the image node).
+  // Painted on the container so it frames the image box, not the rotated img.
+  if (block.borderWidth && block.borderWidth > 0) {
+    containerEl.style.border = `${block.borderWidth}px ${block.borderStyle || 'solid'} ${
+      block.borderColor || '#000000'
+    }`;
+    containerEl.style.boxSizing = 'border-box';
+  }
+
   // Prevent dragging
   imgEl.draggable = false;
 

--- a/docx-editor/packages/core/src/layout-painter/renderParagraph.ts
+++ b/docx-editor/packages/core/src/layout-painter/renderParagraph.ts
@@ -595,6 +595,13 @@ export function renderInlineImageRun(run: ImageRun, doc: Document): HTMLElement 
     // happens to match, but be explicit so future transforms can't drift.
     img.style.transformOrigin = 'center center';
   }
+  // Picture border (set via the Format panel; round-trips on the image node).
+  if (run.borderWidth && run.borderWidth > 0) {
+    img.style.border = `${run.borderWidth}px ${run.borderStyle || 'solid'} ${
+      run.borderColor || '#000000'
+    }`;
+    img.style.boxSizing = 'border-box';
+  }
   if (hasImageVisualAttrs(run)) applyImageVisualAttrs(img, run);
 
   const deg = rotationDegrees(run.transform);
@@ -688,6 +695,13 @@ function renderBlockImage(run: ImageRun, doc: Document): HTMLElement {
   if (run.transform) {
     img.style.transform = run.transform;
     img.style.transformOrigin = 'center center';
+  }
+  // Picture border (set via the Format panel; round-trips on the image node).
+  if (run.borderWidth && run.borderWidth > 0) {
+    img.style.border = `${run.borderWidth}px ${run.borderStyle || 'solid'} ${
+      run.borderColor || '#000000'
+    }`;
+    img.style.boxSizing = 'border-box';
   }
   if (hasImageVisualAttrs(run)) applyImageVisualAttrs(img, run);
 

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -69,6 +69,7 @@ import { CommentMarginMarkers } from './CommentMarginMarkers';
 import { useCommentSidebarItems, type CommentCallbacks } from '../hooks/useCommentSidebarItems';
 import { useTrackedChanges } from '../hooks/useTrackedChanges';
 import type { EditorState as PMEditorState } from 'prosemirror-state';
+import { NodeSelection } from 'prosemirror-state';
 import type { Mark as PMMark } from 'prosemirror-model';
 import { undo as pmUndo, redo as pmRedo } from 'prosemirror-history';
 import type { ReactSidebarItem } from '../plugin-api/types';
@@ -3829,6 +3830,24 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     [getActiveEditorView, focusActiveEditor, state.pmImageContext, state.zoom]
   );
 
+  // Re-select the image as a NODE selection after a Format-panel edit. A plain
+  // text selection at `pos` would NOT rebuild pmImageContext, so the panel
+  // would fall back to its empty "select an object" state — this keeps it on
+  // the image (the "keep selection through edits" follow-up).
+  const reselectImageNode = useCallback(
+    (pos: number) => {
+      const view = getActiveEditorView();
+      if (!view) return;
+      try {
+        const sel = NodeSelection.create(view.state.doc, pos);
+        view.dispatch(view.state.tr.setSelection(sel));
+      } catch {
+        // pos no longer points at a selectable node; ignore.
+      }
+    },
+    [getActiveEditorView]
+  );
+
   // Set explicit image width/height from the Format panel's size inputs.
   // Same node-markup path the resize handles use, so the painted pages and
   // round-trip stay consistent. Re-selects the image so the panel keeps it.
@@ -3847,10 +3866,55 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         height: h,
       });
       view.dispatch(tr);
-      pagedEditorRef.current?.setSelection(pos);
+      reselectImageNode(pos);
       focusActiveEditor();
     },
-    [getActiveEditorView, focusActiveEditor, state.pmImageContext]
+    [getActiveEditorView, focusActiveEditor, state.pmImageContext, reselectImageNode]
+  );
+
+  // Re-select the image as a NODE selection after a Format-panel edit. A plain
+  // text selection at `pos` would NOT rebuild pmImageContext, so the panel
+  // would fall back to its empty "select an object" state — this keeps it on
+  // the image (the "keep selection through edits" follow-up).
+  // Set image border (width/color/style) from the Format panel. Same node
+  // attrs the image-properties dialog uses, so the two stay consistent.
+  const handleImageSetBorder = useCallback(
+    (borderWidth: number | null, borderColor: string | null, borderStyle: string | null) => {
+      const view = getActiveEditorView();
+      if (!view || !state.pmImageContext) return;
+      const pos = state.pmImageContext.pos;
+      const node = view.state.doc.nodeAt(pos);
+      if (!node || node.type.name !== 'image') return;
+      const tr = view.state.tr.setNodeMarkup(pos, undefined, {
+        ...node.attrs,
+        borderWidth,
+        borderColor,
+        borderStyle,
+      });
+      view.dispatch(tr);
+      reselectImageNode(pos);
+      focusActiveEditor();
+    },
+    [getActiveEditorView, focusActiveEditor, state.pmImageContext, reselectImageNode]
+  );
+
+  // Set image alt text (accessibility) from the Format panel.
+  const handleImageSetAlt = useCallback(
+    (alt: string) => {
+      const view = getActiveEditorView();
+      if (!view || !state.pmImageContext) return;
+      const pos = state.pmImageContext.pos;
+      const node = view.state.doc.nodeAt(pos);
+      if (!node || node.type.name !== 'image') return;
+      const tr = view.state.tr.setNodeMarkup(pos, undefined, {
+        ...node.attrs,
+        alt: alt.trim() ? alt : null,
+      });
+      view.dispatch(tr);
+      reselectImageNode(pos);
+      focusActiveEditor();
+    },
+    [getActiveEditorView, focusActiveEditor, state.pmImageContext, reselectImageNode]
   );
 
   // Handle image transform (rotate/flip)
@@ -3898,9 +3962,11 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         transform: newTransform,
       });
       view.dispatch(tr.scrollIntoView());
+      // Keep the image selected so the Format panel stays on it after the edit.
+      reselectImageNode(pos);
       focusActiveEditor();
     },
-    [getActiveEditorView, focusActiveEditor, state.pmImageContext]
+    [getActiveEditorView, focusActiveEditor, state.pmImageContext, reselectImageNode]
   );
 
   // Apply image position changes
@@ -8391,8 +8457,14 @@ body { background: white; }
                               wrapType={state.pmImageContext.wrapType}
                               width={state.pmImageContext.width}
                               height={state.pmImageContext.height}
+                              borderWidth={state.pmImageContext.borderWidth}
+                              borderColor={state.pmImageContext.borderColor}
+                              alt={state.pmImageContext.alt}
                               onSetWrap={handleImageWrapType}
                               onSetSize={handleImageSetSize}
+                              onTransform={handleImageTransform}
+                              onSetBorder={handleImageSetBorder}
+                              onSetAlt={handleImageSetAlt}
                             />
                           )}
                           {propsKind === 'table' && (

--- a/docx-editor/packages/react/src/components/sidebar/ImagePropertiesSection.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/ImagePropertiesSection.tsx
@@ -151,35 +151,134 @@ const sizeLabel: CSSProperties = {
   color: 'var(--doc-text-muted)',
 };
 
+export type ImageTransform = 'rotateCW' | 'rotateCCW' | 'flipH' | 'flipV';
+
 export interface ImagePropertiesSectionProps {
   /** Current wrap mode of the selected image. */
   wrapType: string;
   /** Current rendered width/height in px (drives the editable inputs). */
   width?: number | null;
   height?: number | null;
+  /** Current border attrs (drive the border controls). */
+  borderWidth?: number | null;
+  borderColor?: string | null;
+  /** Current alt text. */
+  alt?: string | null;
   /** Apply a wrap mode (host wires this to setImageWrapType). */
   onSetWrap: (value: string) => void;
   /** Apply an explicit width/height (host wires this to setNodeMarkup). */
   onSetSize?: (width: number, height: number) => void;
+  /** Rotate/flip the image (host wires this to handleImageTransform). */
+  onTransform?: (action: ImageTransform) => void;
+  /** Set border width/color/style (host wires this to setNodeMarkup). */
+  onSetBorder?: (
+    borderWidth: number | null,
+    borderColor: string | null,
+    borderStyle: string | null
+  ) => void;
+  /** Set alt text (host wires this to setNodeMarkup). */
+  onSetAlt?: (alt: string) => void;
 }
+
+const BORDER_PRESETS: { label: string; width: number | null }[] = [
+  { label: 'None', width: null },
+  { label: 'Thin', width: 1 },
+  { label: 'Medium', width: 2 },
+  { label: 'Thick', width: 4 },
+];
+
+const ARRANGE: { action: ImageTransform; label: string; icon: JSX.Element }[] = [
+  {
+    action: 'rotateCCW',
+    label: 'Rotate left',
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M7.11 8.53 5.7 7.11C4.8 8.27 4.24 9.61 4.07 11h2.02c.14-.87.49-1.72 1.02-2.47zM6.09 13H4.07c.17 1.39.72 2.73 1.62 3.89l1.41-1.42c-.52-.75-.87-1.59-1.01-2.47zm1.01 5.32c1.16.9 2.51 1.44 3.9 1.61V17.9c-.87-.15-1.71-.49-2.46-1.03L7.1 18.32zM13 4.07V1L8.45 5.55 13 10V6.09c2.84.48 5 2.94 5 5.91s-2.16 5.43-5 5.91v2.02c3.95-.49 7-3.85 7-7.93s-3.05-7.44-7-7.93z" />
+      </svg>
+    ),
+  },
+  {
+    action: 'rotateCW',
+    label: 'Rotate right',
+    icon: (
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        aria-hidden="true"
+        style={{ transform: 'scaleX(-1)' }}
+      >
+        <path d="M7.11 8.53 5.7 7.11C4.8 8.27 4.24 9.61 4.07 11h2.02c.14-.87.49-1.72 1.02-2.47zM6.09 13H4.07c.17 1.39.72 2.73 1.62 3.89l1.41-1.42c-.52-.75-.87-1.59-1.01-2.47zm1.01 5.32c1.16.9 2.51 1.44 3.9 1.61V17.9c-.87-.15-1.71-.49-2.46-1.03L7.1 18.32zM13 4.07V1L8.45 5.55 13 10V6.09c2.84.48 5 2.94 5 5.91s-2.16 5.43-5 5.91v2.02c3.95-.49 7-3.85 7-7.93s-3.05-7.44-7-7.93z" />
+      </svg>
+    ),
+  },
+  {
+    action: 'flipH',
+    label: 'Flip horizontal',
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M12 3v18" stroke="currentColor" strokeWidth="1.6" strokeDasharray="2 2" />
+        <path d="M10 6 4 12l6 6V6zM14 6v12l6-6-6-6z" fill="currentColor" opacity="0.85" />
+      </svg>
+    ),
+  },
+  {
+    action: 'flipV',
+    label: 'Flip vertical',
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M3 12h18" stroke="currentColor" strokeWidth="1.6" strokeDasharray="2 2" />
+        <path d="M6 10 12 4l6 6H6zM6 14h12l-6 6-6-6z" fill="currentColor" opacity="0.85" />
+      </svg>
+    ),
+  },
+];
+
+const arrangeBtn: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 40,
+  height: 36,
+  border: '1px solid var(--doc-border, #dadce0)',
+  borderRadius: 8,
+  background: 'transparent',
+  color: 'var(--doc-text, #202124)',
+  cursor: 'pointer',
+};
 
 export function ImagePropertiesSection({
   wrapType,
   width,
   height,
+  borderWidth,
+  borderColor,
+  alt,
   onSetWrap,
   onSetSize,
+  onTransform,
+  onSetBorder,
+  onSetAlt,
 }: ImagePropertiesSectionProps) {
   // Local, editable copies so typing doesn't fight the live node attrs. They
   // re-sync whenever the selected image (its size) changes underneath.
   const [w, setW] = useState<string>(width != null ? String(Math.round(width)) : '');
   const [h, setH] = useState<string>(height != null ? String(Math.round(height)) : '');
   const [lockAspect, setLockAspect] = useState(true);
+  const [color, setColor] = useState<string>(borderColor || '#000000');
+  const [altText, setAltText] = useState<string>(alt || '');
 
   useEffect(() => {
     setW(width != null ? String(Math.round(width)) : '');
     setH(height != null ? String(Math.round(height)) : '');
   }, [width, height]);
+  useEffect(() => {
+    setColor(borderColor || '#000000');
+  }, [borderColor]);
+  useEffect(() => {
+    setAltText(alt || '');
+  }, [alt]);
 
   const aspect = width && height ? width / height : null;
 
@@ -283,6 +382,127 @@ export function ImagePropertiesSection({
             />
             Lock aspect ratio
           </label>
+        </>
+      )}
+
+      {onTransform && (
+        <>
+          <div style={GROUP_HEADER}>Arrange</div>
+          <div
+            style={{ display: 'flex', gap: 6, padding: '0 16px 4px' }}
+            role="group"
+            aria-label="Arrange"
+          >
+            {ARRANGE.map((a) => (
+              <button
+                key={a.action}
+                type="button"
+                title={a.label}
+                aria-label={a.label}
+                style={arrangeBtn}
+                data-testid={`properties-image-${a.action}`}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onTransform(a.action);
+                }}
+              >
+                {a.icon}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+
+      {onSetBorder && (
+        <>
+          <div style={GROUP_HEADER}>Border</div>
+          <div
+            style={{ display: 'flex', flexWrap: 'wrap', gap: 6, padding: '0 16px 6px' }}
+            role="group"
+            aria-label="Border width"
+          >
+            {BORDER_PRESETS.map((b) => {
+              const active = (borderWidth ?? null) === b.width;
+              return (
+                <button
+                  key={b.label}
+                  type="button"
+                  style={{
+                    ...arrangeBtn,
+                    width: 'auto',
+                    padding: '0 12px',
+                    fontSize: 12.5,
+                    color: active ? 'var(--doc-primary, #1a73e8)' : 'var(--doc-text, #202124)',
+                    background: active ? 'var(--doc-primary-light, #e8f0fe)' : 'transparent',
+                    borderColor: active
+                      ? 'var(--doc-primary, #1a73e8)'
+                      : 'var(--doc-border, #dadce0)',
+                  }}
+                  data-testid={`properties-image-border-${b.label.toLowerCase()}`}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    onSetBorder(
+                      b.width,
+                      b.width == null ? null : color,
+                      b.width == null ? null : 'solid'
+                    );
+                  }}
+                >
+                  {b.label}
+                </button>
+              );
+            })}
+          </div>
+          <label style={{ ...SIZE_ROW, ...sizeLabel, paddingBottom: 14 }}>
+            Color
+            <input
+              type="color"
+              value={color}
+              data-testid="properties-image-border-color"
+              style={{
+                marginLeft: 8,
+                width: 36,
+                height: 26,
+                padding: 0,
+                border: '1px solid var(--doc-border, #dadce0)',
+                borderRadius: 6,
+                background: 'none',
+                cursor: 'pointer',
+              }}
+              onChange={(e) => {
+                setColor(e.target.value);
+                // Apply immediately if a border is already on; else just stage.
+                if (borderWidth) onSetBorder(borderWidth, e.target.value, 'solid');
+              }}
+            />
+          </label>
+        </>
+      )}
+
+      {onSetAlt && (
+        <>
+          <div style={GROUP_HEADER}>Alt text</div>
+          <div style={{ padding: '0 16px 16px' }}>
+            <textarea
+              value={altText}
+              data-testid="properties-image-alt"
+              placeholder="Describe this image"
+              rows={2}
+              style={{
+                width: '100%',
+                resize: 'vertical',
+                padding: '6px 8px',
+                fontSize: 13,
+                border: '1px solid var(--doc-border, #dadce0)',
+                borderRadius: 6,
+                background: 'var(--doc-surface, #fff)',
+                color: 'var(--doc-text, #202124)',
+                boxSizing: 'border-box',
+              }}
+              onChange={(e) => setAltText(e.target.value)}
+              onBlur={() => onSetAlt(altText)}
+            />
+          </div>
         </>
       )}
     </div>


### PR DESCRIPTION
Builds on the merged Format panel: consolidates the scattered image-editing controls into the contextual panel and makes the picture border actually render.

- **Arrange** — rotate left/right + flip H/V (reuses `handleImageTransform`; paints via the existing `run.transform` path).
- **Border** — None/Thin/Medium/Thick + color. The painter never rendered image borders, so the attr was invisible; wired `borderWidth/Color/Style` through the flow-block (`ImageRun`/`ImageBlock`) → `renderParagraph`/`renderImage`. **Render-only** — the attrs already round-trip via the image node, so no serializer change (921 core tests still green).
- **Alt text** — editable textarea (accessibility).
- **Keep selection through edits** — image mutations now re-select the image as a *node* selection, so the panel stays on the image after a wrap/size/rotate/border change instead of falling back to the empty state. Fixes the known "panel empties after a change" follow-up.

e2e extended: rotate applies a transform; Border "Medium" gives the painted image a visible border width. Screenshot-verified the full panel (Wrapping / Size / Arrange / Border / Alt).

Gate: typecheck · format · lint 0 errors · 921 core tests · smoke · comments-sidebar · panel e2e — all green.