### PR TITLE
feat(ux): text box Format chip + panel (resize / fill / outline)

### DIFF
--- a/docs/internal/24-editability-tracker.md
+++ b/docs/internal/24-editability-tracker.md
@@ -29,7 +29,7 @@ resize). Treat every row as **verified by Playwright probe**, not by reading cod
 | Pri | Item | Impact | Notes / fix direction |
 | --- | --- | --- | --- |
 | P3 | ⬜ **Textbox click-to-select-as-node** (Word border-select) | Low — deletion already works | `Ctrl+A`→Delete already removes a box; **Backspace in an empty box now deletes it** too (✅, BaseKeymapExtension). Remaining nicety: click the box border to select the whole node (for move/resize); not blocking. |
-| P2 | ⬜ **Textbox move / resize** | Med | No drag/resize handles for textbox (only images have them). Add an overlay like `ImageSelectionOverlay`. |
+| P2 | 🟡 **Textbox move / resize** | Med | ✅ **Resize** + fill + outline now editable via the **Format panel** (textbox section), opened by the on-object Format chip while the caret is in the box (#57) — resize-by-number, no drag overlay, sidesteps the anchored-position blocker below. Remaining: drag/resize **handles** overlay (like images) + **move** (gated on anchored-position). |
 | P2 | ⬜ **Anchored position honored by layout** | High (shared) | Floating images + textboxes + shapes store `posOffsetH/V` but the layout engine ignores them (reverted `d8b85d1`). Drag-move updates attrs but a re-layout can reset. Needs hybrid cursor-advance + wrap-exclusion zones. |
 | P2 | ⬜ **Shape (rawXml) safety** | Med | rawXml shapes are preserve-only; editing silently rebuilds → loses VML. Make click-selectable + safely deletable; block in-place edit or patch only the textBody. |
 | P3 | ⬜ **Header/footer caret feedback** | Low | Double-click-to-edit works; caret not painted on the page-behind during edit. |

--- a/docx-editor/e2e/tests/properties-panel.spec.ts
+++ b/docx-editor/e2e/tests/properties-panel.spec.ts
@@ -145,6 +145,75 @@ test('Format panel: table chip → table section (not empty), delete row applies
   expect(cellsAfter).toBeLessThan(cellsBefore);
 });
 
+test('Format panel: textbox chip → section (resize + fill apply)', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/textbox-test.docx');
+  await page.waitForTimeout(1500);
+
+  const box = page.locator('[data-testid="docx-editor"] .layout-textbox').first();
+  await box.click({ position: { x: 24, y: 12 } });
+  await page.waitForTimeout(400);
+
+  // chip appears for the caret-in-textbox; panel not auto-opened
+  await expect(page.locator('[data-testid="textbox-format-chip"]')).toBeVisible();
+  expect(await page.locator(PANEL).count()).toBe(0);
+
+  await page.locator('[data-testid="textbox-format-chip"]').click();
+  await page.waitForTimeout(400);
+  await expect(page.locator(PANEL)).toBeVisible();
+  await expect(page.locator('[data-testid="properties-textbox-section"]')).toBeVisible();
+
+  // outline applies: "Thick" gives the painted box a visible border width
+  await page.locator('[data-testid="properties-textbox-outline-thick"]').click();
+  await page.waitForTimeout(500);
+  const borderW = await page
+    .locator('[data-testid="docx-editor"] .layout-textbox')
+    .first()
+    .evaluate((el) => parseFloat(getComputedStyle(el as HTMLElement).borderTopWidth || '0'));
+  expect(borderW).toBeGreaterThanOrEqual(3);
+
+  // resize applies: width input drives the painted box width
+  const wBefore =
+    (await page.locator('[data-testid="docx-editor"] .layout-textbox').first().boundingBox())
+      ?.width ?? 0;
+  await page.locator('[data-testid="properties-textbox-width"]').fill('120');
+  await page.locator('[data-testid="properties-textbox-width"]').press('Enter');
+  await page.waitForTimeout(500);
+  const wAfter =
+    (await page.locator('[data-testid="docx-editor"] .layout-textbox').first().boundingBox())
+      ?.width ?? 0;
+  expect(wAfter).toBeLessThan(wBefore);
+});
+
+test('Format panel: textbox "No fill" removes a pre-filled background', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/textbox-test.docx');
+  await page.waitForTimeout(1500);
+
+  // The blue info box (2nd) has a fill; clicking "No fill" must clear it.
+  const blue = page.locator('[data-testid="docx-editor"] .layout-textbox').nth(1);
+  await blue.click({ position: { x: 24, y: 12 } });
+  await page.waitForTimeout(400);
+  await page.locator('[data-testid="textbox-format-chip"]').click();
+  await page.waitForTimeout(400);
+
+  const bgBefore = await page
+    .locator('[data-testid="docx-editor"] .layout-textbox')
+    .nth(1)
+    .evaluate((el) => getComputedStyle(el as HTMLElement).backgroundColor);
+  await page.locator('[data-testid="properties-textbox-fill-none"]').click();
+  await page.waitForTimeout(500);
+  const bgAfter = await page
+    .locator('[data-testid="docx-editor"] .layout-textbox')
+    .nth(1)
+    .evaluate((el) => getComputedStyle(el as HTMLElement).backgroundColor);
+  expect(bgAfter).not.toBe(bgBefore);
+});
+
 test('Format panel: only one right-side surface open at a time', async ({ page }) => {
   const editor = new EditorPage(page);
   await editor.goto();

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -54,6 +54,7 @@ import { VersionHistoryPanel } from './sidebar/VersionHistoryPanel';
 import { PropertiesPanel, type PropertiesTargetKind } from './sidebar/PropertiesPanel';
 import { ImagePropertiesSection } from './sidebar/ImagePropertiesSection';
 import { TablePropertiesSection } from './sidebar/TablePropertiesSection';
+import { TextBoxPropertiesSection } from './sidebar/TextBoxPropertiesSection';
 import { useEditHistory } from '../hooks/useEditHistory';
 import { useVersionHistoryCapture } from '../version-history/useVersionHistoryCapture';
 import { downloadServerVersion, type ServerVersionBackend } from '../version-history/server-source';
@@ -875,6 +876,14 @@ interface EditorState {
     width: number | null;
     height: number | null;
   } | null;
+  pmTextBoxContext: {
+    pos: number;
+    width: number | null;
+    height: number | null;
+    fillColor: string | null;
+    outlineWidth: number | null;
+    outlineColor: string | null;
+  } | null;
 }
 
 // ============================================================================
@@ -1584,6 +1593,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     paragraphTabs: null,
     pmTableContext: null,
     pmImageContext: null,
+    pmTextBoxContext: null,
   });
 
   // Table properties dialog state
@@ -2983,6 +2993,42 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         }
       }
 
+      // Check if the caret is inside (or the selection is) a text box. Walk the
+      // ancestor chain so a caret in the box's text still surfaces the box —
+      // textboxes are edited by clicking inside (caret model), like tables.
+      let pmTextBoxCtx: typeof state.pmTextBoxContext = null;
+      if (view) {
+        const sel = view.state.selection;
+        const selNode = (
+          sel as { node?: { type: { name: string }; attrs: Record<string, unknown> } }
+        ).node;
+        let tbNode: { attrs: Record<string, unknown> } | null = null;
+        let tbPos = -1;
+        if (selNode?.type.name === 'textBox') {
+          tbNode = selNode;
+          tbPos = sel.from;
+        } else {
+          const $from = sel.$from;
+          for (let d = $from.depth; d > 0; d--) {
+            if ($from.node(d).type.name === 'textBox') {
+              tbNode = $from.node(d);
+              tbPos = $from.before(d);
+              break;
+            }
+          }
+        }
+        if (tbNode && tbPos >= 0) {
+          pmTextBoxCtx = {
+            pos: tbPos,
+            width: (tbNode.attrs.width as number) ?? null,
+            height: (tbNode.attrs.height as number) ?? null,
+            fillColor: (tbNode.attrs.fillColor as string) ?? null,
+            outlineWidth: (tbNode.attrs.outlineWidth as number) ?? null,
+            outlineColor: (tbNode.attrs.outlineColor as string) ?? null,
+          };
+        }
+      }
+
       if (!selectionState) {
         setFloatingCommentBtn(null);
         setState((prev) => ({
@@ -2990,6 +3036,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
           selectionFormatting: {},
           pmTableContext: pmTableCtx,
           pmImageContext: pmImageCtx,
+          pmTextBoxContext: pmTextBoxCtx,
         }));
         return;
       }
@@ -3073,6 +3120,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         paragraphTabs: paragraphFormatting.tabs ?? null,
         pmTableContext: pmTableCtx,
         pmImageContext: pmImageCtx,
+        pmTextBoxContext: pmTextBoxCtx,
       }));
 
       // Update floating comment button position
@@ -3915,6 +3963,46 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       focusActiveEditor();
     },
     [getActiveEditorView, focusActiveEditor, state.pmImageContext, reselectImageNode]
+  );
+
+  // --- Text box Format-panel handlers ---------------------------------------
+  // All go through setNodeMarkup on the textBox node (reliable + round-trips);
+  // the painter re-renders at the new size/fill/outline. We keep the caret
+  // inside the box (setSelection at pos+1) so the panel stays open on it.
+  const updateTextBoxAttrs = useCallback(
+    (patch: Record<string, unknown>) => {
+      const view = getActiveEditorView();
+      if (!view || !state.pmTextBoxContext) return;
+      const pos = state.pmTextBoxContext.pos;
+      const node = view.state.doc.nodeAt(pos);
+      if (!node || node.type.name !== 'textBox') return;
+      const tr = view.state.tr.setNodeMarkup(pos, undefined, { ...node.attrs, ...patch });
+      view.dispatch(tr);
+      focusActiveEditor();
+    },
+    [getActiveEditorView, focusActiveEditor, state.pmTextBoxContext]
+  );
+  const handleTextBoxSetSize = useCallback(
+    (width: number, height: number | null) => {
+      updateTextBoxAttrs({
+        width: Math.max(24, Math.min(2000, Math.round(width))),
+        height: height == null ? null : Math.max(16, Math.min(2000, Math.round(height))),
+      });
+    },
+    [updateTextBoxAttrs]
+  );
+  const handleTextBoxSetFill = useCallback(
+    (fillColor: string | null) => updateTextBoxAttrs({ fillColor }),
+    [updateTextBoxAttrs]
+  );
+  const handleTextBoxSetOutline = useCallback(
+    (outlineWidth: number | null, outlineColor: string | null) =>
+      updateTextBoxAttrs({
+        outlineWidth,
+        outlineColor: outlineWidth == null ? null : outlineColor,
+        outlineStyle: outlineWidth == null ? null : 'solid',
+      }),
+    [updateTextBoxAttrs]
   );
 
   // Handle image transform (rotate/flip)
@@ -8447,9 +8535,11 @@ body { background: white; }
                       // never overlaps it. Kind derived from the live selection.
                       const propsKind: PropertiesTargetKind | null = state.pmImageContext
                         ? 'image'
-                        : state.pmTableContext?.isInTable
-                          ? 'table'
-                          : null;
+                        : state.pmTextBoxContext
+                          ? 'textbox'
+                          : state.pmTableContext?.isInTable
+                            ? 'table'
+                            : null;
                       return (
                         <PropertiesPanel kind={propsKind} onClose={() => openRightPanel('none')}>
                           {propsKind === 'image' && state.pmImageContext && (
@@ -8469,6 +8559,18 @@ body { background: white; }
                           )}
                           {propsKind === 'table' && (
                             <TablePropertiesSection onAction={handleTableAction} />
+                          )}
+                          {propsKind === 'textbox' && state.pmTextBoxContext && (
+                            <TextBoxPropertiesSection
+                              width={state.pmTextBoxContext.width}
+                              height={state.pmTextBoxContext.height}
+                              fillColor={state.pmTextBoxContext.fillColor}
+                              outlineWidth={state.pmTextBoxContext.outlineWidth}
+                              outlineColor={state.pmTextBoxContext.outlineColor}
+                              onSetSize={handleTextBoxSetSize}
+                              onSetFill={handleTextBoxSetFill}
+                              onSetOutline={handleTextBoxSetOutline}
+                            />
                           )}
                         </PropertiesPanel>
                       );

--- a/docx-editor/packages/react/src/components/sidebar/PropertiesPanel.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/PropertiesPanel.tsx
@@ -17,7 +17,7 @@ import { RightDockPanel } from '../RightDockPanel';
 import { MaterialSymbol } from '../ui/Icons';
 import { PanelState } from '../ui/PanelState';
 
-export type PropertiesTargetKind = 'image' | 'table' | 'shape';
+export type PropertiesTargetKind = 'image' | 'table' | 'shape' | 'textbox';
 
 export interface PropertiesPanelProps {
   /** The kind of object currently selected, or null when none is. */

--- a/docx-editor/packages/react/src/components/sidebar/TextBoxPropertiesSection.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/TextBoxPropertiesSection.tsx
@@ -1,0 +1,211 @@
+/**
+ * Text box section of the Format/Properties panel. A text box is edited by
+ * clicking inside it (caret model), so its Format chip appears while the caret
+ * is in the box; this section gives the box-level properties that aren't text
+ * formatting: size (resize by number), fill, and outline.
+ *
+ * All edits go through setNodeMarkup on the textBox node in the host, so they
+ * round-trip and the painter re-renders — no drag overlay needed for resize.
+ */
+import { useEffect, useState, type CSSProperties } from 'react';
+
+const GROUP_HEADER: CSSProperties = {
+  padding: '14px 16px 8px',
+  fontSize: 11,
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+  color: 'var(--doc-text-muted)',
+  fontWeight: 600,
+};
+
+const ROW: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '2px 16px 6px',
+  fontSize: 12,
+  color: 'var(--doc-text-muted)',
+};
+
+const numInput: CSSProperties = {
+  width: 64,
+  padding: '6px 8px',
+  fontSize: 13,
+  border: '1px solid var(--doc-border, #dadce0)',
+  borderRadius: 6,
+  background: 'var(--doc-surface, #fff)',
+  color: 'var(--doc-text, #202124)',
+};
+
+const swatch: CSSProperties = {
+  width: 36,
+  height: 26,
+  padding: 0,
+  border: '1px solid var(--doc-border, #dadce0)',
+  borderRadius: 6,
+  background: 'none',
+  cursor: 'pointer',
+};
+
+const OUTLINE_PRESETS: { label: string; width: number | null }[] = [
+  { label: 'None', width: null },
+  { label: 'Thin', width: 1 },
+  { label: 'Medium', width: 2 },
+  { label: 'Thick', width: 4 },
+];
+
+const presetBtn = (active: boolean): CSSProperties => ({
+  height: 36,
+  padding: '0 12px',
+  fontSize: 12.5,
+  borderRadius: 8,
+  cursor: 'pointer',
+  color: active ? 'var(--doc-primary, #1a73e8)' : 'var(--doc-text, #202124)',
+  background: active ? 'var(--doc-primary-light, #e8f0fe)' : 'transparent',
+  border: active ? '1px solid var(--doc-primary, #1a73e8)' : '1px solid var(--doc-border, #dadce0)',
+});
+
+export interface TextBoxPropertiesSectionProps {
+  width?: number | null;
+  height?: number | null;
+  fillColor?: string | null;
+  outlineWidth?: number | null;
+  outlineColor?: string | null;
+  onSetSize: (width: number, height: number | null) => void;
+  onSetFill: (fillColor: string | null) => void;
+  onSetOutline: (outlineWidth: number | null, outlineColor: string | null) => void;
+}
+
+export function TextBoxPropertiesSection({
+  width,
+  height,
+  fillColor,
+  outlineWidth,
+  outlineColor,
+  onSetSize,
+  onSetFill,
+  onSetOutline,
+}: TextBoxPropertiesSectionProps) {
+  const [w, setW] = useState(width != null ? String(Math.round(width)) : '');
+  const [h, setH] = useState(height != null ? String(Math.round(height)) : '');
+  const [fill, setFill] = useState(fillColor || '#ffffff');
+  const [stroke, setStroke] = useState(outlineColor || '#000000');
+
+  useEffect(() => setW(width != null ? String(Math.round(width)) : ''), [width]);
+  useEffect(() => setH(height != null ? String(Math.round(height)) : ''), [height]);
+  useEffect(() => setFill(fillColor || '#ffffff'), [fillColor]);
+  useEffect(() => setStroke(outlineColor || '#000000'), [outlineColor]);
+
+  const commitSize = () => {
+    const nw = Number(w);
+    if (!Number.isFinite(nw) || nw <= 0) return;
+    const nh = h.trim() === '' ? null : Number(h);
+    onSetSize(nw, Number.isFinite(nh as number) ? (nh as number) : null);
+  };
+  const onKey = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commitSize();
+    }
+  };
+
+  return (
+    <div data-testid="properties-textbox-section">
+      <div style={GROUP_HEADER}>Size</div>
+      <div style={ROW} data-testid="properties-textbox-size">
+        <label style={{ color: 'inherit' }}>
+          W
+          <input
+            style={{ ...numInput, marginLeft: 6 }}
+            type="number"
+            min={24}
+            max={2000}
+            value={w}
+            data-testid="properties-textbox-width"
+            onChange={(e) => setW(e.target.value)}
+            onBlur={commitSize}
+            onKeyDown={onKey}
+          />
+        </label>
+        <label style={{ color: 'inherit' }}>
+          H
+          <input
+            style={{ ...numInput, marginLeft: 6 }}
+            type="number"
+            min={16}
+            max={2000}
+            value={h}
+            placeholder="auto"
+            data-testid="properties-textbox-height"
+            onChange={(e) => setH(e.target.value)}
+            onBlur={commitSize}
+            onKeyDown={onKey}
+          />
+        </label>
+      </div>
+
+      <div style={GROUP_HEADER}>Fill</div>
+      <div style={ROW}>
+        <input
+          type="color"
+          value={fill}
+          data-testid="properties-textbox-fill"
+          style={swatch}
+          onChange={(e) => {
+            setFill(e.target.value);
+            onSetFill(e.target.value);
+          }}
+        />
+        <button
+          type="button"
+          style={{ ...presetBtn(false), height: 26 }}
+          data-testid="properties-textbox-fill-none"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onSetFill(null);
+          }}
+        >
+          No fill
+        </button>
+      </div>
+
+      <div style={GROUP_HEADER}>Outline</div>
+      <div
+        style={{ display: 'flex', flexWrap: 'wrap', gap: 6, padding: '0 16px 6px' }}
+        role="group"
+        aria-label="Outline width"
+      >
+        {OUTLINE_PRESETS.map((o) => {
+          const active = (outlineWidth ?? null) === o.width;
+          return (
+            <button
+              key={o.label}
+              type="button"
+              style={presetBtn(active)}
+              data-testid={`properties-textbox-outline-${o.label.toLowerCase()}`}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onSetOutline(o.width, o.width == null ? null : stroke);
+              }}
+            >
+              {o.label}
+            </button>
+          );
+        })}
+      </div>
+      <label style={ROW}>
+        Color
+        <input
+          type="color"
+          value={stroke}
+          data-testid="properties-textbox-outline-color"
+          style={{ ...swatch, marginLeft: 8 }}
+          onChange={(e) => {
+            setStroke(e.target.value);
+            if (outlineWidth) onSetOutline(outlineWidth, e.target.value);
+          }}
+        />
+      </label>
+    </div>
+  );
+}

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -1495,6 +1495,12 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     // Mirrors the image chip; opens the same Format panel via onOpenProperties.
     const [tableChipPos, setTableChipPos] = useState<{ x: number; y: number } | null>(null);
 
+    // Text box "Format" chip — overlay-relative {x,y} of the top-right corner
+    // of the text box whose content range contains the caret, else null. The
+    // painted `.layout-textbox` carries data-pm-start/end so detection is a
+    // pure DOM range test (no PM walk needed here).
+    const [textBoxChipPos, setTextBoxChipPos] = useState<{ x: number; y: number } | null>(null);
+
     /** Build ImageSelectionInfo from a DOM element with data-pm-start */
     const buildImageSelectionInfo = useCallback(
       (el: HTMLElement, pmPos: number): ImageSelectionInfo => {
@@ -2373,6 +2379,33 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             if (prev === nextChip) return prev;
             if (prev && nextChip && prev.x === nextChip.x && prev.y === nextChip.y) return prev;
             return nextChip;
+          });
+        }
+
+        // Text box "Format" chip — anchor to the painted text box whose
+        // [data-pm-start, data-pm-end) range contains the caret.
+        {
+          const pagesEl = pagesContainerRef.current;
+          const viewportEl = pagesEl?.parentElement;
+          let nextTb: { x: number; y: number } | null = null;
+          if (pagesEl && viewportEl) {
+            const boxes = pagesEl.querySelectorAll('.layout-textbox[data-pm-start]');
+            for (const el of Array.from(boxes)) {
+              const htmlEl = el as HTMLElement;
+              const s = Number(htmlEl.dataset.pmStart);
+              const e = Number(htmlEl.dataset.pmEnd);
+              if (!Number.isNaN(s) && !Number.isNaN(e) && from >= s && from < e) {
+                const r = htmlEl.getBoundingClientRect();
+                const v = viewportEl.getBoundingClientRect();
+                nextTb = { x: r.right - v.left, y: r.top - v.top };
+                break;
+              }
+            }
+          }
+          setTextBoxChipPos((prev) => {
+            if (prev === nextTb) return prev;
+            if (prev && nextTb && prev.x === nextTb.x && prev.y === nextTb.y) return prev;
+            return nextTb;
           });
         }
 
@@ -4477,6 +4510,60 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
                 position: 'absolute',
                 left: tableChipPos.x,
                 top: tableChipPos.y - 14,
+                transform: 'translateX(-100%)',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+                height: 26,
+                padding: '0 10px',
+                fontSize: 12,
+                fontWeight: 600,
+                lineHeight: '26px',
+                color: '#fff',
+                background: '#2563eb',
+                border: 'none',
+                borderRadius: 13,
+                boxShadow: '0 1px 4px rgba(0,0,0,0.3)',
+                cursor: 'pointer',
+                zIndex: 201,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z" />
+              </svg>
+              Format
+            </button>
+          )}
+
+          {/* Text box "Format" chip — top-right of the box containing the
+              caret. Opens the same contextual Format panel (host derives the
+              textbox kind from its selection context). */}
+          {onOpenProperties && textBoxChipPos && isFocused && (
+            <button
+              type="button"
+              data-testid="textbox-format-chip"
+              aria-label="Format text box"
+              title="Format"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onOpenProperties();
+              }}
+              style={{
+                position: 'absolute',
+                left: textBoxChipPos.x,
+                top: textBoxChipPos.y - 14,
                 transform: 'translateX(-100%)',
                 display: 'inline-flex',
                 alignItems: 'center',


### PR DESCRIPTION
Extends the Format-panel/chip system to **text boxes** — the highest-impact remaining "can see it, can barely edit it" gap (a text box could only have its text edited, not its box-level properties).

A Format chip appears while the caret is in a box (mirrors the table chip; anchored to the painted `.layout-textbox` via its `data-pm-start/end` range). Clicking it opens the panel with:

- **Size** — editable W×H (resize by number; round-trips. No drag overlay, which sidesteps the known anchored-position layout blocker).
- **Fill** — color + "No fill".
- **Outline** — None/Thin/Medium/Thick + color.

All edits go through `setNodeMarkup` on the `textBox` node; the painter already renders fill/outline/size, so changes are immediately visible and round-trip. The panel reads the box's live attrs (verified: the blue info box shows its real fill + outline color).

e2e: caret-in-box → chip → section; outline "Thick" paints a ≥3px border; width 120 shrinks the painted box; "No fill" clears a pre-filled box's background. Screenshot-verified.

Gate: typecheck · format · lint 0 errors · smoke · comments-sidebar · panel e2e (6 tests) — all green.

Note: resize-by-number is the reliable path; drag-handles for text boxes (like images) remain a separate follow-up, gated on the anchored-position work.