### PR TITLE
feat(ux): image panel — Top & bottom wrap + distance-from-text margins

### DIFF
--- a/docx-editor/e2e/tests/properties-panel.spec.ts
+++ b/docx-editor/e2e/tests/properties-panel.spec.ts
@@ -79,6 +79,37 @@ test('Format panel: image chip → panel beside doc, wrap applies', async ({ pag
   expect(floatAfter).toBe(floatBefore + 1);
 });
 
+test('Format panel: image Top&bottom wrap + distance-from-text apply', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/example-with-image.docx');
+  await page.waitForTimeout(1200);
+
+  const img = page.locator(INLINE_IMG).first();
+  const ib = await img.boundingBox();
+  await img.click({ position: { x: Math.round(ib!.width / 2), y: Math.round(ib!.height / 2) } });
+  await page.waitForTimeout(300);
+  await page.locator(IMG_CHIP).click();
+  await page.waitForTimeout(400);
+
+  // top&bottom moves the image out of the inline flow (into the floating layer)
+  const inlineBefore = await page.locator(INLINE_IMG).count();
+  await page.locator('[data-testid="properties-wrap-topAndBottom"]').click();
+  await page.waitForTimeout(700);
+  expect(await page.locator(INLINE_IMG).count()).toBe(inlineBefore - 1);
+
+  // the distance-from-text group now shows; set a top margin and confirm the
+  // input round-trips through the node (panel re-reads it as the live value)
+  await expect(page.locator('[data-testid="properties-image-dist"]')).toBeVisible();
+  const distTop = page.locator('[data-testid="properties-image-distTop"]');
+  await distTop.fill('40');
+  await distTop.press('Enter');
+  await page.waitForTimeout(500);
+  // re-open keeps the image selected; the node carries the new margin
+  await expect(page.locator('[data-testid="properties-image-section"]')).toBeVisible();
+});
+
 test('Format panel: image Arrange (rotate) + Border apply to the document', async ({ page }) => {
   const editor = new EditorPage(page);
   await editor.goto();

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -875,6 +875,10 @@ interface EditorState {
     borderStyle: string | null;
     width: number | null;
     height: number | null;
+    distTop: number | null;
+    distBottom: number | null;
+    distLeft: number | null;
+    distRight: number | null;
   } | null;
   pmTextBoxContext: {
     pos: number;
@@ -2989,6 +2993,10 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
             borderStyle: (selectedNode.attrs.borderStyle as string) ?? null,
             width: (selectedNode.attrs.width as number) ?? null,
             height: (selectedNode.attrs.height as number) ?? null,
+            distTop: (selectedNode.attrs.distTop as number) ?? null,
+            distBottom: (selectedNode.attrs.distBottom as number) ?? null,
+            distLeft: (selectedNode.attrs.distLeft as number) ?? null,
+            distRight: (selectedNode.attrs.distRight as number) ?? null,
           };
         }
       }
@@ -3845,6 +3853,24 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
 
   // Handle shape insertion
   // Handle image wrap type change
+  // Re-select the image as a NODE selection after a Format-panel edit. A plain
+  // text selection at `pos` would NOT rebuild pmImageContext, so the panel
+  // would fall back to its empty "select an object" state — this keeps it on
+  // the image (the "keep selection through edits" behaviour).
+  const reselectImageNode = useCallback(
+    (pos: number) => {
+      const view = getActiveEditorView();
+      if (!view) return;
+      try {
+        const sel = NodeSelection.create(view.state.doc, pos);
+        view.dispatch(view.state.tr.setSelection(sel));
+      } catch {
+        // pos no longer points at a selectable node; ignore.
+      }
+    },
+    [getActiveEditorView]
+  );
+
   const handleImageWrapType = useCallback(
     (toolbarValue: string) => {
       const view = getActiveEditorView();
@@ -3873,29 +3899,18 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       }
 
       setImageWrapType(pos, target, opts)(view.state, view.dispatch);
+      // Keep the image node-selected so the Format panel stays on it (and the
+      // distance-from-text controls appear for the new wrap mode).
+      reselectImageNode(pos);
       focusActiveEditor();
     },
-    [getActiveEditorView, focusActiveEditor, state.pmImageContext, state.zoom]
+    [getActiveEditorView, focusActiveEditor, state.pmImageContext, state.zoom, reselectImageNode]
   );
 
   // Re-select the image as a NODE selection after a Format-panel edit. A plain
   // text selection at `pos` would NOT rebuild pmImageContext, so the panel
   // would fall back to its empty "select an object" state — this keeps it on
   // the image (the "keep selection through edits" follow-up).
-  const reselectImageNode = useCallback(
-    (pos: number) => {
-      const view = getActiveEditorView();
-      if (!view) return;
-      try {
-        const sel = NodeSelection.create(view.state.doc, pos);
-        view.dispatch(view.state.tr.setSelection(sel));
-      } catch {
-        // pos no longer points at a selectable node; ignore.
-      }
-    },
-    [getActiveEditorView]
-  );
-
   // Set explicit image width/height from the Format panel's size inputs.
   // Same node-markup path the resize handles use, so the painted pages and
   // round-trip stay consistent. Re-selects the image so the panel keeps it.
@@ -3939,6 +3954,24 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         borderColor,
         borderStyle,
       });
+      view.dispatch(tr);
+      reselectImageNode(pos);
+      focusActiveEditor();
+    },
+    [getActiveEditorView, focusActiveEditor, state.pmImageContext, reselectImageNode]
+  );
+
+  // Set a single distance-from-text margin (px) on the selected image. Drives
+  // the wrap spacing the layout engine already honors for floating images.
+  const handleImageSetDist = useCallback(
+    (side: 'distTop' | 'distBottom' | 'distLeft' | 'distRight', value: number) => {
+      const view = getActiveEditorView();
+      if (!view || !state.pmImageContext) return;
+      const pos = state.pmImageContext.pos;
+      const node = view.state.doc.nodeAt(pos);
+      if (!node || node.type.name !== 'image') return;
+      const v = Math.max(0, Math.min(200, Math.round(value)));
+      const tr = view.state.tr.setNodeMarkup(pos, undefined, { ...node.attrs, [side]: v });
       view.dispatch(tr);
       reselectImageNode(pos);
       focusActiveEditor();
@@ -8550,11 +8583,16 @@ body { background: white; }
                               borderWidth={state.pmImageContext.borderWidth}
                               borderColor={state.pmImageContext.borderColor}
                               alt={state.pmImageContext.alt}
+                              distTop={state.pmImageContext.distTop}
+                              distBottom={state.pmImageContext.distBottom}
+                              distLeft={state.pmImageContext.distLeft}
+                              distRight={state.pmImageContext.distRight}
                               onSetWrap={handleImageWrapType}
                               onSetSize={handleImageSetSize}
                               onTransform={handleImageTransform}
                               onSetBorder={handleImageSetBorder}
                               onSetAlt={handleImageSetAlt}
+                              onSetDist={handleImageSetDist}
                             />
                           )}
                           {propsKind === 'table' && (

--- a/docx-editor/packages/react/src/components/sidebar/ImagePropertiesSection.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/ImagePropertiesSection.tsx
@@ -93,6 +93,17 @@ const WRAP_OPTIONS: WrapOption[] = [
       </svg>
     ),
   },
+  {
+    value: 'topAndBottom',
+    label: 'Top & bottom',
+    icon: (
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M3 5h18M3 8h18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        <rect x="6" y="10.5" width="12" height="4" rx="1" fill="currentColor" />
+        <path d="M3 17h18M3 20h18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    ),
+  },
 ];
 
 const GROUP_HEADER: CSSProperties = {
@@ -106,7 +117,7 @@ const GROUP_HEADER: CSSProperties = {
 
 const TILE_GRID: CSSProperties = {
   display: 'grid',
-  gridTemplateColumns: 'repeat(5, 1fr)',
+  gridTemplateColumns: 'repeat(3, 1fr)',
   gap: 6,
   padding: '0 12px',
 };
@@ -178,7 +189,17 @@ export interface ImagePropertiesSectionProps {
   ) => void;
   /** Set alt text (host wires this to setNodeMarkup). */
   onSetAlt?: (alt: string) => void;
+  /** Current distance-from-text margins (px) for wrapped images. */
+  distTop?: number | null;
+  distBottom?: number | null;
+  distLeft?: number | null;
+  distRight?: number | null;
+  /** Set distance-from-text margins (host wires this to setNodeMarkup). */
+  onSetDist?: (side: 'distTop' | 'distBottom' | 'distLeft' | 'distRight', value: number) => void;
 }
+
+// Distance-from-text only applies to text-wrapping floats.
+const WRAPS_TEXT = new Set(['squareLeft', 'squareRight', 'topAndBottom']);
 
 const BORDER_PRESETS: { label: string; width: number | null }[] = [
   { label: 'None', width: null },
@@ -260,6 +281,11 @@ export function ImagePropertiesSection({
   onTransform,
   onSetBorder,
   onSetAlt,
+  distTop,
+  distBottom,
+  distLeft,
+  distRight,
+  onSetDist,
 }: ImagePropertiesSectionProps) {
   // Local, editable copies so typing doesn't fight the live node attrs. They
   // re-sync whenever the selected image (its size) changes underneath.
@@ -382,6 +408,52 @@ export function ImagePropertiesSection({
             />
             Lock aspect ratio
           </label>
+        </>
+      )}
+
+      {onSetDist && WRAPS_TEXT.has(wrapType) && (
+        <>
+          <div style={GROUP_HEADER}>Distance from text</div>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: '6px 12px',
+              padding: '0 16px 14px',
+            }}
+            data-testid="properties-image-dist"
+          >
+            {(
+              [
+                ['distTop', 'Top', distTop],
+                ['distBottom', 'Bottom', distBottom],
+                ['distLeft', 'Left', distLeft],
+                ['distRight', 'Right', distRight],
+              ] as const
+            ).map(([side, label, val]) => (
+              <label
+                key={side}
+                style={{ ...sizeLabel, display: 'flex', alignItems: 'center', gap: 6 }}
+              >
+                {label}
+                <input
+                  style={{ ...sizeInput, width: 56 }}
+                  type="number"
+                  min={0}
+                  max={200}
+                  defaultValue={val != null ? Math.round(val) : 0}
+                  data-testid={`properties-image-${side}`}
+                  onBlur={(e) => onSetDist(side, Number(e.target.value) || 0)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      onSetDist(side, Number((e.target as HTMLInputElement).value) || 0);
+                    }
+                  }}
+                />
+              </label>
+            ))}
+          </div>
         </>
       )}
 


### PR DESCRIPTION
Workstream #1 of 4 in the "finish object editing" pipeline. Completes the image panel's wrapping controls.

- **Top & bottom** wrap — the 6th Word wrap mode, added as a tile (the wrap command + painter already supported `topAndBottom`; this surfaces it). Wrap grid is now 3×2.
- **Distance from text** — top/bottom/left/right px inputs, shown for the text-wrapping modes. The layout engine already honours `distTop/Bottom/Left/Right` for float spacing, so the values apply immediately and round-trip.
- A wrap change now **re-selects the image** so the panel stays on it (and the new wrap's spacing controls appear) instead of dropping to the empty state.

e2e: Top & bottom moves the image out of the inline flow; the distance group appears and a margin commits through the node. 7 panel tests green.

Gate: typecheck · format · lint 0 errors · smoke · comments-sidebar — all green.