### PR TITLE
feat(ux): table Format panel as scannable icon tiles

### DIFF
--- a/docx-editor/packages/react/src/components/sidebar/TablePropertiesSection.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/TablePropertiesSection.tsx
@@ -1,38 +1,151 @@
 /**
  * Table section of the Format/Properties panel. Surfaces the core table
- * structure operations (insert / delete rows & columns, merge / split cells,
- * delete table) in the contextual right rail — the same actions that were
- * previously only reachable from the toolbar grid dropdown. Grouped like the
- * Google-Docs table menu so the panel is the single home for object
- * properties. Border / shading / cell-alignment groups plug in here next.
+ * structure operations as scannable ICON tiles (insert / delete rows &
+ * columns, merge / split cells, delete table) — the Google-Docs table-tools
+ * model — instead of a wall of text. Each tile dispatches through the editor's
+ * existing `handleTableAction`, so behaviour is identical to the toolbar path.
  *
- * Each button dispatches through the editor's existing `handleTableAction`,
- * so behaviour is identical to the toolbar path — this is purely a relocation
- * of the controls into the panel, not a new command surface.
+ * Icon motif: a mini 2×2 table grid with the affected row/column tinted, plus
+ * a green ＋ for insert (on the relevant edge) or a red bar for delete, so the
+ * direction/effect reads at a glance.
  */
-import type { CSSProperties } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import type { TableAction } from '../ui/TableToolbar';
 
-const GROUP_HEADER: CSSProperties = {
-  padding: '12px 16px 6px',
-  fontSize: 11,
-  textTransform: 'uppercase',
-  letterSpacing: '0.04em',
-  color: 'var(--doc-text-muted)',
-  fontWeight: 600,
-};
+const ACCENT = 'var(--doc-primary, #1a73e8)';
+const ADD = '#1e8e3e';
+const DEL = '#d93025';
+const LINE = 'currentColor';
 
-const ROW_BTN = (danger: boolean): CSSProperties => ({
-  display: 'block',
-  width: '100%',
-  textAlign: 'left',
-  padding: '7px 16px',
-  fontSize: 13,
-  background: 'transparent',
-  color: danger ? 'var(--doc-danger, #d93025)' : 'var(--doc-text, #202124)',
-  border: 'none',
-  cursor: 'pointer',
-});
+// Shared mini-grid frame (a 2×2 table). `tint` colours one band to show which
+// row/column an action targets.
+function Grid({
+  tint,
+  band,
+}: {
+  tint?: string;
+  band?: 'top' | 'bottom' | 'left' | 'right' | 'all';
+}) {
+  const cells: ReactNode[] = [];
+  if (tint && band) {
+    if (band === 'top')
+      cells.push(<rect key="b" x="4" y="4" width="16" height="6" fill={tint} opacity="0.85" />);
+    if (band === 'bottom')
+      cells.push(<rect key="b" x="4" y="14" width="16" height="6" fill={tint} opacity="0.85" />);
+    if (band === 'left')
+      cells.push(<rect key="b" x="4" y="4" width="6" height="16" fill={tint} opacity="0.85" />);
+    if (band === 'right')
+      cells.push(<rect key="b" x="14" y="4" width="6" height="16" fill={tint} opacity="0.85" />);
+    if (band === 'all')
+      cells.push(<rect key="b" x="4" y="4" width="16" height="16" fill={tint} opacity="0.15" />);
+  }
+  return (
+    <>
+      {cells}
+      <rect
+        x="4"
+        y="4"
+        width="16"
+        height="16"
+        rx="1.5"
+        fill="none"
+        stroke={LINE}
+        strokeWidth="1.5"
+      />
+      <path d="M12 4v16M4 12h16" stroke={LINE} strokeWidth="1.2" />
+    </>
+  );
+}
+
+function Plus({ x, y }: { x: number; y: number }) {
+  return (
+    <g stroke={ADD} strokeWidth="1.8" strokeLinecap="round">
+      <path d={`M${x - 3} ${y}h6M${x} ${y - 3}v6`} />
+    </g>
+  );
+}
+
+const ICONS: Record<string, ReactNode> = {
+  addRowAbove: (
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="none">
+      <Grid tint={ADD} band="top" />
+      <Plus x={12} y={1.5} />
+    </svg>
+  ),
+  addRowBelow: (
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="none">
+      <Grid tint={ADD} band="bottom" />
+      <Plus x={12} y={22.5} />
+    </svg>
+  ),
+  deleteRow: (
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="none">
+      <Grid tint={DEL} band="all" />
+      <rect x="4" y="10.5" width="16" height="3" fill={DEL} />
+    </svg>
+  ),
+  addColumnLeft: (
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="none">
+      <Grid tint={ADD} band="left" />
+      <Plus x={1.5} y={12} />
+    </svg>
+  ),
+  addColumnRight: (
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="none">
+      <Grid tint={ADD} band="right" />
+      <Plus x={22.5} y={12} />
+    </svg>
+  ),
+  deleteColumn: (
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="none">
+      <Grid tint={DEL} band="all" />
+      <rect x="10.5" y="4" width="3" height="16" fill={DEL} />
+    </svg>
+  ),
+  mergeCells: (
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="none">
+      <rect
+        x="4"
+        y="6"
+        width="16"
+        height="12"
+        rx="1.5"
+        fill="none"
+        stroke={LINE}
+        strokeWidth="1.5"
+      />
+      <path d="M12 6v3M12 15v3" stroke={LINE} strokeWidth="1.2" />
+      <path
+        d="M9 12h6M9 12l2-2M9 12l2 2M15 12l-2-2M15 12l-2 2"
+        stroke={ACCENT}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
+  splitCell: (
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="none">
+      <rect
+        x="4"
+        y="6"
+        width="16"
+        height="12"
+        rx="1.5"
+        fill="none"
+        stroke={LINE}
+        strokeWidth="1.5"
+      />
+      <path d="M12 6v12" stroke={ACCENT} strokeWidth="1.5" strokeDasharray="2 2" />
+    </svg>
+  ),
+  deleteTable: (
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="none">
+      <Grid />
+      <path d="M7 7l10 10M17 7L7 17" stroke={DEL} strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  ),
+};
 
 interface Item {
   action: Extract<TableAction, string>;
@@ -44,24 +157,24 @@ const GROUPS: { header: string; items: Item[] }[] = [
   {
     header: 'Rows',
     items: [
-      { action: 'addRowAbove', label: 'Insert row above' },
-      { action: 'addRowBelow', label: 'Insert row below' },
-      { action: 'deleteRow', label: 'Delete row', danger: true },
+      { action: 'addRowAbove', label: 'Above' },
+      { action: 'addRowBelow', label: 'Below' },
+      { action: 'deleteRow', label: 'Delete', danger: true },
     ],
   },
   {
     header: 'Columns',
     items: [
-      { action: 'addColumnLeft', label: 'Insert column left' },
-      { action: 'addColumnRight', label: 'Insert column right' },
-      { action: 'deleteColumn', label: 'Delete column', danger: true },
+      { action: 'addColumnLeft', label: 'Left' },
+      { action: 'addColumnRight', label: 'Right' },
+      { action: 'deleteColumn', label: 'Delete', danger: true },
     ],
   },
   {
     header: 'Cells',
     items: [
-      { action: 'mergeCells', label: 'Merge cells' },
-      { action: 'splitCell', label: 'Split cell' },
+      { action: 'mergeCells', label: 'Merge' },
+      { action: 'splitCell', label: 'Split' },
     ],
   },
   {
@@ -69,6 +182,38 @@ const GROUPS: { header: string; items: Item[] }[] = [
     items: [{ action: 'deleteTable', label: 'Delete table', danger: true }],
   },
 ];
+
+const GROUP_HEADER: CSSProperties = {
+  padding: '12px 16px 6px',
+  fontSize: 11,
+  textTransform: 'uppercase',
+  letterSpacing: '0.04em',
+  color: 'var(--doc-text-muted)',
+  fontWeight: 600,
+};
+
+const TILE_GRID: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  gap: 6,
+  padding: '0 12px 4px',
+};
+
+const tile = (danger: boolean): CSSProperties => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 4,
+  padding: '8px 2px 6px',
+  fontSize: 11,
+  lineHeight: 1.2,
+  textAlign: 'center',
+  color: danger ? 'var(--doc-danger, #d93025)' : 'var(--doc-text, #202124)',
+  background: 'transparent',
+  border: '1.5px solid var(--doc-border, #dadce0)',
+  borderRadius: 8,
+  cursor: 'pointer',
+});
 
 export interface TablePropertiesSectionProps {
   /** Dispatch a table action (host wires this to handleTableAction). */
@@ -81,20 +226,22 @@ export function TablePropertiesSection({ onAction }: TablePropertiesSectionProps
       {GROUPS.map((group) => (
         <div key={group.header}>
           <div style={GROUP_HEADER}>{group.header}</div>
-          <div role="group" aria-label={group.header}>
+          <div style={TILE_GRID} role="group" aria-label={group.header}>
             {group.items.map((item) => (
               <button
                 key={item.action}
                 type="button"
-                role="menuitem"
-                style={ROW_BTN(!!item.danger)}
+                style={tile(!!item.danger)}
+                title={item.label}
+                aria-label={`${group.header}: ${item.label}`}
                 data-testid={`properties-table-${item.action}`}
                 onMouseDown={(e) => {
                   e.preventDefault();
                   onAction(item.action);
                 }}
               >
-                {item.label}
+                {ICONS[item.action]}
+                <span>{item.label}</span>
               </button>
             ))}
           </div>


### PR DESCRIPTION
The table Format panel was a plain text list — you couldn't tell what each action did at a glance. Rebuilt as **icon tiles** grouped Rows / Columns / Cells / Table, mirroring the image panel's tile picker.

Each tile is a mini 2×2 table-grid glyph with the affected row/column tinted + a direction cue:
- green **＋** on the relevant edge for insert (Above / Below, Left / Right)
- red bar for delete row / column
- merge arrows / dashed divider for cells
- red **✕** for delete table

Destructive tiles are red. Behaviour unchanged — same `handleTableAction`, testids preserved.

Screenshot-verified. Gate: typecheck · format · lint 0 errors · panel + comments-sidebar + smoke (10 e2e) green.