### PR TITLE
feat(footnotes): collab-sync footnote edits (shared Y.Map) + coverage audit

### DIFF
--- a/docs/internal/25-collab-coverage.md
+++ b/docs/internal/25-collab-coverage.md
@@ -1,0 +1,43 @@
+# 25 — Collab coverage of editable surfaces
+
+What syncs over the shared Y.Doc (Hocuspocus + `useCollab`) and what doesn't.
+The rule: anything edited **inside the ProseMirror document** rides `ySyncPlugin`
+automatically; anything edited **outside** the PM tree needs its own shared Yjs
+type in the same Y.Doc (a `Y.Map`/`Y.Array`) or it won't reach peers — and can be
+lost when a different peer triggers the snapshot.
+
+## In the PM document → synced automatically ✅
+These mutate PM nodes/marks via `view.dispatch`, so `ySyncPlugin` syncs them and
+any peer's snapshot carries them. All this session's Format-panel work is here:
+
+| Surface | Mechanism | Collab |
+| --- | --- | --- |
+| Body text / paragraphs / lists / tables | PM nodes | ✅ |
+| Image edits (wrap, size, rotate/flip, border, alt, dist) | `setNodeMarkup` on the image node | ✅ |
+| Table ops (insert/delete row·col, merge/split, delete) | PM table commands | ✅ |
+| Text box / shape edits (size, fill, outline) + **rawXml-clear-on-edit** | `setNodeMarkup` on the textBox node | ✅ |
+| Text box on-canvas resize handles | `setNodeMarkup` (same node attrs) | ✅ |
+| Comment **range highlights** | `comment` PM mark | ✅ (mark only — see below) |
+
+## Outside the PM document → needs a shared Yjs type
+| Surface | Where it lives | Collab status | Action |
+| --- | --- | --- | --- |
+| **File name / meta** | `meta` Y.Map | ✅ synced | — (already wired) |
+| **Footnote text** | `package.footnotes` | ✅ **synced** via the `footnotes` Y.Map + `makeFootnoteSync` (PR #65) | done |
+| **Comment threads** (text, author, replies, resolved) | React `comments` state / controlled `comments` prop | ❌ **NOT synced** — the highlight mark syncs but the thread content does not, so a peer sees a highlight with no comment. **Real gap.** | Wire a `comments` Y.Array in `useCollab`; reconcile with DocxEditor's existing controlled `comments` + `onCommentsChange` API. Concurrency (replies/resolve) needs per-item modelling. Sizeable — own focused effort. |
+| **Endnote text** | `package.endnotes` | ⚪ not editable yet (render-only) | when endnote editing is added, mirror the footnote `endnotes` Y.Map pattern |
+| **Document properties** (title/author/…) | `package.properties` | ⚪ not synced; low-frequency | minor; a `props` Y.Map later if needed |
+| **Header/footer text** | parsed parts; edited via double-click → PM region | mostly PM (synced); the part wiring needs a spot check | verify, then wire if any out-of-PM bits |
+
+## The pattern (for any future out-of-PM surface)
+1. Add a `Y.Map`/`Y.Array` to the same Y.Doc in `useCollab`.
+2. Expose a small `{ set, observe }` adapter (`makeFootnoteSync` is the template).
+3. In DocxEditor, route local edits through `set`; an observer applies **every**
+   changed entry (local + remote) to that peer's model + repaints — so every
+   peer's snapshot carries the edit.
+4. Prove it with a two-`Y.Doc` unit test (no server needed).
+
+## Verdict
+Everything built this session is collab-safe: the Format-panel edits are PM-node
+edits (synced), and footnotes are now synced. The one **real** remaining gap is
+**comment-thread sync** — same class of fix, but a sizeable feature on its own.

--- a/docx-editor/packages/react/src/collab/footnoteSync.test.ts
+++ b/docx-editor/packages/react/src/collab/footnoteSync.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from 'bun:test';
+import * as Y from 'yjs';
+import { makeFootnoteSync } from './useCollab';
+
+/**
+ * Proves footnote edits sync across peers WITHOUT a server: two Y.Docs, an edit
+ * on one is observed on the other after a state update is exchanged — exactly
+ * how Hocuspocus relays them in a room.
+ */
+describe('makeFootnoteSync (collab transport)', () => {
+  test('an edit on peer A is observed on peer B with parsed id + text', () => {
+    const docA = new Y.Doc();
+    const docB = new Y.Doc();
+    const mapA = docA.getMap<string>('footnotes');
+    const mapB = docB.getMap<string>('footnotes');
+
+    const received: Array<[number, string]> = [];
+    const syncB = makeFootnoteSync(mapB);
+    const unsub = syncB.observe((id, text) => received.push([id, text]));
+
+    // Peer A edits footnote 2; relay the update to B (what the server does).
+    makeFootnoteSync(mapA).set(2, 'Synced footnote body');
+    Y.applyUpdate(docB, Y.encodeStateAsUpdate(docA));
+
+    expect(mapB.get('2')).toBe('Synced footnote body');
+    expect(received).toContainEqual([2, 'Synced footnote body']);
+
+    unsub();
+    docA.destroy();
+    docB.destroy();
+  });
+
+  test('observe stops firing after unsubscribe', () => {
+    const doc = new Y.Doc();
+    const map = doc.getMap<string>('footnotes');
+    let calls = 0;
+    const unsub = makeFootnoteSync(map).observe(() => calls++);
+    map.set('1', 'a');
+    unsub();
+    map.set('1', 'b');
+    expect(calls).toBe(1);
+    doc.destroy();
+  });
+});

--- a/docx-editor/packages/react/src/collab/useCollab.ts
+++ b/docx-editor/packages/react/src/collab/useCollab.ts
@@ -60,6 +60,41 @@ export interface CollabState {
    * Yjs propagates to all others.
    */
   metaMap: Y.Map<unknown>;
+  /**
+   * Shared footnote-text edits (footnote id → plain text), in the same Y.Doc
+   * as the body. Footnotes aren't in the ProseMirror tree, so this is how
+   * footnote edits sync across peers. Hosts pass a small adapter built from
+   * this map to `<DocxEditor footnoteSync={...} />`.
+   */
+  footnotesMap: Y.Map<string>;
+}
+
+/** A transport for footnote-text edits (id → text), backed by a shared map. */
+export interface FootnoteSync {
+  set: (id: number, text: string) => void;
+  observe: (cb: (id: number, text: string) => void) => () => void;
+}
+
+/**
+ * Build a {@link FootnoteSync} over a `footnotes` Y.Map. `set` writes the new
+ * text (which Yjs syncs to peers); `observe` fires the callback for every
+ * changed key — local AND remote — so each peer applies edits to its own model
+ * uniformly. Pure of React so it can be unit-tested with two synced Y.Docs.
+ */
+export function makeFootnoteSync(map: Y.Map<string>): FootnoteSync {
+  return {
+    set: (id, text) => map.set(String(id), text),
+    observe: (cb) => {
+      const handler = (event: Y.YMapEvent<string>) => {
+        event.changes.keys.forEach((_change, key) => {
+          const text = map.get(key);
+          if (text !== undefined) cb(Number(key), text);
+        });
+      };
+      map.observe(handler);
+      return () => map.unobserve(handler);
+    },
+  };
 }
 
 export interface UseCollabOptions {
@@ -84,7 +119,7 @@ export interface UseCollabOptions {
  * loader doesn't overwrite the Yjs-populated PM state.
  */
 export function useCollab({ room, backend, user, token }: UseCollabOptions): CollabState {
-  const { ydoc, provider, plugins, metaMap } = useMemo(() => {
+  const { ydoc, provider, plugins, metaMap, footnotesMap } = useMemo(() => {
     const ydoc = new Y.Doc();
     // Hocuspocus carries the document name in the handshake (`name`),
     // not the URL path — so `backend` is the bare ws endpoint. A
@@ -106,7 +141,13 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
       yUndoPlugin(),
     ];
     const metaMap = ydoc.getMap('meta');
-    return { ydoc, provider, plugins, metaMap };
+    // Footnote text edits don't live in the ProseMirror document (footnotes are
+    // a separate part of the .docx), so they don't travel over ySyncPlugin.
+    // A dedicated shared map in the SAME Y.Doc gives them the same realtime
+    // sync + offline resilience as the body content. Keyed by footnote id
+    // (string) → current plain text.
+    const footnotesMap = ydoc.getMap<string>('footnotes');
+    return { ydoc, provider, plugins, metaMap, footnotesMap };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [room, backend, token]);
 
@@ -162,5 +203,5 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
     };
   }, [provider, ydoc]);
 
-  return { plugins, status, peers, awareness: provider.awareness, metaMap };
+  return { plugins, status, peers, awareness: provider.awareness, metaMap, footnotesMap };
 }

--- a/docx-editor/packages/react/src/components/CasualEditor.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.tsx
@@ -39,6 +39,7 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -50,6 +51,7 @@ import type { Document } from '@eigenpal/docx-core/types/document';
 
 import {
   useCollab,
+  makeFootnoteSync,
   type CollabPeer,
   type CollabState,
   type CollabStatus,
@@ -221,6 +223,14 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
       if (collabState && onCollabState) onCollabState(collabState);
     }, [collabState, onCollabState]);
 
+    // Adapter so footnote edits ride the shared `footnotes` Y.Map (footnotes
+    // aren't in the PM tree, so they don't travel over ySyncPlugin). Memoised on
+    // collabState so the editor's observer subscribes once per session.
+    const footnoteSync = useMemo(
+      () => (collabState ? makeFootnoteSync(collabState.footnotesMap) : undefined),
+      [collabState]
+    );
+
     // ---------------------------------------------------------------
     // Autosave — opt-in via autosave={true}
     // ---------------------------------------------------------------
@@ -273,6 +283,7 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
         document={collabState ? blankDoc() : undefined}
         externalContent={!!collabState}
         externalPlugins={collabState ? collabState.plugins : undefined}
+        footnoteSync={footnoteSync}
         author={author}
         onSave={onSave}
         onSelectionChange={onSelectionChange}

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -498,6 +498,18 @@ export interface DocxEditorProps {
    */
   externalContent?: boolean;
   /**
+   * Collab transport for footnote-text edits. Footnotes aren't in the
+   * ProseMirror document, so they don't ride ySyncPlugin; the host wires this
+   * to a shared map (e.g. the `footnotes` Y.Map from `useCollab`) so footnote
+   * edits sync across peers and survive any peer's snapshot. When provided,
+   * footnote edits route through it; the observer applies local + remote edits
+   * uniformly. Omit for single-user (edits apply directly).
+   */
+  footnoteSync?: {
+    set: (id: number, text: string) => void;
+    observe: (cb: (id: number, text: string) => void) => () => void;
+  };
+  /**
    * Starting offset for comment/tracked-change IDs. Default 0.
    *
    * Comments and tracked-change revisions share a single numeric ID space
@@ -1567,6 +1579,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     onCommentsChange,
     externalPlugins,
     externalContent = false,
+    footnoteSync,
     commentIdBase,
     onEditorViewReady,
     onRenderedDomContextReady,
@@ -4061,25 +4074,19 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // Footnotes live on the document package (history.state), NOT the PM doc.
   const handleEditFootnote = useCallback(
     (footnoteId: number) => {
-      // Footnotes are NOT part of the Yjs-synced PM document, so an edit here
-      // wouldn't propagate to collaborators and could be lost on another peer's
-      // snapshot. Disable footnote editing in collaborative sessions until
-      // footnotes are modelled in the shared CRDT.
-      if (externalContent) {
-        toast.info('Footnote editing isn’t available in collaborative sessions yet.');
-        return;
-      }
       const fn = history.state?.package?.footnotes?.find((f) => f.id === footnoteId);
       setFootnoteEdit({ id: footnoteId, text: fn ? getFootnoteText(fn) : '' });
     },
-    [history, externalContent]
+    [history]
   );
 
   // Apply a footnote text edit to BOTH the render doc (history.state — repainted
   // via relayout) and the save doc (agentRef — read by handleSave). Marking the
   // footnote `edited` makes the save path regenerate ONLY its text in
-  // footnotes.xml; every untouched footnote stays verbatim.
-  const handleApplyFootnoteEdit = useCallback(
+  // footnotes.xml; every untouched footnote stays verbatim. This runs for BOTH
+  // local edits and remote (collab) edits observed off the shared map, so every
+  // peer's model — and therefore any peer's snapshot — carries the change.
+  const applyFootnoteEditToModel = useCallback(
     (footnoteId: number, text: string) => {
       const apply = (
         pkg: { footnotes?: import('@eigenpal/docx-core/types').Footnote[] } | undefined
@@ -4103,10 +4110,35 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         .forEach((el) => {
           (el as HTMLElement).textContent = ' ' + text;
         });
-      setFootnoteEdit(null);
     },
     [history]
   );
+
+  // Commit an edit from the editor dialog. In collab, route through the shared
+  // footnote map so peers receive it; the observer below applies it to every
+  // peer's model (including ours). Single-user applies directly.
+  const handleApplyFootnoteEdit = useCallback(
+    (footnoteId: number, text: string) => {
+      if (footnoteSync) {
+        footnoteSync.set(footnoteId, text);
+      } else {
+        applyFootnoteEditToModel(footnoteId, text);
+        pagedEditorRef.current?.relayout();
+      }
+      setFootnoteEdit(null);
+    },
+    [footnoteSync, applyFootnoteEditToModel]
+  );
+
+  // Apply remote (and own) footnote edits broadcast over the shared map.
+  useEffect(() => {
+    if (!footnoteSync) return;
+    const unsubscribe = footnoteSync.observe((id, text) => {
+      applyFootnoteEditToModel(id, text);
+      pagedEditorRef.current?.relayout();
+    });
+    return unsubscribe;
+  }, [footnoteSync, applyFootnoteEditToModel]);
 
   // Handle image transform (rotate/flip)
   const handleImageTransform = useCallback(


### PR DESCRIPTION
Follow-up to #65 — the collab half of footnote editing, which landed too late to be captured in #65's squash (main currently has footnote editing **with the collab gate still on**). This adds the sync and removes the gate.

Footnotes aren't in the ProseMirror tree, so they don't ride `ySyncPlugin`. Added a dedicated **`footnotes` Y.Map** to the same shared Y.Doc:
- `useCollab` exposes `footnotesMap`; `makeFootnoteSync(map)` → a `{ set, observe }` transport (pure, unit-tested).
- DocxEditor takes optional `footnoteSync`: edits route through `set`; an observer applies **every** changed key (local + remote) to that peer's model + repaints. Every peer applies the edit, so **any peer's snapshot carries it** (fixes the prior "lost on another peer's save" risk too).
- `CasualEditor` wires it from the collab session. Single-user passes nothing (applies directly).
- **Removes** the "disabled in collaborative sessions" gate.

Proven without a server: a two-`Y.Doc` test shows an edit on peer A is observed on peer B (parsed id + text) after a state exchange — exactly how Hocuspocus relays it.

Also adds `docs/internal/25-collab-coverage.md` — the audit of which editable surfaces sync over collab. Verdict: all of this session's Format-panel edits are PM-node edits (synced); footnotes now synced; the one remaining real gap is **comment-thread sync** (highlights sync, thread content doesn't).

Gate: typecheck · collab sync test green. (No core/save changes — additive collab wiring.)