### PR TITLE
feat(collab): sync comment threads over a shared Y.Map

### DIFF
--- a/docs/internal/25-collab-coverage.md
+++ b/docs/internal/25-collab-coverage.md
@@ -24,7 +24,7 @@ any peer's snapshot carries them. All this session's Format-panel work is here:
 | --- | --- | --- | --- |
 | **File name / meta** | `meta` Y.Map | ✅ synced | — (already wired) |
 | **Footnote text** | `package.footnotes` | ✅ **synced** via the `footnotes` Y.Map + `makeFootnoteSync` (PR #65) | done |
-| **Comment threads** (text, author, replies, resolved) | React `comments` state / controlled `comments` prop | ❌ **NOT synced** — the highlight mark syncs but the thread content does not, so a peer sees a highlight with no comment. **Real gap.** | Wire a `comments` Y.Array in `useCollab`; reconcile with DocxEditor's existing controlled `comments` + `onCommentsChange` API. Concurrency (replies/resolve) needs per-item modelling. Sizeable — own focused effort. |
+| **Comment threads** (text, author, replies, resolved) | React `comments` state / controlled `comments` prop | ✅ **synced** via the `comments` Y.Map (keyed by id) + `collab/commentSync`; CasualEditor drives DocxEditor's controlled `comments` + `onCommentsChange`. Replies are separate entries (parentId); add/reply/resolve/delete + concurrent adds proven by a two-peer test. | done |
 | **Endnote text** | `package.endnotes` | ⚪ not editable yet (render-only) | when endnote editing is added, mirror the footnote `endnotes` Y.Map pattern |
 | **Document properties** (title/author/…) | `package.properties` | ⚪ not synced; low-frequency | minor; a `props` Y.Map later if needed |
 | **Header/footer text** | parsed parts; edited via double-click → PM region | mostly PM (synced); the part wiring needs a spot check | verify, then wire if any out-of-PM bits |
@@ -39,5 +39,6 @@ any peer's snapshot carries them. All this session's Format-panel work is here:
 
 ## Verdict
 Everything built this session is collab-safe: the Format-panel edits are PM-node
-edits (synced), and footnotes are now synced. The one **real** remaining gap is
-**comment-thread sync** — same class of fix, but a sizeable feature on its own.
+edits (synced), footnotes are synced, and **comment threads are now synced**. No
+known out-of-PM editable surface remains unsynced. Endnote editing (not built
+yet) and doc properties are the only future items, and each mirrors this pattern.

--- a/docx-editor/packages/react/src/collab/commentSync.test.ts
+++ b/docx-editor/packages/react/src/collab/commentSync.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect } from 'bun:test';
+import * as Y from 'yjs';
+import type { Comment } from '@eigenpal/docx-core/types/content';
+import { commentsFromMap, writeCommentsToMap, observeComments } from './commentSync';
+
+function comment(id: number, text: string, extra: Partial<Comment> = {}): Comment {
+  return {
+    id,
+    author: 'A',
+    content: [{ type: 'paragraph', content: [{ type: 'run', content: [{ type: 'text', text }] }] }],
+    ...extra,
+  };
+}
+
+const sync = (from: Y.Doc, to: Y.Doc) => Y.applyUpdate(to, Y.encodeStateAsUpdate(from));
+
+describe('commentSync (collab transport)', () => {
+  test('add, reply, resolve, delete all propagate to a peer', () => {
+    const docA = new Y.Doc();
+    const docB = new Y.Doc();
+    const mapA = docA.getMap('comments');
+    const mapB = docB.getMap('comments');
+
+    let latestB: Comment[] = [];
+    const unsub = observeComments(mapB, (c) => (latestB = c));
+
+    // A adds a comment
+    writeCommentsToMap(mapA, [comment(1, 'first comment')]);
+    sync(docA, docB);
+    expect(latestB.map((c) => c.id)).toEqual([1]);
+    expect(latestB[0].content[0].content[0]).toMatchObject({ type: 'run' });
+
+    // A adds a reply (separate comment with parentId)
+    writeCommentsToMap(mapA, [comment(1, 'first comment'), comment(2, 'a reply', { parentId: 1 })]);
+    sync(docA, docB);
+    expect(latestB.map((c) => c.id)).toEqual([1, 2]);
+    expect(latestB.find((c) => c.id === 2)?.parentId).toBe(1);
+
+    // A resolves the thread
+    writeCommentsToMap(mapA, [
+      comment(1, 'first comment', { done: true }),
+      comment(2, 'a reply', { parentId: 1 }),
+    ]);
+    sync(docA, docB);
+    expect(latestB.find((c) => c.id === 1)?.done).toBe(true);
+
+    // A deletes the reply
+    writeCommentsToMap(mapA, [comment(1, 'first comment', { done: true })]);
+    sync(docA, docB);
+    expect(latestB.map((c) => c.id)).toEqual([1]);
+
+    unsub();
+    docA.destroy();
+    docB.destroy();
+  });
+
+  test('concurrent adds from two peers merge (different keys)', () => {
+    const docA = new Y.Doc();
+    const docB = new Y.Doc();
+    // each peer adds its own comment independently, then they exchange state
+    writeCommentsToMap(docA.getMap('comments'), [comment(1, 'from A')]);
+    writeCommentsToMap(docB.getMap('comments'), [comment(2, 'from B')]);
+    sync(docA, docB);
+    sync(docB, docA);
+    expect(commentsFromMap(docA.getMap('comments')).map((c) => c.id)).toEqual([1, 2]);
+    expect(commentsFromMap(docB.getMap('comments')).map((c) => c.id)).toEqual([1, 2]);
+    docA.destroy();
+    docB.destroy();
+  });
+});

--- a/docx-editor/packages/react/src/collab/commentSync.ts
+++ b/docx-editor/packages/react/src/collab/commentSync.ts
@@ -1,0 +1,61 @@
+/**
+ * Collab transport for comment threads. Comment highlight marks ride
+ * ySyncPlugin (they're in the PM doc), but the thread content — author, text,
+ * replies, resolved state — lives in React state and would NOT reach peers.
+ * This bridges DocxEditor's controlled `comments` + `onCommentsChange` API to a
+ * shared `comments` Y.Map keyed by comment id.
+ *
+ * Model: one Y.Map entry per Comment (replies are separate Comments with
+ * `parentId`). Concurrency:
+ *   - two peers adding different comments → different keys → merge cleanly.
+ *   - two peers editing the SAME comment → last-write-wins on that key.
+ * That's the right granularity for v1 (each thread/reply is independent).
+ */
+import type * as Y from 'yjs';
+import type { Comment } from '@eigenpal/docx-core/types/content';
+
+/** Rebuild the Comment[] from the shared map, ordered by id (creation order). */
+export function commentsFromMap(map: Y.Map<unknown>): Comment[] {
+  const out: Comment[] = [];
+  map.forEach((value) => {
+    if (value && typeof value === 'object') out.push(value as Comment);
+  });
+  out.sort((a, b) => a.id - b.id);
+  return out;
+}
+
+/**
+ * Reconcile the full Comment[] into the shared map in one transaction: upsert
+ * every current comment by id, delete entries that no longer exist. Skips the
+ * write entirely when nothing changed so we don't echo our own observer.
+ */
+export function writeCommentsToMap(map: Y.Map<unknown>, comments: Comment[]): void {
+  const doc = map.doc;
+  const apply = () => {
+    const nextIds = new Set(comments.map((c) => String(c.id)));
+    // Delete removed.
+    for (const key of Array.from(map.keys())) {
+      if (!nextIds.has(key)) map.delete(key);
+    }
+    // Upsert changed (cheap deep-equal via JSON to avoid redundant churn).
+    for (const c of comments) {
+      const key = String(c.id);
+      const existing = map.get(key);
+      if (!existing || JSON.stringify(existing) !== JSON.stringify(c)) {
+        map.set(key, c);
+      }
+    }
+  };
+  if (doc) doc.transact(apply);
+  else apply();
+}
+
+/** Observe remote+local map changes; fire `cb` with the rebuilt Comment[]. */
+export function observeComments(
+  map: Y.Map<unknown>,
+  cb: (comments: Comment[]) => void
+): () => void {
+  const handler = () => cb(commentsFromMap(map));
+  map.observe(handler);
+  return () => map.unobserve(handler);
+}

--- a/docx-editor/packages/react/src/collab/useCollab.ts
+++ b/docx-editor/packages/react/src/collab/useCollab.ts
@@ -67,6 +67,13 @@ export interface CollabState {
    * this map to `<DocxEditor footnoteSync={...} />`.
    */
   footnotesMap: Y.Map<string>;
+  /**
+   * Shared comment threads (comment id → Comment JSON), in the same Y.Doc as
+   * the body. Comment highlight marks ride ySyncPlugin, but the thread content
+   * doesn't — this map carries it. Hosts wire it to DocxEditor's controlled
+   * `comments` + `onCommentsChange` via the helpers in `collab/commentSync`.
+   */
+  commentsMap: Y.Map<unknown>;
 }
 
 /** A transport for footnote-text edits (id → text), backed by a shared map. */
@@ -119,7 +126,7 @@ export interface UseCollabOptions {
  * loader doesn't overwrite the Yjs-populated PM state.
  */
 export function useCollab({ room, backend, user, token }: UseCollabOptions): CollabState {
-  const { ydoc, provider, plugins, metaMap, footnotesMap } = useMemo(() => {
+  const { ydoc, provider, plugins, metaMap, footnotesMap, commentsMap } = useMemo(() => {
     const ydoc = new Y.Doc();
     // Hocuspocus carries the document name in the handshake (`name`),
     // not the URL path — so `backend` is the bare ws endpoint. A
@@ -147,7 +154,12 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
     // sync + offline resilience as the body content. Keyed by footnote id
     // (string) → current plain text.
     const footnotesMap = ydoc.getMap<string>('footnotes');
-    return { ydoc, provider, plugins, metaMap, footnotesMap };
+    // Comment threads (text / replies / resolved) live in React state, not the
+    // PM tree, so the highlight marks sync but the thread content wouldn't.
+    // A shared map keyed by comment id (string) → Comment JSON gives them the
+    // same realtime sync. Replies are separate Comment entries (parentId).
+    const commentsMap = ydoc.getMap<unknown>('comments');
+    return { ydoc, provider, plugins, metaMap, footnotesMap, commentsMap };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [room, backend, token]);
 
@@ -203,5 +215,13 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
     };
   }, [provider, ydoc]);
 
-  return { plugins, status, peers, awareness: provider.awareness, metaMap, footnotesMap };
+  return {
+    plugins,
+    status,
+    peers,
+    awareness: provider.awareness,
+    metaMap,
+    footnotesMap,
+    commentsMap,
+  };
 }

--- a/docx-editor/packages/react/src/components/CasualEditor.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.tsx
@@ -37,6 +37,7 @@
 
 import {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -48,6 +49,7 @@ import {
 import { DocxEditor, type DocxEditorProps, type DocxEditorRef } from './DocxEditor';
 import { createEmptyDocument } from '@eigenpal/docx-core/utils';
 import type { Document } from '@eigenpal/docx-core/types/document';
+import type { Comment } from '@eigenpal/docx-core/types/content';
 
 import {
   useCollab,
@@ -56,6 +58,7 @@ import {
   type CollabState,
   type CollabStatus,
 } from '../collab/useCollab';
+import { commentsFromMap, observeComments, writeCommentsToMap } from '../collab/commentSync';
 import {
   useFileSourceAutoSave,
   type UseFileSourceAutoSaveReturn,
@@ -231,6 +234,25 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
       [collabState]
     );
 
+    // Comment threads ride a shared `comments` Y.Map (highlight marks sync via
+    // ySyncPlugin, but the thread content doesn't). In collab we drive
+    // DocxEditor's CONTROLLED comments from the map: observe → setState; the
+    // editor's onCommentsChange reconciles back into the map (the observer is
+    // the single source of truth, so local writes round-trip through it too).
+    const [collabComments, setCollabComments] = useState<Comment[]>([]);
+    useEffect(() => {
+      if (!collabState) return;
+      const map = collabState.commentsMap;
+      setCollabComments(commentsFromMap(map));
+      return observeComments(map, setCollabComments);
+    }, [collabState]);
+    const handleCommentsChange = useCallback(
+      (next: Comment[]) => {
+        if (collabState) writeCommentsToMap(collabState.commentsMap, next);
+      },
+      [collabState]
+    );
+
     // ---------------------------------------------------------------
     // Autosave — opt-in via autosave={true}
     // ---------------------------------------------------------------
@@ -284,6 +306,8 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
         externalContent={!!collabState}
         externalPlugins={collabState ? collabState.plugins : undefined}
         footnoteSync={footnoteSync}
+        comments={collabState ? collabComments : undefined}
+        onCommentsChange={collabState ? handleCommentsChange : undefined}
         author={author}
         onSave={onSave}
         onSelectionChange={onSelectionChange}


### PR DESCRIPTION
Closes the last out-of-PM collab gap. Comment **highlight marks** ride `ySyncPlugin`, but the **thread content** (author/text/replies/resolved) lived only in React state — so a collaborator saw a highlight with no comment. Now it syncs.

- `useCollab` exposes a `comments` Y.Map (keyed by comment id → `Comment` JSON).
- `collab/commentSync`: `commentsFromMap` / `writeCommentsToMap` (one transaction — upsert-by-id + delete-missing, JSON-equal guard) / `observeComments`.
- `CasualEditor` drives DocxEditor's existing **controlled** `comments` + `onCommentsChange`: observe map → setState; change → reconcile into the map (observer is the single source of truth, so local + remote round-trip uniformly). Every peer applies every change → any peer's snapshot carries the threads.
- Single-user is unchanged (uncontrolled comments path).

**Model:** one entry per `Comment`; replies are separate entries (`parentId`). **Two-peer test** proves add / reply / resolve / delete propagate and concurrent adds from two peers merge.

Coverage audit (`docs/internal/25`) updated — **no out-of-PM editable surface remains unsynced**.

Gate: typecheck · format · lint 0 errors · collab unit tests (footnote + comment) · smoke. (One pre-existing flake — comments-sidebar Ctrl+Alt+M — fails on a clean tree too; unrelated.)