### PR TITLE
feat(endnotes): render at document end + editable + collab-synced

### DIFF
--- a/docs/internal/25-collab-coverage.md
+++ b/docs/internal/25-collab-coverage.md
@@ -25,7 +25,7 @@ any peer's snapshot carries them. All this session's Format-panel work is here:
 | **File name / meta** | `meta` Y.Map | ✅ synced | — (already wired) |
 | **Footnote text** | `package.footnotes` | ✅ **synced** via the `footnotes` Y.Map + `makeFootnoteSync` (PR #65) | done |
 | **Comment threads** (text, author, replies, resolved) | React `comments` state / controlled `comments` prop | ✅ **synced** via the `comments` Y.Map (keyed by id) + `collab/commentSync`; CasualEditor drives DocxEditor's controlled `comments` + `onCommentsChange`. Replies are separate entries (parentId); add/reply/resolve/delete + concurrent adds proven by a two-peer test. | done |
-| **Endnote text** | `package.endnotes` | ⚪ not editable yet (render-only) | when endnote editing is added, mirror the footnote `endnotes` Y.Map pattern |
+| **Endnote text** | `package.endnotes` | ✅ **rendered + editable + synced**: endnotes now paint at document end (`EndnoteSection` — they were never displayed before), double-click → edit → surgical `endnotes.xml` regen on save; synced via the `endnotes` Y.Map (reuses `makeFootnoteSync`). Mirrors footnotes end-to-end. | done |
 | **Document properties** (title/author/…) | `package.properties` | ⚪ not synced; low-frequency | minor; a `props` Y.Map later if needed |
 | **Header/footer text** | parsed parts; edited via double-click → PM region | mostly PM (synced); the part wiring needs a spot check | verify, then wire if any out-of-PM bits |
 
@@ -38,7 +38,7 @@ any peer's snapshot carries them. All this session's Format-panel work is here:
 4. Prove it with a two-`Y.Doc` unit test (no server needed).
 
 ## Verdict
-Everything built this session is collab-safe: the Format-panel edits are PM-node
-edits (synced), footnotes are synced, and **comment threads are now synced**. No
-known out-of-PM editable surface remains unsynced. Endnote editing (not built
-yet) and doc properties are the only future items, and each mirrors this pattern.
+Everything is collab-safe: Format-panel edits are PM-node edits (synced),
+footnotes synced, comment threads synced, and **endnotes rendered + editable +
+synced**. The only remaining future item is **doc-properties sync** (low-
+frequency, a `props` Y.Map when wanted) — same pattern.

--- a/docx-editor/e2e/tests/endnote-edit.spec.ts
+++ b/docx-editor/e2e/tests/endnote-edit.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Endnote text editing — render + edit + round-trip persistence. Endnotes are
+ * now rendered at document end; double-click → editor → change → save → reload
+ * persists (endnotes.xml surgically regenerated).
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+import { writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const EN = '[data-testid="docx-editor"] .layout-endnote[data-endnote-id]';
+const UNIQUE = 'EN_EDIT_PERSIST_2026';
+
+test('endnote: renders at doc end → edit → save → reload persists', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/demo.docx');
+  await page.waitForTimeout(1800);
+
+  // the endnote section renders
+  await expect(page.locator('[data-testid="endnote-section"]')).toBeAttached();
+  const en = page.locator(EN).first();
+  await expect(en).toBeAttached();
+  await en.scrollIntoViewIfNeeded();
+  await en.dblclick();
+  await page.waitForTimeout(300);
+
+  await expect(page.locator('[data-testid="footnote-edit-dialog"]')).toBeVisible();
+  await page.locator('[data-testid="footnote-edit-text"]').fill(UNIQUE);
+  await page.locator('[data-testid="footnote-edit-apply"]').click();
+  await page.waitForTimeout(500);
+
+  // live update
+  await expect(page.locator(EN).first()).toContainText(UNIQUE);
+
+  // export → reload → persisted
+  const b64 = await page.evaluate(async () => {
+    // @ts-expect-error e2e hook
+    const buf: ArrayBuffer | null = await window.__editorRef?.current?.exportDocx?.();
+    if (!buf) return null;
+    let bin = '';
+    const bytes = new Uint8Array(buf);
+    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+    return btoa(bin);
+  });
+  expect(b64).toBeTruthy();
+  const out = join(tmpdir(), `rt-endnote-${Date.now()}.docx`);
+  writeFileSync(out, Buffer.from(b64 as string, 'base64'));
+
+  await editor.loadDocxFile(out);
+  await page.waitForTimeout(1800);
+  await expect(page.locator(EN).first()).toContainText(UNIQUE);
+});

--- a/docx-editor/packages/core/src/docx/index.ts
+++ b/docx-editor/packages/core/src/docx/index.ts
@@ -45,7 +45,7 @@ export {
   isSeparatorEndnote,
 } from './footnoteParser';
 export type { FootnoteMap, EndnoteMap } from './footnoteParser';
-export { setFootnotePlainText } from './serializer/footnoteSerializer';
+export { setFootnotePlainText, setEndnotePlainText } from './serializer/footnoteSerializer';
 
 // Fields
 export {

--- a/docx-editor/packages/core/src/docx/rezip.ts
+++ b/docx-editor/packages/core/src/docx/rezip.ts
@@ -34,7 +34,7 @@ import type { Document } from '../types/document';
 import type { BlockContent, HeaderFooter, Image, Hyperlink } from '../types/content';
 import { serializeDocument } from './serializer/documentSerializer';
 import { serializeHeaderFooter } from './serializer/headerFooterSerializer';
-import { replaceFootnotesInXml } from './serializer/footnoteSerializer';
+import { replaceFootnotesInXml, replaceEndnotesInXml } from './serializer/footnoteSerializer';
 import {
   serializeCommentsWithInfo,
   serializeCommentsExtended,
@@ -500,6 +500,17 @@ export async function repackDocx(doc: Document, options: RepackOptions = {}): Pr
         });
       }
     }
+    const editedEndnotes = (exportDocument.package?.endnotes ?? []).filter((e) => e.edited);
+    if (editedEndnotes.length > 0) {
+      const enFile = originalZip.file('word/endnotes.xml');
+      if (enFile) {
+        const newEnXml = replaceEndnotesInXml(await enFile.async('text'), editedEndnotes);
+        newZip.file('word/endnotes.xml', newEnXml, {
+          compression: 'DEFLATE',
+          compressionOptions: { level: compressionLevel },
+        });
+      }
+    }
   }
 
   // Update docProps/core.xml. Two independent inputs are applied:
@@ -608,6 +619,17 @@ export async function repackDocxFromRaw(
       if (fnFile) {
         const newFnXml = replaceFootnotesInXml(await fnFile.async('text'), editedFootnotes);
         newZip.file('word/footnotes.xml', newFnXml, {
+          compression: 'DEFLATE',
+          compressionOptions: { level: compressionLevel },
+        });
+      }
+    }
+    const editedEndnotes = (exportDocument.package?.endnotes ?? []).filter((e) => e.edited);
+    if (editedEndnotes.length > 0) {
+      const enFile = rawContent.originalZip.file('word/endnotes.xml');
+      if (enFile) {
+        const newEnXml = replaceEndnotesInXml(await enFile.async('text'), editedEndnotes);
+        newZip.file('word/endnotes.xml', newEnXml, {
           compression: 'DEFLATE',
           compressionOptions: { level: compressionLevel },
         });

--- a/docx-editor/packages/core/src/docx/serializer/endnoteSerializer.test.ts
+++ b/docx-editor/packages/core/src/docx/serializer/endnoteSerializer.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import JSZip from 'jszip';
+import { parseEndnotes, getEndnoteText } from '../footnoteParser';
+import { setEndnotePlainText, replaceEndnotesInXml } from './footnoteSerializer';
+
+const FIXTURE = join(__dirname, '../../../../../e2e/fixtures/demo.docx');
+
+async function loadEndnotesXml(): Promise<string> {
+  const zip = await JSZip.loadAsync(readFileSync(FIXTURE));
+  const f = zip.file('word/endnotes.xml');
+  return f ? await f.async('text') : '';
+}
+
+const blockOf = (xml: string, id: number) =>
+  new RegExp(`<w:endnote\\b[^>]*\\bw:id="${id}"[^>]*>[\\s\\S]*?</w:endnote>`).exec(xml)![0];
+
+describe('endnoteSerializer (text-surgery, opt-in)', () => {
+  test('replaces only the edited endnote text; marker + others byte-identical', async () => {
+    const xml = await loadEndnotesXml();
+    expect(xml).toContain('<w:endnote');
+    const map = parseEndnotes(xml);
+    const edited = map.endnotes.find(
+      (e) => (e.noteType ?? 'normal') === 'normal' && getEndnoteText(e).trim().length > 0
+    )!;
+    expect(edited).toBeTruthy();
+    const other = map.endnotes.find((e) => e.id !== edited.id);
+
+    setEndnotePlainText(edited, 'UNIQUE_ENDNOTE_EDIT_99');
+    const out = replaceEndnotesInXml(xml, [edited]);
+
+    const newBlock = blockOf(out, edited.id);
+    expect(newBlock).toContain('UNIQUE_ENDNOTE_EDIT_99');
+    expect(newBlock).toContain('<w:endnoteRef');
+    if (other) expect(out).toContain(blockOf(xml, other.id));
+    expect(out).toContain('<w:separator/>');
+
+    expect(getEndnoteText(parseEndnotes(out).byId.get(edited.id)!)).toBe('UNIQUE_ENDNOTE_EDIT_99');
+  });
+
+  test('no edited endnotes → XML returned untouched', async () => {
+    const xml = await loadEndnotesXml();
+    expect(replaceEndnotesInXml(xml, [])).toBe(xml);
+  });
+});

--- a/docx-editor/packages/core/src/docx/serializer/footnoteSerializer.ts
+++ b/docx-editor/packages/core/src/docx/serializer/footnoteSerializer.ts
@@ -14,8 +14,8 @@
  * were actually edited. Untouched documents keep footnotes.xml verbatim, so
  * the round-trip-fidelity guarantee is preserved.
  */
-import type { Footnote } from '../../types/content';
-import { getFootnoteText } from '../footnoteParser';
+import type { Endnote, Footnote } from '../../types/content';
+import { getEndnoteText, getFootnoteText } from '../footnoteParser';
 import { escapeXml } from './xmlUtils';
 
 /**
@@ -50,13 +50,26 @@ function setBodyText(bodyXml: string, text: string): string {
  * exact. The new text is the footnote model's current plain text.
  */
 export function replaceFootnotesInXml(originalXml: string, edited: Footnote[]): string {
+  return replaceNotesInXml(originalXml, edited, 'footnote', getFootnoteText);
+}
+
+/** Endnote sibling of {@link replaceFootnotesInXml} (operates on `<w:endnote>`). */
+export function replaceEndnotesInXml(originalXml: string, edited: Endnote[]): string {
+  return replaceNotesInXml(originalXml, edited, 'endnote', getEndnoteText);
+}
+
+/** Shared text-surgery for footnotes/endnotes — identical except the element. */
+function replaceNotesInXml<T extends { id: number }>(
+  originalXml: string,
+  edited: T[],
+  tag: 'footnote' | 'endnote',
+  getText: (n: T) => string
+): string {
   let xml = originalXml;
-  for (const fn of edited) {
-    const re = new RegExp(
-      `(<w:footnote\\b[^>]*\\bw:id="${fn.id}"[^>]*>)([\\s\\S]*?)(</w:footnote>)`
-    );
+  for (const note of edited) {
+    const re = new RegExp(`(<w:${tag}\\b[^>]*\\bw:id="${note.id}"[^>]*>)([\\s\\S]*?)(</w:${tag}>)`);
     xml = xml.replace(re, (_m, open: string, body: string, close: string) => {
-      return open + setBodyText(body, getFootnoteText(fn)) + close;
+      return open + setBodyText(body, getText(note)) + close;
     });
   }
   return xml;
@@ -68,6 +81,16 @@ export function replaceFootnotesInXml(originalXml: string, edited: Footnote[]): 
  * marker run is kept, the body collapses to a single text run.
  */
 export function setFootnotePlainText(fn: Footnote, text: string): void {
+  setNotePlainText(fn, text);
+}
+
+/** Endnote sibling of {@link setFootnotePlainText}. */
+export function setEndnotePlainText(en: Endnote, text: string): void {
+  setNotePlainText(en, text);
+}
+
+function setNotePlainText(note: Footnote | Endnote, text: string): void {
+  const fn = note;
   const para = fn.content.find((b) => b.type === 'paragraph');
   if (!para || para.type !== 'paragraph') {
     fn.content = [

--- a/docx-editor/packages/core/src/docx/serializer/index.ts
+++ b/docx-editor/packages/core/src/docx/serializer/index.ts
@@ -15,4 +15,9 @@ export { serializeRun } from './runSerializer';
 export { serializeTable } from './tableSerializer';
 export { serializeHeaderFooter } from './headerFooterSerializer';
 export { serializeComments } from './commentSerializer';
-export { setFootnotePlainText, replaceFootnotesInXml } from './footnoteSerializer';
+export {
+  setFootnotePlainText,
+  replaceFootnotesInXml,
+  setEndnotePlainText,
+  replaceEndnotesInXml,
+} from './footnoteSerializer';

--- a/docx-editor/packages/core/src/types/content.ts
+++ b/docx-editor/packages/core/src/types/content.ts
@@ -1428,6 +1428,8 @@ export interface Endnote {
    * the body — paragraphs and tables. See note on `Footnote.content`.
    */
   content: (Paragraph | Table)[];
+  /** Set true on edit; the save path regenerates only this endnote's text. */
+  edited?: boolean;
 }
 
 // ============================================================================

--- a/docx-editor/packages/react/src/collab/useCollab.ts
+++ b/docx-editor/packages/react/src/collab/useCollab.ts
@@ -67,6 +67,8 @@ export interface CollabState {
    * this map to `<DocxEditor footnoteSync={...} />`.
    */
   footnotesMap: Y.Map<string>;
+  /** Shared endnote-text edits (endnote id → plain text). Mirror of footnotes. */
+  endnotesMap: Y.Map<string>;
   /**
    * Shared comment threads (comment id → Comment JSON), in the same Y.Doc as
    * the body. Comment highlight marks ride ySyncPlugin, but the thread content
@@ -126,42 +128,44 @@ export interface UseCollabOptions {
  * loader doesn't overwrite the Yjs-populated PM state.
  */
 export function useCollab({ room, backend, user, token }: UseCollabOptions): CollabState {
-  const { ydoc, provider, plugins, metaMap, footnotesMap, commentsMap } = useMemo(() => {
-    const ydoc = new Y.Doc();
-    // Hocuspocus carries the document name in the handshake (`name`),
-    // not the URL path — so `backend` is the bare ws endpoint. A
-    // truthy token lets the handshake complete past an onAuthenticate
-    // hook even for anonymous sessions.
-    const provider = new HocuspocusProvider({
-      url: backend,
-      name: room,
-      document: ydoc,
-      token: token ?? 'anon',
-    });
-    const fragment = ydoc.getXmlFragment('prosemirror');
-    // Hocuspocus creates awareness by default; guard the type union so
-    // the cursor plugin is only wired when it's actually present.
-    const awareness = provider.awareness;
-    const plugins = [
-      ySyncPlugin(fragment),
-      ...(awareness ? [yCursorPlugin(awareness)] : []),
-      yUndoPlugin(),
-    ];
-    const metaMap = ydoc.getMap('meta');
-    // Footnote text edits don't live in the ProseMirror document (footnotes are
-    // a separate part of the .docx), so they don't travel over ySyncPlugin.
-    // A dedicated shared map in the SAME Y.Doc gives them the same realtime
-    // sync + offline resilience as the body content. Keyed by footnote id
-    // (string) → current plain text.
-    const footnotesMap = ydoc.getMap<string>('footnotes');
-    // Comment threads (text / replies / resolved) live in React state, not the
-    // PM tree, so the highlight marks sync but the thread content wouldn't.
-    // A shared map keyed by comment id (string) → Comment JSON gives them the
-    // same realtime sync. Replies are separate Comment entries (parentId).
-    const commentsMap = ydoc.getMap<unknown>('comments');
-    return { ydoc, provider, plugins, metaMap, footnotesMap, commentsMap };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [room, backend, token]);
+  const { ydoc, provider, plugins, metaMap, footnotesMap, endnotesMap, commentsMap } =
+    useMemo(() => {
+      const ydoc = new Y.Doc();
+      // Hocuspocus carries the document name in the handshake (`name`),
+      // not the URL path — so `backend` is the bare ws endpoint. A
+      // truthy token lets the handshake complete past an onAuthenticate
+      // hook even for anonymous sessions.
+      const provider = new HocuspocusProvider({
+        url: backend,
+        name: room,
+        document: ydoc,
+        token: token ?? 'anon',
+      });
+      const fragment = ydoc.getXmlFragment('prosemirror');
+      // Hocuspocus creates awareness by default; guard the type union so
+      // the cursor plugin is only wired when it's actually present.
+      const awareness = provider.awareness;
+      const plugins = [
+        ySyncPlugin(fragment),
+        ...(awareness ? [yCursorPlugin(awareness)] : []),
+        yUndoPlugin(),
+      ];
+      const metaMap = ydoc.getMap('meta');
+      // Footnote text edits don't live in the ProseMirror document (footnotes are
+      // a separate part of the .docx), so they don't travel over ySyncPlugin.
+      // A dedicated shared map in the SAME Y.Doc gives them the same realtime
+      // sync + offline resilience as the body content. Keyed by footnote id
+      // (string) → current plain text.
+      const footnotesMap = ydoc.getMap<string>('footnotes');
+      const endnotesMap = ydoc.getMap<string>('endnotes');
+      // Comment threads (text / replies / resolved) live in React state, not the
+      // PM tree, so the highlight marks sync but the thread content wouldn't.
+      // A shared map keyed by comment id (string) → Comment JSON gives them the
+      // same realtime sync. Replies are separate Comment entries (parentId).
+      const commentsMap = ydoc.getMap<unknown>('comments');
+      return { ydoc, provider, plugins, metaMap, footnotesMap, endnotesMap, commentsMap };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [room, backend, token]);
 
   const [status, setStatus] = useState<CollabStatus>('connecting');
   const [peers, setPeers] = useState<CollabPeer[]>([]);
@@ -222,6 +226,7 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
     awareness: provider.awareness,
     metaMap,
     footnotesMap,
+    endnotesMap,
     commentsMap,
   };
 }

--- a/docx-editor/packages/react/src/components/CasualEditor.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.tsx
@@ -233,6 +233,10 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
       () => (collabState ? makeFootnoteSync(collabState.footnotesMap) : undefined),
       [collabState]
     );
+    const endnoteSync = useMemo(
+      () => (collabState ? makeFootnoteSync(collabState.endnotesMap) : undefined),
+      [collabState]
+    );
 
     // Comment threads ride a shared `comments` Y.Map (highlight marks sync via
     // ySyncPlugin, but the thread content doesn't). In collab we drive
@@ -306,6 +310,7 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
         externalContent={!!collabState}
         externalPlugins={collabState ? collabState.plugins : undefined}
         footnoteSync={footnoteSync}
+        endnoteSync={endnoteSync}
         comments={collabState ? collabComments : undefined}
         onCommentsChange={collabState ? handleCommentsChange : undefined}
         author={author}

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -264,7 +264,13 @@ import { Toaster, toast } from 'sonner';
 import { getBuiltinTableStyle, type TableStylePreset } from './ui/TableStyleGallery';
 import { DocumentAgent } from '@eigenpal/docx-core/agent';
 import { DefaultLoadingIndicator, DefaultPlaceholder, ParseError } from './DocxEditorHelpers';
-import { parseDocx, getFootnoteText, setFootnotePlainText } from '@eigenpal/docx-core/docx';
+import {
+  parseDocx,
+  getFootnoteText,
+  setFootnotePlainText,
+  getEndnoteText,
+  setEndnotePlainText,
+} from '@eigenpal/docx-core/docx';
 import { findBodyPmAnchors } from '@eigenpal/docx-core/layout-bridge';
 import { type DocxInput } from '@eigenpal/docx-core/utils';
 import { onFontsLoaded, loadDocumentFonts } from '@eigenpal/docx-core/utils';
@@ -506,6 +512,11 @@ export interface DocxEditorProps {
    * uniformly. Omit for single-user (edits apply directly).
    */
   footnoteSync?: {
+    set: (id: number, text: string) => void;
+    observe: (cb: (id: number, text: string) => void) => () => void;
+  };
+  /** Collab transport for endnote-text edits (mirror of `footnoteSync`). */
+  endnoteSync?: {
     set: (id: number, text: string) => void;
     observe: (cb: (id: number, text: string) => void) => () => void;
   };
@@ -1580,6 +1591,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     externalPlugins,
     externalContent = false,
     footnoteSync,
+    endnoteSync,
     commentIdBase,
     onEditorViewReady,
     onRenderedDomContextReady,
@@ -1690,10 +1702,15 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   const [showVersionHistory, setShowVersionHistory] = useState(false);
   const [showProperties, setShowProperties] = useState(false);
   // Footnote text editor (opened by double-clicking a footnote at page bottom).
-  const [footnoteEdit, setFootnoteEdit] = useState<{ id: number; text: string } | null>(null);
-  // Pending footnote text edits (id → new text), applied to the save document
-  // in handleSave so they persist regardless of doc-object identity.
+  const [noteEdit, setNoteEdit] = useState<{
+    kind: 'footnote' | 'endnote';
+    id: number;
+    text: string;
+  } | null>(null);
+  // Pending footnote/endnote text edits (id → new text), applied to the save
+  // document in handleSave so they persist regardless of doc-object identity.
   const footnoteEditsRef = useRef<Map<number, string>>(new Map());
+  const endnoteEditsRef = useRef<Map<number, string>>(new Map());
   const editHistory = useEditHistory({ author: 'You' });
 
   // Shared toggle handlers — used by both the toolbar buttons and the
@@ -4070,43 +4087,47 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     [updateTextBoxAttrs]
   );
 
-  // Open the footnote editor with the current text of the double-clicked note.
-  // Footnotes live on the document package (history.state), NOT the PM doc.
+  // Open the note editor with the current text of the double-clicked note.
+  // Footnotes/endnotes live on the document package (history.state), NOT the PM doc.
   const handleEditFootnote = useCallback(
     (footnoteId: number) => {
       const fn = history.state?.package?.footnotes?.find((f) => f.id === footnoteId);
-      setFootnoteEdit({ id: footnoteId, text: fn ? getFootnoteText(fn) : '' });
+      setNoteEdit({ kind: 'footnote', id: footnoteId, text: fn ? getFootnoteText(fn) : '' });
+    },
+    [history]
+  );
+  const handleEditEndnote = useCallback(
+    (endnoteId: number) => {
+      const en = history.state?.package?.endnotes?.find((e) => e.id === endnoteId);
+      setNoteEdit({ kind: 'endnote', id: endnoteId, text: en ? getEndnoteText(en) : '' });
     },
     [history]
   );
 
-  // Apply a footnote text edit to BOTH the render doc (history.state — repainted
-  // via relayout) and the save doc (agentRef — read by handleSave). Marking the
-  // footnote `edited` makes the save path regenerate ONLY its text in
-  // footnotes.xml; every untouched footnote stays verbatim. This runs for BOTH
-  // local edits and remote (collab) edits observed off the shared map, so every
-  // peer's model — and therefore any peer's snapshot — carries the change.
-  const applyFootnoteEditToModel = useCallback(
-    (footnoteId: number, text: string) => {
-      const apply = (
-        pkg: { footnotes?: import('@eigenpal/docx-core/types').Footnote[] } | undefined
-      ) => {
-        const fn = pkg?.footnotes?.find((f) => f.id === footnoteId);
-        if (fn) {
-          setFootnotePlainText(fn, text);
-          fn.edited = true;
+  // Apply a footnote/endnote text edit to BOTH the render doc (history.state)
+  // and the save doc (agentRef). Marking the note `edited` makes the save path
+  // regenerate ONLY its text in footnotes.xml/endnotes.xml; untouched notes stay
+  // verbatim. Runs for local AND remote (collab) edits, so every peer's model —
+  // and any peer's snapshot — carries the change.
+  const applyNoteEditToModel = useCallback(
+    (kind: 'footnote' | 'endnote', noteId: number, text: string) => {
+      const editsRef = kind === 'footnote' ? footnoteEditsRef : endnoteEditsRef;
+      const apply = (pkg: import('@eigenpal/docx-core/types/document').DocxPackage | undefined) => {
+        const list = kind === 'footnote' ? pkg?.footnotes : pkg?.endnotes;
+        const note = list?.find((n) => n.id === noteId);
+        if (note) {
+          if (kind === 'footnote') setFootnotePlainText(note as never, text);
+          else setEndnotePlainText(note as never, text);
+          note.edited = true;
         }
       };
-      apply(history.state?.package); // render doc model (for the next relayout)
-      apply(agentRef.current?.getDocument()?.package); // save doc (best-effort)
-      footnoteEditsRef.current.set(footnoteId, text); // re-applied at save time
-      // Instant visual feedback: patch the painted footnote text span(s). The
-      // canonical model is updated above and persisted on save; this avoids a
-      // confusing "nothing changed" until the next reload.
+      apply(history.state?.package);
+      apply(agentRef.current?.getDocument()?.package);
+      editsRef.current.set(noteId, text);
+      // Instant visual feedback: patch the painted note text span(s).
+      const cls = kind === 'footnote' ? 'layout-footnote' : 'layout-endnote';
       document
-        .querySelectorAll(
-          `.layout-footnote[data-footnote-id="${footnoteId}"] .layout-footnote-text`
-        )
+        .querySelectorAll(`.${cls}[data-${kind}-id="${noteId}"] .${cls}-text`)
         .forEach((el) => {
           (el as HTMLElement).textContent = ' ' + text;
         });
@@ -4114,31 +4135,42 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     [history]
   );
 
-  // Commit an edit from the editor dialog. In collab, route through the shared
-  // footnote map so peers receive it; the observer below applies it to every
-  // peer's model (including ours). Single-user applies directly.
-  const handleApplyFootnoteEdit = useCallback(
-    (footnoteId: number, text: string) => {
-      if (footnoteSync) {
-        footnoteSync.set(footnoteId, text);
+  // Commit an edit from the dialog. In collab, route through the shared map so
+  // peers receive it; the observer applies it to every peer's model (including
+  // ours). Single-user applies directly.
+  const handleApplyNoteEdit = useCallback(
+    (kind: 'footnote' | 'endnote', noteId: number, text: string) => {
+      const noteSync = kind === 'footnote' ? footnoteSync : endnoteSync;
+      if (noteSync) {
+        noteSync.set(noteId, text);
       } else {
-        applyFootnoteEditToModel(footnoteId, text);
+        applyNoteEditToModel(kind, noteId, text);
         pagedEditorRef.current?.relayout();
       }
-      setFootnoteEdit(null);
+      setNoteEdit(null);
     },
-    [footnoteSync, applyFootnoteEditToModel]
+    [footnoteSync, endnoteSync, applyNoteEditToModel]
   );
 
-  // Apply remote (and own) footnote edits broadcast over the shared map.
+  // Apply remote (and own) note edits broadcast over the shared maps.
   useEffect(() => {
-    if (!footnoteSync) return;
-    const unsubscribe = footnoteSync.observe((id, text) => {
-      applyFootnoteEditToModel(id, text);
-      pagedEditorRef.current?.relayout();
-    });
-    return unsubscribe;
-  }, [footnoteSync, applyFootnoteEditToModel]);
+    const unsubs: Array<() => void> = [];
+    if (footnoteSync)
+      unsubs.push(
+        footnoteSync.observe((id, text) => {
+          applyNoteEditToModel('footnote', id, text);
+          pagedEditorRef.current?.relayout();
+        })
+      );
+    if (endnoteSync)
+      unsubs.push(
+        endnoteSync.observe((id, text) => {
+          applyNoteEditToModel('endnote', id, text);
+          pagedEditorRef.current?.relayout();
+        })
+      );
+    return () => unsubs.forEach((u) => u());
+  }, [footnoteSync, endnoteSync, applyNoteEditToModel]);
 
   // Handle image transform (rotate/flip)
   const handleImageTransform = useCallback(
@@ -6257,6 +6289,15 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
             }
           }
         }
+        if (endnoteEditsRef.current.size > 0 && agentDoc.package.endnotes) {
+          for (const [id, text] of endnoteEditsRef.current) {
+            const en = agentDoc.package.endnotes.find((e) => e.id === id);
+            if (en) {
+              setEndnotePlainText(en, text);
+              en.edited = true;
+            }
+          }
+        }
 
         // Inject commentRangeStart/End for reply comments that share the parent's range.
         // Pages/Word require every comment (including replies) to have range markers in document.xml.
@@ -6290,10 +6331,11 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
               hasUntrackedChanges:
                 hasUntrackedChanges(editorState) ||
                 hasNonParagraphBlockChanges(editorState) ||
-                // Footnote edits live outside the PM doc (in footnotes.xml), so
-                // the paraId-keyed selective path can't see them — force a full
-                // repack so the footnotes.xml override in rezip runs.
-                footnoteEditsRef.current.size > 0,
+                // Footnote/endnote edits live outside the PM doc (in
+                // footnotes.xml/endnotes.xml), so the paraId-keyed selective path
+                // can't see them — force a full repack so the override runs.
+                footnoteEditsRef.current.size > 0 ||
+                endnoteEditsRef.current.size > 0,
             },
           };
         }
@@ -8432,6 +8474,7 @@ body { background: white; }
                           onOpenProperties={() => openRightPanel('properties')}
                           onResizeTextBox={handleTextBoxSetSize}
                           onEditFootnote={handleEditFootnote}
+                          onEditEndnote={handleEditEndnote}
                           commentsSidebarOpen={sidebarOpen}
                           onAnchorPositionsChange={setAnchorPositions}
                           onTotalPagesChange={(totalPages) => {
@@ -9273,11 +9316,12 @@ body { background: white; }
                   onApply={handleApplyImagePosition}
                 />
               )}
-              {footnoteEdit && (
+              {noteEdit && (
                 <FootnoteEditDialog
-                  initialText={footnoteEdit.text}
-                  onCancel={() => setFootnoteEdit(null)}
-                  onApply={(t) => handleApplyFootnoteEdit(footnoteEdit.id, t)}
+                  initialText={noteEdit.text}
+                  title={noteEdit.kind === 'endnote' ? 'Edit endnote' : 'Edit footnote'}
+                  onCancel={() => setNoteEdit(null)}
+                  onApply={(t) => handleApplyNoteEdit(noteEdit.kind, noteEdit.id, t)}
                 />
               )}
 

--- a/docx-editor/packages/react/src/components/FootnoteEditDialog.tsx
+++ b/docx-editor/packages/react/src/components/FootnoteEditDialog.tsx
@@ -62,9 +62,16 @@ export interface FootnoteEditDialogProps {
   initialText: string;
   onApply: (text: string) => void;
   onCancel: () => void;
+  /** Dialog heading — defaults to "Edit footnote"; pass "Edit endnote" for endnotes. */
+  title?: string;
 }
 
-export function FootnoteEditDialog({ initialText, onApply, onCancel }: FootnoteEditDialogProps) {
+export function FootnoteEditDialog({
+  initialText,
+  onApply,
+  onCancel,
+  title = 'Edit footnote',
+}: FootnoteEditDialogProps) {
   const [text, setText] = useState(initialText);
   const ref = useRef<HTMLTextAreaElement>(null);
 
@@ -76,7 +83,7 @@ export function FootnoteEditDialog({ initialText, onApply, onCancel }: FootnoteE
   return (
     <div style={OVERLAY} data-testid="footnote-edit-dialog" onMouseDown={onCancel}>
       <div style={CARD} onMouseDown={(e) => e.stopPropagation()}>
-        <div style={TITLE}>Edit footnote</div>
+        <div style={TITLE}>{title}</div>
         <textarea
           ref={ref}
           style={TEXTAREA}

--- a/docx-editor/packages/react/src/paged-editor/EndnoteSection.tsx
+++ b/docx-editor/packages/react/src/paged-editor/EndnoteSection.tsx
@@ -1,0 +1,65 @@
+/**
+ * Endnote section — rendered at the END of the document (after the last page),
+ * since the paged layout-painter has no endnote area of its own. Plain-text v1,
+ * styled to match the page width + the footnote area. Double-click an entry to
+ * edit it (mirrors footnotes); each entry carries `data-endnote-id` so the host
+ * can route the edit.
+ */
+import { getEndnoteText } from '@eigenpal/docx-core/docx';
+import type { Endnote } from '@eigenpal/docx-core/types/content';
+import type { CSSProperties } from 'react';
+
+export interface EndnoteSectionProps {
+  endnotes: Endnote[];
+  /** Page content width (px) so the section lines up under the pages. */
+  width?: number;
+  onEditEndnote?: (endnoteId: number) => void;
+}
+
+const WRAP: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'center',
+  padding: '0 0 32px',
+};
+
+const CARD: CSSProperties = {
+  background: 'var(--doc-surface, #fff)',
+  boxShadow: '0 1px 3px rgba(60,64,67,0.15)',
+  padding: '24px 48px',
+  fontSize: '10px',
+  lineHeight: 1.4,
+  color: '#000',
+  boxSizing: 'border-box',
+};
+
+const TITLE: CSSProperties = { fontWeight: 700, fontSize: '12px', marginBottom: '10px' };
+
+const ITEM: CSSProperties = { marginBottom: '4px', cursor: 'text' };
+
+const SUP: CSSProperties = { fontSize: '7px', marginRight: '2px' };
+
+export function EndnoteSection({ endnotes, width, onEditEndnote }: EndnoteSectionProps) {
+  const items = endnotes.filter((e) => (e.noteType ?? 'normal') === 'normal');
+  if (items.length === 0) return null;
+
+  return (
+    <div style={WRAP} data-testid="endnote-section">
+      <div style={{ ...CARD, width: width ?? 816 }}>
+        <div style={TITLE}>Endnotes</div>
+        {items.map((en, i) => (
+          <div
+            key={en.id}
+            className="layout-endnote"
+            data-endnote-id={en.id}
+            style={ITEM}
+            title={onEditEndnote ? 'Double-click to edit endnote' : undefined}
+            onDoubleClick={() => onEditEndnote?.(en.id)}
+          >
+            <sup style={SUP}>{i + 1}</sup>
+            <span className="layout-endnote-text">{getEndnoteText(en)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -37,6 +37,7 @@ import { SelectionOverlay } from './SelectionOverlay';
 import { MobileFormatBar } from '../components/ui/MobileFormatBar';
 import { usePinchZoom } from '../components/hooks/usePinchZoom';
 import { ImageSelectionOverlay, type ImageSelectionInfo } from './ImageSelectionOverlay';
+import { EndnoteSection } from './EndnoteSection';
 import { DecorationLayer } from './DecorationLayer';
 import { spellcheckPluginKey } from '@eigenpal/docx-core/prosemirror/extensions';
 import { getTableContext } from '@eigenpal/docx-core/prosemirror';
@@ -357,6 +358,8 @@ export interface PagedEditorProps {
   onResizeTextBox?: (width: number, height: number) => void;
   /** Open the footnote text editor for the footnote double-clicked at page bottom. */
   onEditFootnote?: (footnoteId: number) => void;
+  /** Open the endnote text editor for the endnote double-clicked at document end. */
+  onEditEndnote?: (endnoteId: number) => void;
   /** Callback with pre-computed Y positions for comment/tracked-change anchors (for sidebar positioning without DOM queries). */
   onAnchorPositionsChange?: (positions: Map<string, number>) => void;
   /**
@@ -1399,6 +1402,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       onOpenProperties,
       onResizeTextBox,
       onEditFootnote,
+      onEditEndnote,
       onAnchorPositionsChange,
       onTotalPagesChange,
       resolvedCommentIds,
@@ -4488,6 +4492,16 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             onContextMenu={handlePagesContextMenu}
             aria-hidden="true" // Visual only, PM provides semantic content
           />
+
+          {/* Endnotes — rendered after the last page (the layout-painter has no
+              endnote area). Double-click an entry to edit it. */}
+          {document?.package?.endnotes && document.package.endnotes.length > 0 && (
+            <EndnoteSection
+              endnotes={document.package.endnotes}
+              width={layout?.pages[0]?.size.w}
+              onEditEndnote={onEditEndnote}
+            />
+          )}
 
           {/* Selection overlay */}
           <SelectionOverlay


### PR DESCRIPTION
Endnotes were parsed but **never displayed** in the paged editor. Now they render at the end of the document and are editable end-to-end — mirroring footnotes.

- **Render** — `EndnoteSection` mounted after the pages (the layout-painter has no endnote area). Page-styled card, plain text; each entry has `data-endnote-id`, double-click to edit. *(First time endnotes are shown at all.)*
- **Persist** — the text-surgery serializer is generalised to footnotes **and** endnotes (`replaceEndnotesInXml` / `setEndnotePlainText`); `rezip` overrides `endnotes.xml` **only for edited endnotes** (opt-in) → untouched docs verbatim, **39-fixture round-trip pristine**.
- **Edit** — the note dialog + DocxEditor handlers generalised to handle both kinds (one code path; heading switches "Edit footnote"/"Edit endnote").
- **Collab** — an `endnotes` Y.Map (reuses `makeFootnoteSync`), wired via `CasualEditor` as `endnoteSync`. Edits sync across peers + survive any peer's snapshot, like footnotes.

**Tests:** endnote serializer unit test (text replaced, `<w:endnoteRef/>` marker preserved, others byte-identical, no-op when empty) + round-trip e2e (renders at doc end → edit → save → reload persists). Collab covered by the shared `makeFootnoteSync` test.

Coverage doc updated — only **doc-properties sync** remains as a future item.

Gate: typecheck · format · lint 0 errors · core round-trip pristine · footnote + endnote + smoke e2e · collab unit tests.