### PR TITLE
feat(collab): sync document properties — collab coverage complete

### DIFF
--- a/docs/internal/25-collab-coverage.md
+++ b/docs/internal/25-collab-coverage.md
@@ -26,7 +26,7 @@ any peer's snapshot carries them. All this session's Format-panel work is here:
 | **Footnote text** | `package.footnotes` | ✅ **synced** via the `footnotes` Y.Map + `makeFootnoteSync` (PR #65) | done |
 | **Comment threads** (text, author, replies, resolved) | React `comments` state / controlled `comments` prop | ✅ **synced** via the `comments` Y.Map (keyed by id) + `collab/commentSync`; CasualEditor drives DocxEditor's controlled `comments` + `onCommentsChange`. Replies are separate entries (parentId); add/reply/resolve/delete + concurrent adds proven by a two-peer test. | done |
 | **Endnote text** | `package.endnotes` | ✅ **rendered + editable + synced**: endnotes now paint at document end (`EndnoteSection` — they were never displayed before), double-click → edit → surgical `endnotes.xml` regen on save; synced via the `endnotes` Y.Map (reuses `makeFootnoteSync`). Mirrors footnotes end-to-end. | done |
-| **Document properties** (title/author/…) | `package.properties` | ⚪ not synced; low-frequency | minor; a `props` Y.Map later if needed |
+| **Document properties** (title/subject/creator/…) | `package.properties` | ✅ **synced** via the `props` Y.Map (field → value) + `makePropsSync`; File → Properties edits route through `propsSync`, observer applies to every peer; written on save via `applyCorePropertiesToXml`. Two peers editing different fields merge. | done |
 | **Header/footer text** | parsed parts; edited via double-click → PM region | mostly PM (synced); the part wiring needs a spot check | verify, then wire if any out-of-PM bits |
 
 ## The pattern (for any future out-of-PM surface)
@@ -38,7 +38,6 @@ any peer's snapshot carries them. All this session's Format-panel work is here:
 4. Prove it with a two-`Y.Doc` unit test (no server needed).
 
 ## Verdict
-Everything is collab-safe: Format-panel edits are PM-node edits (synced),
-footnotes synced, comment threads synced, and **endnotes rendered + editable +
-synced**. The only remaining future item is **doc-properties sync** (low-
-frequency, a `props` Y.Map when wanted) — same pattern.
+**Complete.** Every editable surface — body/images/tables/text-boxes/shapes (PM
+nodes), footnotes, comment threads, endnotes, and document properties — syncs
+over the shared Y.Doc. No out-of-PM editable surface remains unsynced.

--- a/docx-editor/packages/react/src/collab/propsSync.test.ts
+++ b/docx-editor/packages/react/src/collab/propsSync.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from 'bun:test';
+import * as Y from 'yjs';
+import { makePropsSync } from './useCollab';
+
+const sync = (from: Y.Doc, to: Y.Doc) => Y.applyUpdate(to, Y.encodeStateAsUpdate(from));
+
+describe('makePropsSync (collab transport)', () => {
+  test('a property edit on peer A is observed on peer B', () => {
+    const docA = new Y.Doc();
+    const docB = new Y.Doc();
+    let latestB: Record<string, string> = {};
+    const unsub = makePropsSync(docB.getMap<string>('props')).observe((p) => (latestB = p));
+
+    makePropsSync(docA.getMap<string>('props')).set({ title: 'Shared Title', creator: 'Ada' });
+    sync(docA, docB);
+
+    expect(latestB).toMatchObject({ title: 'Shared Title', creator: 'Ada' });
+    unsub();
+    docA.destroy();
+    docB.destroy();
+  });
+
+  test('two peers editing different fields merge', () => {
+    const docA = new Y.Doc();
+    const docB = new Y.Doc();
+    makePropsSync(docA.getMap<string>('props')).set({ title: 'From A' });
+    makePropsSync(docB.getMap<string>('props')).set({ subject: 'From B' });
+    sync(docA, docB);
+    sync(docB, docA);
+    const read = (d: Y.Doc) => {
+      const o: Record<string, string> = {};
+      d.getMap<string>('props').forEach((v, k) => (o[k] = v));
+      return o;
+    };
+    expect(read(docA)).toMatchObject({ title: 'From A', subject: 'From B' });
+    expect(read(docB)).toMatchObject({ title: 'From A', subject: 'From B' });
+    docA.destroy();
+    docB.destroy();
+  });
+});

--- a/docx-editor/packages/react/src/collab/useCollab.ts
+++ b/docx-editor/packages/react/src/collab/useCollab.ts
@@ -69,6 +69,8 @@ export interface CollabState {
   footnotesMap: Y.Map<string>;
   /** Shared endnote-text edits (endnote id → plain text). Mirror of footnotes. */
   endnotesMap: Y.Map<string>;
+  /** Shared core document properties (field name → value), File → Properties. */
+  propsMap: Y.Map<string>;
   /**
    * Shared comment threads (comment id → Comment JSON), in the same Y.Doc as
    * the body. Comment highlight marks ride ySyncPlugin, but the thread content
@@ -106,6 +108,37 @@ export function makeFootnoteSync(map: Y.Map<string>): FootnoteSync {
   };
 }
 
+/** Transport for document-properties edits (field → value). */
+export interface PropsSync {
+  set: (edits: Record<string, string>) => void;
+  observe: (cb: (props: Record<string, string>) => void) => () => void;
+}
+
+/** Build a {@link PropsSync} over a `props` Y.Map (one entry per field). */
+export function makePropsSync(map: Y.Map<string>): PropsSync {
+  return {
+    set: (edits) => {
+      const doc = map.doc;
+      const apply = () => {
+        for (const [k, v] of Object.entries(edits)) map.set(k, v);
+      };
+      if (doc) doc.transact(apply);
+      else apply();
+    },
+    observe: (cb) => {
+      const handler = () => {
+        const obj: Record<string, string> = {};
+        map.forEach((v, k) => {
+          obj[k] = v;
+        });
+        cb(obj);
+      };
+      map.observe(handler);
+      return () => map.unobserve(handler);
+    },
+  };
+}
+
 export interface UseCollabOptions {
   /** Per-doc room identifier — typically the docID. */
   room: string;
@@ -128,7 +161,7 @@ export interface UseCollabOptions {
  * loader doesn't overwrite the Yjs-populated PM state.
  */
 export function useCollab({ room, backend, user, token }: UseCollabOptions): CollabState {
-  const { ydoc, provider, plugins, metaMap, footnotesMap, endnotesMap, commentsMap } =
+  const { ydoc, provider, plugins, metaMap, footnotesMap, endnotesMap, propsMap, commentsMap } =
     useMemo(() => {
       const ydoc = new Y.Doc();
       // Hocuspocus carries the document name in the handshake (`name`),
@@ -158,12 +191,16 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
       // (string) → current plain text.
       const footnotesMap = ydoc.getMap<string>('footnotes');
       const endnotesMap = ydoc.getMap<string>('endnotes');
+      // Core document properties (title / subject / creator / keywords /
+      // description) edited via File → Properties. Not in the PM tree; keyed by
+      // field name → value so two peers editing different fields merge.
+      const propsMap = ydoc.getMap<string>('props');
       // Comment threads (text / replies / resolved) live in React state, not the
       // PM tree, so the highlight marks sync but the thread content wouldn't.
       // A shared map keyed by comment id (string) → Comment JSON gives them the
       // same realtime sync. Replies are separate Comment entries (parentId).
       const commentsMap = ydoc.getMap<unknown>('comments');
-      return { ydoc, provider, plugins, metaMap, footnotesMap, endnotesMap, commentsMap };
+      return { ydoc, provider, plugins, metaMap, footnotesMap, endnotesMap, propsMap, commentsMap };
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [room, backend, token]);
 
@@ -227,6 +264,7 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
     metaMap,
     footnotesMap,
     endnotesMap,
+    propsMap,
     commentsMap,
   };
 }

--- a/docx-editor/packages/react/src/components/CasualEditor.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.tsx
@@ -54,6 +54,7 @@ import type { Comment } from '@eigenpal/docx-core/types/content';
 import {
   useCollab,
   makeFootnoteSync,
+  makePropsSync,
   type CollabPeer,
   type CollabState,
   type CollabStatus,
@@ -237,6 +238,10 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
       () => (collabState ? makeFootnoteSync(collabState.endnotesMap) : undefined),
       [collabState]
     );
+    const propsSync = useMemo(
+      () => (collabState ? makePropsSync(collabState.propsMap) : undefined),
+      [collabState]
+    );
 
     // Comment threads ride a shared `comments` Y.Map (highlight marks sync via
     // ySyncPlugin, but the thread content doesn't). In collab we drive
@@ -311,6 +316,7 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
         externalPlugins={collabState ? collabState.plugins : undefined}
         footnoteSync={footnoteSync}
         endnoteSync={endnoteSync}
+        propsSync={propsSync}
         comments={collabState ? collabComments : undefined}
         onCommentsChange={collabState ? handleCommentsChange : undefined}
         author={author}

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -520,6 +520,11 @@ export interface DocxEditorProps {
     set: (id: number, text: string) => void;
     observe: (cb: (id: number, text: string) => void) => () => void;
   };
+  /** Collab transport for core document properties (File → Properties). */
+  propsSync?: {
+    set: (edits: Record<string, string>) => void;
+    observe: (cb: (props: Record<string, string>) => void) => () => void;
+  };
   /**
    * Starting offset for comment/tracked-change IDs. Default 0.
    *
@@ -1592,6 +1597,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     externalContent = false,
     footnoteSync,
     endnoteSync,
+    propsSync,
     commentIdBase,
     onEditorViewReady,
     onRenderedDomContextReady,
@@ -1711,6 +1717,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // document in handleSave so they persist regardless of doc-object identity.
   const footnoteEditsRef = useRef<Map<number, string>>(new Map());
   const endnoteEditsRef = useRef<Map<number, string>>(new Map());
+  // Pending core-property edits, applied to the save document in handleSave.
+  const propsEditsRef = useRef<Record<string, string>>({});
   const editHistory = useEditHistory({ author: 'You' });
 
   // Shared toggle handlers — used by both the toolbar buttons and the
@@ -4152,6 +4160,34 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     [footnoteSync, endnoteSync, applyNoteEditToModel]
   );
 
+  // Apply core-property edits to the live + save docs. Runs for local and remote
+  // (collab) edits so every peer's model carries them and any peer's snapshot
+  // writes them through applyCorePropertiesToXml.
+  const applyPropsToModel = useCallback((edits: Record<string, string>) => {
+    const apply = (pkg: import('@eigenpal/docx-core/types/document').DocxPackage | undefined) => {
+      if (pkg) pkg.properties = { ...(pkg.properties ?? {}), ...edits };
+    };
+    apply(history.state?.package);
+    apply(agentRef.current?.getDocument()?.package);
+    propsEditsRef.current = { ...propsEditsRef.current, ...edits };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Commit a File → Properties edit. In collab, route through the shared map so
+  // peers receive it; the observer applies it everywhere. Single-user direct.
+  const handleApplyFileProperties = useCallback(
+    (edits: Record<string, string>) => {
+      if (propsSync) propsSync.set(edits);
+      else applyPropsToModel(edits);
+    },
+    [propsSync, applyPropsToModel]
+  );
+
+  useEffect(() => {
+    if (!propsSync) return;
+    return propsSync.observe((props) => applyPropsToModel(props));
+  }, [propsSync, applyPropsToModel]);
+
   // Apply remote (and own) note edits broadcast over the shared maps.
   useEffect(() => {
     const unsubs: Array<() => void> = [];
@@ -6298,6 +6334,14 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
             }
           }
         }
+        // Apply pending core-property edits to the save doc (collab peers may
+        // have set these via the observer; ensure the saver writes them).
+        if (Object.keys(propsEditsRef.current).length > 0) {
+          agentDoc.package.properties = {
+            ...(agentDoc.package.properties ?? {}),
+            ...propsEditsRef.current,
+          };
+        }
 
         // Inject commentRangeStart/End for reply comments that share the parent's range.
         // Pages/Word require every comment (including replies) to have range markers in document.xml.
@@ -6335,7 +6379,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                 // footnotes.xml/endnotes.xml), so the paraId-keyed selective path
                 // can't see them — force a full repack so the override runs.
                 footnoteEditsRef.current.size > 0 ||
-                endnoteEditsRef.current.size > 0,
+                endnoteEditsRef.current.size > 0 ||
+                Object.keys(propsEditsRef.current).length > 0,
             },
           };
         }
@@ -9372,16 +9417,7 @@ body { background: white; }
                   fileName={documentName}
                   sizeBytes={loadedSizeRef.current ?? undefined}
                   current={history.state?.package?.properties}
-                  onApply={(edits) => {
-                    // Push edits onto the current package so the next save
-                    // writes them through `applyCorePropertiesToXml`. The
-                    // edits land on the live `Document` so the dialog can
-                    // re-open against the new values without a save.
-                    const pkg = history.state?.package;
-                    if (!pkg) return;
-                    const next = { ...(pkg.properties ?? {}), ...edits };
-                    pkg.properties = next;
-                  }}
+                  onApply={(edits) => handleApplyFileProperties(edits as Record<string, string>)}
                 />
               )}
               {showWordCount && (


### PR DESCRIPTION
The last out-of-PM surface. File → Properties edits (title / subject / creator / keywords / description) live on `package.properties`, outside the PM tree, so they didn't sync. Now a shared **`props` Y.Map** (field → value) carries them.

- `useCollab` exposes `propsMap`; `makePropsSync(map)` → `{ set, observe }` (one entry per field → two peers editing different fields merge).
- DocxEditor: optional `propsSync`. File → Properties routes through it; an observer applies every field (local + remote) to the live + save docs; `handleSave` applies pending edits so the saver writes them via `applyCorePropertiesToXml`. Single-user applies directly.
- `CasualEditor` wires it from the collab session.

**Two-peer test** proves a property edit on peer A is observed on peer B, and that two peers editing different fields merge. React-only change — **core round-trip unaffected**.

Closes the collab-coverage audit (`docs/internal/25`): **every editable surface now syncs** — body/images/tables/text-boxes/shapes, footnotes, comments, endnotes, document properties.

Gate: typecheck · format · lint 0 errors · collab unit tests (footnote + comment + props) · core unaffected · smoke.