### PR TITLE
fix(ux): consistent thin scrollbars across OS/browser

### DIFF
--- a/docx-editor/packages/react/src/styles/editor.css
+++ b/docx-editor/packages/react/src/styles/editor.css
@@ -1068,3 +1068,44 @@
     border-color var(--doc-anim-fast),
     box-shadow var(--doc-anim-fast);
 }
+
+/* ============================================================================
+   Consistent scrollbars across OS / browser
+   Native scrollbars differ wildly — macOS shows thin overlay bars, Linux/Windows
+   show chunky always-on bars (the "ugly + inconsistent on Ubuntu/Chromium"
+   report). Style them thin, subtle and rounded inside the editor so the chrome
+   looks the same everywhere. Firefox uses scrollbar-width/-color; Chromium /
+   WebKit use the ::-webkit-scrollbar pseudo-elements.
+   ============================================================================ */
+.ep-root,
+.ep-root * {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(100, 116, 139, 0.45) transparent;
+}
+.ep-root ::-webkit-scrollbar,
+.ep-root::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+.ep-root ::-webkit-scrollbar-track,
+.ep-root::-webkit-scrollbar-track {
+  background: transparent;
+}
+.ep-root ::-webkit-scrollbar-thumb,
+.ep-root::-webkit-scrollbar-thumb {
+  background-color: rgba(100, 116, 139, 0.4);
+  border-radius: 8px;
+  /* transparent border + content-box clip makes the thumb read as a slim pill
+     with breathing room, instead of filling the full track width. */
+  border: 3px solid transparent;
+  background-clip: content-box;
+}
+.ep-root ::-webkit-scrollbar-thumb:hover,
+.ep-root::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(100, 116, 139, 0.62);
+  background-clip: content-box;
+}
+.ep-root ::-webkit-scrollbar-corner,
+.ep-root::-webkit-scrollbar-corner {
+  background: transparent;
+}


### PR DESCRIPTION
Native scrollbars differ wildly — macOS shows thin overlay bars, Linux/Windows show chunky always-on bars (reported as **ugly + inconsistent on Ubuntu/Chromium**). Styles them thin, subtle, rounded inside the editor (scoped to `.ep-root`) via `scrollbar-width`/`-color` (Firefox) + `::-webkit-scrollbar` (Chromium/WebKit).

Verified: `scrollbar-width: thin` applies; build + smoke green. (Pure CSS, scoped to the editor root.)