### PR TITLE
feat(markdown): open/edit/save .md & .txt in a source+preview editor

### DIFF
--- a/docx-editor/bun.lock
+++ b/docx-editor/bun.lock
@@ -39,8 +39,16 @@
       "name": "docx-editor-example-vite",
       "dependencies": {
         "@casualoffice/docs": "workspace:*",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.43.2",
+        "@hocuspocus/provider": "^2.15.0",
+        "codemirror": "^6.0.2",
+        "dompurify": "^3.4.11",
+        "marked": "^18.0.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "y-codemirror.next": "^0.3.5",
         "y-prosemirror": "^1.2.12",
         "y-websocket": "^2.1.0",
         "yjs": "^13.6.18",
@@ -247,6 +255,28 @@
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "6.1.0", "fs-extra": "7.0.1", "human-id": "4.1.3", "prettier": "2.8.8" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
+
+    "@codemirror/commands": ["@codemirror/commands@6.10.4", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.7.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg=="],
+
+    "@codemirror/lang-css": ["@codemirror/lang-css@6.3.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/css": "^1.1.7" } }, "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg=="],
+
+    "@codemirror/lang-html": ["@codemirror/lang-html@6.4.11", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/css": "^1.1.0", "@lezer/html": "^1.3.12" } }, "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw=="],
+
+    "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
+
+    "@codemirror/lang-markdown": ["@codemirror/lang-markdown@6.5.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.7.1", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.3.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/markdown": "^1.0.0" } }, "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.3", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA=="],
+
+    "@codemirror/lint": ["@codemirror/lint@6.9.7", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.42.0", "crelt": "^1.0.5" } }, "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg=="],
+
+    "@codemirror/search": ["@codemirror/search@6.7.1", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.37.0", "crelt": "^1.0.5" } }, "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA=="],
+
+    "@codemirror/state": ["@codemirror/state@6.7.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg=="],
+
+    "@codemirror/view": ["@codemirror/view@6.43.2", "", { "dependencies": { "@codemirror/state": "^6.7.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-8kU6WNRYBKV9Sw3cxNz+uSvUvx3tt+1qgupGFPubnbLFDHOgh5qQdIGmXcD7bkA/PROK6LDKVhKMpcY7H++Amg=="],
+
     "@eigenpal/docx-core": ["@eigenpal/docx-core@workspace:packages/core"],
 
     "@eigenpal/docx-editor-vue": ["@eigenpal/docx-editor-vue@workspace:packages/vue"],
@@ -415,11 +445,27 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "3.1.2", "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
+
+    "@lezer/css": ["@lezer/css@1.3.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/html": ["@lezer/html@1.3.13", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg=="],
+
+    "@lezer/javascript": ["@lezer/javascript@1.5.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.1.3", "@lezer/lr": "^1.3.0" } }, "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
+
+    "@lezer/markdown": ["@lezer/markdown@1.6.4", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA=="],
+
     "@lifeomic/attempt": ["@lifeomic/attempt@3.1.0", "", {}, "sha512-QZqem4QuAnAyzfz+Gj5/+SLxqwCAw2qmt7732ZXodr6VDWGeYLG6w1i/vYLa55JQM9wRuBKLmXmiZ2P0LtE5rw=="],
 
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "7.29.2", "@types/node": "12.20.55", "find-up": "4.1.0", "fs-extra": "8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "7.29.2", "@changesets/types": "4.1.0", "@manypkg/find-root": "1.1.0", "fs-extra": "8.1.0", "globby": "11.1.0", "read-yaml-file": "1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
     "@mlc-ai/web-llm": ["@mlc-ai/web-llm@0.2.84", "", { "dependencies": { "loglevel": "^1.9.1" } }, "sha512-hrOWzK4/nGNmgoRKT8pgVmZZ2oEPpbblIWQOwpqNyvK2dysHw3KVB1gNJOuRcQfKOPhucEhX1NJzXzgMDnwSCQ=="],
 
@@ -621,6 +667,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "19.2.14" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "25.9.1" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
@@ -769,6 +817,8 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "codemirror": ["codemirror@6.0.2", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/lint": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw=="],
+
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
@@ -782,6 +832,8 @@
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "3.1.1", "shebang-command": "2.0.0", "which": "2.0.2" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -832,6 +884,8 @@
     "docxtemplater": ["docxtemplater@3.68.7", "", { "dependencies": { "@xmldom/xmldom": "0.9.10" } }, "sha512-FwgeAKqY2vc9eVm2V2XGg8bq25B0OQjtSDITGi9zNnvu5GbtR4WvGjM5QNld/ALB6ZbsSuHskBPK9SvPpKhsbA=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
     "dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
 
@@ -1187,6 +1241,8 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
+
     "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
@@ -1479,6 +1535,8 @@
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
+
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "0.3.13", "commander": "4.1.1", "lines-and-columns": "1.2.4", "mz": "2.7.0", "pirates": "4.0.7", "tinyglobby": "0.2.16", "ts-interface-checker": "0.1.13" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
@@ -1574,6 +1632,8 @@
     "xml-js": ["xml-js@1.6.11", "", { "dependencies": { "sax": "1.6.0" }, "bin": { "xml-js": "./bin/cli.js" } }, "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
+    "y-codemirror.next": ["y-codemirror.next@0.3.5", "", { "dependencies": { "lib0": "^0.2.42" }, "peerDependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "yjs": "^13.5.6" } }, "sha512-VluNu3e5HfEXybnypnsGwKAj+fKLd4iAnR7JuX1Sfyydmn1jCBS5wwEL/uS04Ch2ib0DnMAOF6ZRR/8kK3wyGw=="],
 
     "y-leveldb": ["y-leveldb@0.1.2", "", { "dependencies": { "level": "6.0.1", "lib0": "0.2.117" }, "peerDependencies": { "yjs": "13.6.30" } }, "sha512-6ulEn5AXfXJYi89rXPEg2mMHAyyw8+ZfeMMdOtBbV8FJpQ1NOrcgi6DTAcXof0dap84NjHPT2+9d0rb6cFsjEg=="],
 

--- a/docx-editor/e2e/fixtures/casual-sample.md
+++ b/docx-editor/e2e/fixtures/casual-sample.md
@@ -1,0 +1,6 @@
+# Markdown Fixture Title
+
+This paragraph has **bold text** to prove the preview renders.
+
+- first item
+- second item

--- a/docx-editor/e2e/fixtures/casual-sample.txt
+++ b/docx-editor/e2e/fixtures/casual-sample.txt
@@ -1,0 +1,3 @@
+Plain text file.
+No markdown preview here.
+Just source editing.

--- a/docx-editor/e2e/tests/markdown-editor.spec.ts
+++ b/docx-editor/e2e/tests/markdown-editor.spec.ts
@@ -99,3 +99,25 @@ test('editing the source updates the preview live', async ({ page }) => {
 
   await expect(preview.locator('h1').first()).toHaveText('Live Edit Heading');
 });
+
+test('Download saves the edited source back to a .md file', async ({ page }) => {
+  await openMarkdown(page);
+
+  // Edit, then download — the saved file must reflect the live edit.
+  const content = page.getByTestId('markdown-source').locator('.cm-content');
+  await content.click();
+  await page.keyboard.press('ControlOrMeta+Home');
+  await page.keyboard.type('# Saved Heading\n\n');
+
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByTestId('markdown-download').click();
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toBe('casual-sample.md');
+  const stream = await download.createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(chunk as Buffer);
+  const saved = Buffer.concat(chunks).toString('utf-8');
+  expect(saved).toContain('# Saved Heading');
+  expect(saved).toContain('# Markdown Fixture Title');
+});

--- a/docx-editor/e2e/tests/markdown-editor.spec.ts
+++ b/docx-editor/e2e/tests/markdown-editor.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MD_FIXTURE = path.join(__dirname, '..', 'fixtures', 'casual-sample.md');
+const TXT_FIXTURE = path.join(__dirname, '..', 'fixtures', 'casual-sample.txt');
+
+/**
+ * Markdown / text editor opened from the Home picker.
+ *
+ * `.md` files are NOT flattened to DOCX — they open in a dedicated CodeMirror
+ * source pane with a live HTML preview and three view modes (source / split /
+ * preview), the same shape other markdown editors use. This drives the real
+ * picker → editor, asserting:
+ *   - raw markdown shows in the source pane (not rendered),
+ *   - the preview renders HTML (h1 + bold),
+ *   - all three view modes show/hide the right panes,
+ *   - editing the source updates the preview live.
+ */
+
+async function openMarkdown(page: import('@playwright/test').Page) {
+  await page.goto('/');
+  const fileInput = page.getByTestId('home-file-input');
+  await expect(fileInput).toHaveAttribute('accept', /\.md/);
+  await fileInput.setInputFiles(MD_FIXTURE);
+  await page.waitForSelector('[data-testid="markdown-editor"]', { timeout: 30000 });
+}
+
+test('opens .md in the source+preview editor with raw markdown and rendered preview', async ({
+  page,
+}) => {
+  await openMarkdown(page);
+
+  const source = page.getByTestId('markdown-source');
+  const preview = page.getByTestId('markdown-preview');
+
+  // Default mode for markdown is split — both panes visible.
+  await expect(source).toBeVisible();
+  await expect(preview).toBeVisible();
+
+  // Source shows the RAW markdown syntax (the literal '#', '**').
+  await expect(source).toContainText('# Markdown Fixture Title');
+  await expect(source).toContainText('**bold text**');
+
+  // Preview renders it to HTML — heading as <h1>, bold as <strong>.
+  await expect(preview.locator('h1')).toHaveText('Markdown Fixture Title');
+  await expect(preview.locator('strong')).toHaveText('bold text');
+  await expect(preview.locator('li')).toHaveCount(2);
+
+  await page.screenshot({ path: 'screenshots/markdown-split.png' });
+});
+
+test('view modes show and hide the correct panes', async ({ page }) => {
+  await openMarkdown(page);
+  const source = page.getByTestId('markdown-source');
+  const preview = page.getByTestId('markdown-preview');
+
+  // Source-only: editor visible, preview gone.
+  await page.getByTestId('markdown-view-source').click();
+  await expect(source).toBeVisible();
+  await expect(preview).toHaveCount(0);
+
+  // Preview-only: preview visible, source hidden.
+  await page.getByTestId('markdown-view-preview').click();
+  await expect(preview).toBeVisible();
+  await expect(source).toBeHidden();
+
+  // Back to split: both visible.
+  await page.getByTestId('markdown-view-split').click();
+  await expect(source).toBeVisible();
+  await expect(preview).toBeVisible();
+});
+
+test('.txt opens as source-only — no preview pane or view toggle', async ({ page }) => {
+  await page.goto('/');
+  const fileInput = page.getByTestId('home-file-input');
+  await expect(fileInput).toHaveAttribute('accept', /\.txt/);
+  await fileInput.setInputFiles(TXT_FIXTURE);
+  await page.waitForSelector('[data-testid="markdown-editor"]', { timeout: 30000 });
+
+  // Plain text has no markdown semantics: source pane only, no preview,
+  // and no source/split/preview toggle.
+  await expect(page.getByTestId('markdown-source')).toContainText('No markdown preview here.');
+  await expect(page.getByTestId('markdown-preview')).toHaveCount(0);
+  await expect(page.getByTestId('markdown-view-split')).toHaveCount(0);
+});
+
+test('editing the source updates the preview live', async ({ page }) => {
+  await openMarkdown(page);
+  const source = page.getByTestId('markdown-source');
+  const preview = page.getByTestId('markdown-preview');
+
+  // Put the caret at the very start of the document and type a new heading.
+  const content = source.locator('.cm-content');
+  await content.click();
+  await page.keyboard.press('ControlOrMeta+Home');
+  await page.keyboard.type('# Live Edit Heading\n\n');
+
+  await expect(preview.locator('h1').first()).toHaveText('Live Edit Heading');
+});

--- a/docx-editor/examples/vite/package.json
+++ b/docx-editor/examples/vite/package.json
@@ -9,8 +9,16 @@
   },
   "dependencies": {
     "@casualoffice/docs": "workspace:*",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/state": "^6.7.0",
+    "@codemirror/view": "^6.43.2",
+    "@hocuspocus/provider": "^2.15.0",
+    "codemirror": "^6.0.2",
+    "dompurify": "^3.4.11",
+    "marked": "^18.0.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "y-codemirror.next": "^0.3.5",
     "y-prosemirror": "^1.2.12",
     "y-websocket": "^2.1.0",
     "yjs": "^13.6.18"

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -24,6 +24,8 @@ import {
   type FileSource,
 } from '@casualoffice/docs';
 import { Home } from './Home';
+import { MarkdownEditor } from './markdown/MarkdownEditor';
+import { MarkdownCollabApp } from './markdown/MarkdownCollabApp';
 import { loadTemplate } from './templates/loader';
 import type { TemplateEntry } from './templates/manifest';
 import { navigate, useRoute } from './router';
@@ -389,6 +391,14 @@ export function App() {
   const [documentBuffer, setDocumentBuffer] = useState<ArrayBuffer | null>(null);
   const [fileName, setFileName] = useState<string>('docx-editor-demo.docx');
   const [status, setStatus] = useState<string>('');
+  // Plain-text / markdown documents (.md / .markdown / .txt) open in the
+  // dedicated source+preview editor, not the DOCX surface — they're never
+  // flattened to DOCX. Null when a DOCX-family doc is open.
+  const [textDoc, setTextDoc] = useState<{
+    text: string;
+    fileName: string;
+    kind: 'markdown' | 'text';
+  } | null>(null);
 
   // Browser tab title = the open file's name (Google-Docs style), not the
   // app name. On the home screen, fall back to the product name.
@@ -447,7 +457,12 @@ export function App() {
       const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
       backend = `${proto}//${window.location.host}/yjs`;
     }
-    return { room, backend };
+    // `?kind=text` (or `markdown`) opens the collaborative source/markdown
+    // editor instead of the DOCX surface for this room. Default is DOCX.
+    const kindParam = params.get('kind');
+    const kind: 'docx' | 'markdown' | 'text' =
+      kindParam === 'text' ? 'text' : kindParam === 'markdown' ? 'markdown' : 'docx';
+    return { room, backend, kind };
   }, []);
 
   // Backend HTTP base — used for the upload (POST /api/docs) in
@@ -630,21 +645,34 @@ export function App() {
       try {
         suppressSeedDocumentRef.current = true;
         setStatus('Loading…');
-        const raw = await file.arrayBuffer();
-        // Non-DOCX uploads (.odt / .md / .txt) are converted to the DOCX model
-        // via the WASM worker before the editor loads them — mirrors the
-        // editor's File → Open path so the Home picker isn't DOCX-only.
-        let buffer: ArrayBuffer = raw;
         const fmt = formatFromFilename(file.name);
+
+        // .md / .markdown / .txt open as plain text in the source+preview
+        // editor — not converted to DOCX. Markdown gets the live preview;
+        // .txt is source-only.
+        if (fmt === 'md' || fmt === 'txt') {
+          const text = await file.text();
+          setDocumentBuffer(null);
+          setCurrentDocument(null);
+          setTextDoc({ text, fileName: file.name, kind: fmt === 'md' ? 'markdown' : 'text' });
+          setStatus('');
+          if (!legacyForcedEditor) navigate('/document/new');
+          setView('editor');
+          return;
+        }
+
+        const raw = await file.arrayBuffer();
+        // Other non-DOCX uploads (.odt) are converted to the DOCX model via
+        // the WASM worker before the editor loads them — mirrors the editor's
+        // File → Open path so the Home picker isn't DOCX-only.
+        let buffer: ArrayBuffer = raw;
         if (fmt && isForeignFormat(fmt)) {
           setStatus('Converting…');
           const out = await convertToDocx(new Uint8Array(raw), fmt);
-          buffer = out.buffer.slice(
-            out.byteOffset,
-            out.byteOffset + out.byteLength
-          ) as ArrayBuffer;
+          buffer = out.buffer.slice(out.byteOffset, out.byteOffset + out.byteLength) as ArrayBuffer;
         }
-        const cleanName = file.name.replace(/\.(odt|md|markdown|txt)$/i, '.docx');
+        const cleanName = file.name.replace(/\.odt$/i, '.docx');
+        setTextDoc(null);
         setCurrentDocument(null);
         setDocumentBuffer(buffer);
         setFileName(cleanName);
@@ -715,6 +743,7 @@ export function App() {
     if (!ok) return;
     setCurrentDocument(null);
     setDocumentBuffer(null);
+    setTextDoc(null);
     setFileName('Untitled.docx');
     setStatus('');
     suppressSeedDocumentRef.current = false;
@@ -801,6 +830,19 @@ export function App() {
   // (everyone shares one source of truth — the gateway). Rendered
   // by a child component so useCollab is always called when its
   // mounting condition is true.
+  if (collabParams && collabParams.kind !== 'docx') {
+    return (
+      <MarkdownCollabApp
+        room={collabParams.room}
+        backend={collabParams.backend}
+        user={localUser}
+        kind={collabParams.kind}
+        onBack={handleGoHome}
+        renderLogo={renderLogo}
+      />
+    );
+  }
+
   if (collabParams) {
     return (
       <CollabApp
@@ -822,6 +864,19 @@ export function App() {
 
   if (view === 'home') {
     return <Home onSelectTemplate={handleSelectTemplate} onOpenFile={handleOpenFromHome} />;
+  }
+
+  if (textDoc) {
+    return (
+      <MarkdownEditor
+        initialText={textDoc.text}
+        fileName={textDoc.fileName}
+        kind={textDoc.kind}
+        onRenameFile={(name) => setTextDoc((d) => (d ? { ...d, fileName: name } : d))}
+        onBack={handleGoHome}
+        renderLogo={renderLogo}
+      />
+    );
   }
 
   return (

--- a/docx-editor/examples/vite/src/Home.tsx
+++ b/docx-editor/examples/vite/src/Home.tsx
@@ -898,7 +898,7 @@ export function Home({ onSelectTemplate, onOpenFile }: HomeProps): React.JSX.Ele
       <input
         ref={fileInputRef}
         type="file"
-        accept=".docx,.odt"
+        accept=".docx,.odt,.md,.markdown,.txt"
         style={styles.hiddenInput}
         onChange={handleFileChange}
         data-testid="home-file-input"

--- a/docx-editor/examples/vite/src/markdown/MarkdownCollabApp.tsx
+++ b/docx-editor/examples/vite/src/markdown/MarkdownCollabApp.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { MarkdownEditor } from './MarkdownEditor';
+import { useMarkdownCollab } from './useMarkdownCollab';
+
+export interface MarkdownCollabAppProps {
+  room: string;
+  backend: string;
+  user: { name: string; color: string };
+  /** `markdown` (default) shows the preview; `text` is source-only. */
+  kind?: 'markdown' | 'text';
+  onBack?: () => void;
+  renderLogo?: () => React.ReactNode;
+}
+
+/**
+ * Collaborative variant of the text/markdown editor. Activated when a share
+ * URL carries `?room=…&kind=text` — the editor binds CodeMirror to a shared
+ * `Y.Text` over the same Hocuspocus collab server the DocxEditor uses. The
+ * first peer's content seeds the room; later joiners sync from it.
+ *
+ * Content is owned by the Y.Doc, so `initialText` is empty here — there's no
+ * local file to seed from in a pure-collab session.
+ */
+export function MarkdownCollabApp({
+  room,
+  backend,
+  user,
+  kind = 'markdown',
+  onBack,
+  renderLogo,
+}: MarkdownCollabAppProps): React.ReactElement {
+  const collab = useMarkdownCollab({ room, backend, user });
+  return (
+    <MarkdownEditor
+      initialText=""
+      fileName={`${room}.${kind === 'text' ? 'txt' : 'md'}`}
+      kind={kind}
+      collab={collab}
+      onBack={onBack}
+      renderLogo={renderLogo}
+    />
+  );
+}

--- a/docx-editor/examples/vite/src/markdown/MarkdownEditor.tsx
+++ b/docx-editor/examples/vite/src/markdown/MarkdownEditor.tsx
@@ -154,6 +154,36 @@ export function MarkdownEditor({
     [onRenameFile]
   );
 
+  // Download the current source as its file. The visible CodeMirror state is
+  // the source of truth (it mirrors the shared Y.Text in collab mode), so read
+  // straight from the view to avoid a stale React-state snapshot.
+  const handleDownload = useCallback(() => {
+    const text = viewRef.current?.state.doc.toString() ?? docText;
+    const mime = kind === 'markdown' ? 'text/markdown' : 'text/plain';
+    const blob = new Blob([text], { type: `${mime};charset=utf-8` });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName || (kind === 'markdown' ? 'document.md' : 'document.txt');
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }, [docText, fileName, kind]);
+
+  // Cmd/Ctrl+S saves (downloads) instead of triggering the browser's
+  // save-page dialog — the Google-Docs-style expectation.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
+        e.preventDefault();
+        handleDownload();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [handleDownload]);
+
   const showSource = mode === 'source' || mode === 'split';
   const showPreview = supportsPreview && (mode === 'preview' || mode === 'split');
 
@@ -191,27 +221,47 @@ export function MarkdownEditor({
           />
         </div>
 
-        {supportsPreview && (
-          <div style={styles.toggle} role="group" aria-label="View mode">
-            {(['source', 'split', 'preview'] as MarkdownViewMode[]).map((m) => {
-              const active = mode === m;
-              return (
-                <button
-                  key={m}
-                  type="button"
-                  onClick={() => setMode(m)}
-                  aria-pressed={active}
-                  title={MODE_LABEL[m]}
-                  data-testid={`markdown-view-${m}`}
-                  style={{ ...styles.toggleButton, ...(active ? styles.toggleButtonActive : {}) }}
-                >
-                  <span style={styles.toggleIcon}>{ICONS[m]}</span>
-                  <span>{MODE_LABEL[m]}</span>
-                </button>
-              );
-            })}
-          </div>
-        )}
+        <div style={styles.barRight}>
+          {supportsPreview && (
+            <div style={styles.toggle} role="group" aria-label="View mode">
+              {(['source', 'split', 'preview'] as MarkdownViewMode[]).map((m) => {
+                const active = mode === m;
+                return (
+                  <button
+                    key={m}
+                    type="button"
+                    onClick={() => setMode(m)}
+                    aria-pressed={active}
+                    title={MODE_LABEL[m]}
+                    data-testid={`markdown-view-${m}`}
+                    style={{ ...styles.toggleButton, ...(active ? styles.toggleButtonActive : {}) }}
+                  >
+                    <span style={styles.toggleIcon}>{ICONS[m]}</span>
+                    <span>{MODE_LABEL[m]}</span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={handleDownload}
+            style={styles.downloadButton}
+            title="Download"
+            data-testid="markdown-download"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path
+                d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <span>Download</span>
+          </button>
+        </div>
       </header>
 
       <div style={styles.body}>
@@ -257,6 +307,20 @@ const styles: Record<string, React.CSSProperties> = {
     flex: '0 0 auto',
   },
   barLeft: { display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 },
+  barRight: { display: 'flex', alignItems: 'center', gap: 10, flex: '0 0 auto' },
+  downloadButton: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    border: '1px solid #e2e8f0',
+    borderRadius: 8,
+    padding: '6px 12px',
+    fontSize: 13,
+    fontWeight: 500,
+    color: '#334155',
+    background: '#ffffff',
+    cursor: 'pointer',
+  },
   iconButton: {
     display: 'inline-flex',
     alignItems: 'center',

--- a/docx-editor/examples/vite/src/markdown/MarkdownEditor.tsx
+++ b/docx-editor/examples/vite/src/markdown/MarkdownEditor.tsx
@@ -1,0 +1,322 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { EditorView, basicSetup } from 'codemirror';
+import { EditorState } from '@codemirror/state';
+import { markdown } from '@codemirror/lang-markdown';
+import { yCollab } from 'y-codemirror.next';
+import { markdownToHtml } from './markdownToHtml';
+import { seedYText } from './seedYText';
+import type { MarkdownCollab } from './useMarkdownCollab';
+import './markdown-preview.css';
+
+export type MarkdownViewMode = 'source' | 'split' | 'preview';
+
+export interface MarkdownEditorProps {
+  /** Raw file text to seed the editor (local open) or the shared doc (collab). */
+  initialText: string;
+  fileName: string;
+  /** `markdown` shows the preview + view toggle; `text` is source-only. */
+  kind: 'markdown' | 'text';
+  /** Present when a share session is live — binds CodeMirror to the Y.Text. */
+  collab?: MarkdownCollab | null;
+  onRenameFile?: (name: string) => void;
+  onBack?: () => void;
+  renderLogo?: () => React.ReactNode;
+}
+
+const COLORS = {
+  border: '#e2e8f0',
+  bar: '#ffffff',
+  toggleBg: '#f1f5f9',
+  toggleActive: '#ffffff',
+  text: '#0f172a',
+  muted: '#64748b',
+  accent: '#2563eb',
+  previewBg: '#ffffff',
+};
+
+const ICONS: Record<MarkdownViewMode, React.ReactNode> = {
+  source: (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M8 6l-5 6 5 6M16 6l5 6-5 6"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
+  split: (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <rect x="3" y="4" width="18" height="16" rx="2" stroke="currentColor" strokeWidth="2" />
+      <path d="M12 4v16" stroke="currentColor" strokeWidth="2" />
+    </svg>
+  ),
+  preview: (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinejoin="round"
+      />
+      <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="2" />
+    </svg>
+  ),
+};
+
+const MODE_LABEL: Record<MarkdownViewMode, string> = {
+  source: 'Source',
+  split: 'Split',
+  preview: 'Preview',
+};
+
+export function MarkdownEditor({
+  initialText,
+  fileName,
+  kind,
+  collab,
+  onRenameFile,
+  onBack,
+  renderLogo,
+}: MarkdownEditorProps): React.ReactElement {
+  // .txt has no markdown semantics — source-only, no preview toggle.
+  const supportsPreview = kind === 'markdown';
+  const [mode, setMode] = useState<MarkdownViewMode>(supportsPreview ? 'split' : 'source');
+  const [docText, setDocText] = useState(initialText);
+  const editorHostRef = useRef<HTMLDivElement | null>(null);
+  const viewRef = useRef<EditorView | null>(null);
+
+  // Build CodeMirror once. Re-running on collab identity change is correct —
+  // the binding is part of the extension set.
+  useEffect(() => {
+    const host = editorHostRef.current;
+    if (!host) return;
+
+    const langExtensions = kind === 'markdown' ? [markdown()] : [];
+
+    // Push every doc change into React state so the preview re-renders. In
+    // collab mode this also fires for remote edits applied by yCollab.
+    const sync = EditorView.updateListener.of((update) => {
+      if (update.docChanged) setDocText(update.state.doc.toString());
+    });
+
+    let collabExtensions: ReturnType<typeof yCollab>[] = [];
+    let startDoc = initialText;
+    if (collab) {
+      // The shared Y.Text is authoritative; seed it once if this is the first
+      // peer, then let yCollab drive CodeMirror's content + remote cursors.
+      seedYText(collab.ytext, initialText);
+      startDoc = collab.ytext.toString();
+      collabExtensions = [
+        yCollab(collab.ytext, collab.awareness ?? null, { undoManager: collab.undoManager }),
+      ];
+    }
+
+    const view = new EditorView({
+      parent: host,
+      state: EditorState.create({
+        doc: startDoc,
+        extensions: [
+          basicSetup,
+          ...langExtensions,
+          ...collabExtensions,
+          EditorView.lineWrapping,
+          sync,
+          EditorView.theme({
+            '&': { height: '100%', fontSize: '14px' },
+            '.cm-scroller': {
+              fontFamily:
+                'ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace',
+            },
+            '.cm-content': { padding: '16px 0' },
+          }),
+        ],
+      }),
+    });
+    viewRef.current = view;
+    setDocText(view.state.doc.toString());
+
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [collab, kind]);
+
+  const previewHtml = useMemo(
+    () => (supportsPreview ? markdownToHtml(docText) : ''),
+    [docText, supportsPreview]
+  );
+
+  const handleRename = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onRenameFile?.(e.target.value),
+    [onRenameFile]
+  );
+
+  const showSource = mode === 'source' || mode === 'split';
+  const showPreview = supportsPreview && (mode === 'preview' || mode === 'split');
+
+  return (
+    <div style={styles.root} data-testid="markdown-editor">
+      <header style={styles.bar}>
+        <div style={styles.barLeft}>
+          {onBack && (
+            <button
+              type="button"
+              onClick={onBack}
+              style={styles.iconButton}
+              title="Return to home"
+              aria-label="Return to home"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path
+                  d="M3 11l9-8 9 8M5 10v10h5v-6h4v6h5V10"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          )}
+          {renderLogo?.()}
+          <input
+            value={fileName}
+            onChange={handleRename}
+            style={styles.title}
+            spellCheck={false}
+            aria-label="Document name"
+            data-testid="markdown-filename"
+          />
+        </div>
+
+        {supportsPreview && (
+          <div style={styles.toggle} role="group" aria-label="View mode">
+            {(['source', 'split', 'preview'] as MarkdownViewMode[]).map((m) => {
+              const active = mode === m;
+              return (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => setMode(m)}
+                  aria-pressed={active}
+                  title={MODE_LABEL[m]}
+                  data-testid={`markdown-view-${m}`}
+                  style={{ ...styles.toggleButton, ...(active ? styles.toggleButtonActive : {}) }}
+                >
+                  <span style={styles.toggleIcon}>{ICONS[m]}</span>
+                  <span>{MODE_LABEL[m]}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </header>
+
+      <div style={styles.body}>
+        <div
+          ref={editorHostRef}
+          data-testid="markdown-source"
+          style={{
+            ...styles.pane,
+            ...(showSource ? {} : styles.hidden),
+            borderRight: showPreview ? `1px solid ${COLORS.border}` : 'none',
+          }}
+        />
+        {showPreview && (
+          <div
+            data-testid="markdown-preview"
+            className="markdown-preview-body"
+            style={styles.previewPane}
+            // Sanitized by DOMPurify in markdownToHtml — safe to inject.
+            dangerouslySetInnerHTML={{ __html: previewHtml }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100vh',
+    background: '#f8fafc',
+    color: COLORS.text,
+  },
+  bar: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 16,
+    padding: '8px 16px',
+    background: COLORS.bar,
+    borderBottom: `1px solid ${COLORS.border}`,
+    flex: '0 0 auto',
+  },
+  barLeft: { display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 },
+  iconButton: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 32,
+    height: 32,
+    border: 'none',
+    borderRadius: 8,
+    background: 'transparent',
+    color: COLORS.muted,
+    cursor: 'pointer',
+  },
+  title: {
+    border: 'none',
+    outline: 'none',
+    fontSize: 15,
+    fontWeight: 600,
+    color: COLORS.text,
+    background: 'transparent',
+    maxWidth: 360,
+    padding: '4px 6px',
+    borderRadius: 6,
+  },
+  toggle: {
+    display: 'inline-flex',
+    gap: 2,
+    padding: 2,
+    background: COLORS.toggleBg,
+    borderRadius: 10,
+    flex: '0 0 auto',
+  },
+  toggleButton: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    border: 'none',
+    borderRadius: 8,
+    padding: '6px 12px',
+    fontSize: 13,
+    fontWeight: 500,
+    color: COLORS.muted,
+    background: 'transparent',
+    cursor: 'pointer',
+  },
+  toggleButtonActive: {
+    background: COLORS.toggleActive,
+    color: COLORS.accent,
+    boxShadow: '0 1px 2px rgba(15,23,42,0.08)',
+  },
+  toggleIcon: { display: 'inline-flex', alignItems: 'center' },
+  body: { flex: '1 1 auto', display: 'flex', minHeight: 0, background: COLORS.bar },
+  pane: { flex: '1 1 0', minWidth: 0, height: '100%', overflow: 'hidden' },
+  hidden: { display: 'none' },
+  previewPane: {
+    flex: '1 1 0',
+    minWidth: 0,
+    height: '100%',
+    overflow: 'auto',
+    padding: '24px 32px',
+    background: COLORS.previewBg,
+    lineHeight: 1.6,
+  },
+};

--- a/docx-editor/examples/vite/src/markdown/markdown-preview.css
+++ b/docx-editor/examples/vite/src/markdown/markdown-preview.css
@@ -1,0 +1,163 @@
+/*
+ * Typography for the markdown preview pane. The app ships a CSS reset
+ * (Tailwind preflight) that strips heading sizes and list bullets, so the
+ * preview needs its own scoped styles to read like a real markdown render
+ * (GitHub-ish). All selectors are scoped under `.markdown-preview-body` so
+ * they never leak into the rest of the app.
+ */
+
+.markdown-preview-body {
+  color: #1f2328;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  word-wrap: break-word;
+}
+
+.markdown-preview-body > *:first-child {
+  margin-top: 0;
+}
+
+.markdown-preview-body h1,
+.markdown-preview-body h2,
+.markdown-preview-body h3,
+.markdown-preview-body h4,
+.markdown-preview-body h5,
+.markdown-preview-body h6 {
+  margin: 24px 0 16px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.markdown-preview-body h1 {
+  font-size: 2em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid #d1d9e0;
+}
+
+.markdown-preview-body h2 {
+  font-size: 1.5em;
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid #d1d9e0;
+}
+
+.markdown-preview-body h3 {
+  font-size: 1.25em;
+}
+.markdown-preview-body h4 {
+  font-size: 1em;
+}
+.markdown-preview-body h5 {
+  font-size: 0.875em;
+}
+.markdown-preview-body h6 {
+  font-size: 0.85em;
+  color: #59636e;
+}
+
+.markdown-preview-body p,
+.markdown-preview-body blockquote,
+.markdown-preview-body ul,
+.markdown-preview-body ol,
+.markdown-preview-body table,
+.markdown-preview-body pre {
+  margin: 0 0 16px;
+}
+
+.markdown-preview-body ul,
+.markdown-preview-body ol {
+  padding-left: 2em;
+}
+
+.markdown-preview-body ul {
+  list-style: disc;
+}
+.markdown-preview-body ol {
+  list-style: decimal;
+}
+.markdown-preview-body li {
+  margin: 0.25em 0;
+}
+.markdown-preview-body li > ul,
+.markdown-preview-body li > ol {
+  margin: 0.25em 0;
+}
+
+.markdown-preview-body ul.contains-task-list {
+  list-style: none;
+  padding-left: 1.2em;
+}
+
+.markdown-preview-body a {
+  color: #0969da;
+  text-decoration: none;
+}
+.markdown-preview-body a:hover {
+  text-decoration: underline;
+}
+
+.markdown-preview-body strong {
+  font-weight: 600;
+}
+.markdown-preview-body em {
+  font-style: italic;
+}
+
+.markdown-preview-body code {
+  padding: 0.2em 0.4em;
+  margin: 0;
+  font-size: 85%;
+  background: rgba(129, 139, 152, 0.15);
+  border-radius: 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
+}
+
+.markdown-preview-body pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  background: #f6f8fa;
+  border-radius: 8px;
+}
+
+.markdown-preview-body pre code {
+  padding: 0;
+  background: transparent;
+  font-size: 100%;
+}
+
+.markdown-preview-body blockquote {
+  padding: 0 1em;
+  color: #59636e;
+  border-left: 0.25em solid #d1d9e0;
+}
+
+.markdown-preview-body table {
+  border-collapse: collapse;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+}
+
+.markdown-preview-body th,
+.markdown-preview-body td {
+  padding: 6px 13px;
+  border: 1px solid #d1d9e0;
+}
+
+.markdown-preview-body tr:nth-child(2n) {
+  background: #f6f8fa;
+}
+
+.markdown-preview-body img {
+  max-width: 100%;
+}
+
+.markdown-preview-body hr {
+  height: 0.25em;
+  margin: 24px 0;
+  background: #d1d9e0;
+  border: 0;
+}

--- a/docx-editor/examples/vite/src/markdown/markdownToHtml.ts
+++ b/docx-editor/examples/vite/src/markdown/markdownToHtml.ts
@@ -1,0 +1,18 @@
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+// GitHub-ish rendering: hard line breaks + GFM tables/strikethrough/task-lists.
+marked.setOptions({ gfm: true, breaks: true });
+
+/**
+ * Render markdown source to sanitized HTML for the preview pane.
+ *
+ * `marked` turns markdown → HTML; `DOMPurify` strips anything dangerous
+ * (`<script>`, inline event handlers, `javascript:` URLs) so a malicious
+ * `.md` file can't run code in the editor. Synchronous — no async marked
+ * extensions are registered, so `parse` returns a string.
+ */
+export function markdownToHtml(src: string): string {
+  const raw = marked.parse(src, { async: false }) as string;
+  return DOMPurify.sanitize(raw);
+}

--- a/docx-editor/examples/vite/src/markdown/seedYText.test.ts
+++ b/docx-editor/examples/vite/src/markdown/seedYText.test.ts
@@ -1,0 +1,60 @@
+import { test, expect } from 'bun:test';
+import * as Y from 'yjs';
+import { seedYText } from './seedYText';
+
+/**
+ * The markdown editor's collab content lives in a shared Y.Text. These tests
+ * pin the data-layer contract yCollab rides on: the first peer seeds the room,
+ * later peers find it already populated and don't duplicate, and concurrent
+ * edits converge.
+ */
+
+function sync(a: Y.Doc, b: Y.Doc): void {
+  Y.applyUpdate(b, Y.encodeStateAsUpdate(a));
+  Y.applyUpdate(a, Y.encodeStateAsUpdate(b));
+}
+
+test('seeds an empty Y.Text with the opened file content', () => {
+  const doc = new Y.Doc();
+  const text = doc.getText('content');
+  seedYText(text, '# Hello');
+  expect(text.toString()).toBe('# Hello');
+});
+
+test('a second peer joining a populated room does NOT re-seed (no duplication)', () => {
+  const first = new Y.Doc();
+  seedYText(first.getText('content'), '# Shared doc');
+
+  const second = new Y.Doc();
+  sync(first, second);
+
+  // The joiner runs the same seed call, but the text is already populated.
+  seedYText(second.getText('content'), '# Shared doc');
+  sync(first, second);
+
+  expect(second.getText('content').toString()).toBe('# Shared doc');
+  expect(first.getText('content').toString()).toBe('# Shared doc');
+});
+
+test('empty initial content seeds nothing', () => {
+  const doc = new Y.Doc();
+  seedYText(doc.getText('content'), '');
+  expect(doc.getText('content').length).toBe(0);
+});
+
+test('concurrent edits from two peers converge', () => {
+  const a = new Y.Doc();
+  const b = new Y.Doc();
+  seedYText(a.getText('content'), 'start');
+  sync(a, b);
+
+  // Both peers append at the end concurrently, then sync.
+  a.getText('content').insert(a.getText('content').length, ' A');
+  b.getText('content').insert(b.getText('content').length, ' B');
+  sync(a, b);
+
+  expect(a.getText('content').toString()).toBe(b.getText('content').toString());
+  expect(a.getText('content').toString()).toContain('start');
+  expect(a.getText('content').toString()).toContain('A');
+  expect(a.getText('content').toString()).toContain('B');
+});

--- a/docx-editor/examples/vite/src/markdown/seedYText.ts
+++ b/docx-editor/examples/vite/src/markdown/seedYText.ts
@@ -1,0 +1,14 @@
+import type * as Y from 'yjs';
+
+/**
+ * Seed a shared `Y.Text` with the opened file's content — but only if it's
+ * still empty. The first peer to open a fresh room fills it; later joiners
+ * find it already populated by sync and skip seeding, so the document is
+ * never duplicated. Pure of React/CodeMirror so it can be unit-tested with
+ * two synced Y.Docs.
+ */
+export function seedYText(ytext: Y.Text, initial: string): void {
+  if (ytext.length === 0 && initial.length > 0) {
+    ytext.insert(0, initial);
+  }
+}

--- a/docx-editor/examples/vite/src/markdown/useMarkdownCollab.ts
+++ b/docx-editor/examples/vite/src/markdown/useMarkdownCollab.ts
@@ -1,0 +1,84 @@
+/**
+ * useMarkdownCollab — Yjs collab for the plain-text / markdown editor.
+ *
+ * Mirrors the DocxEditor's `useCollab`, but the shared state is a single
+ * `Y.Text` (raw markdown/text source) instead of a ProseMirror XML fragment.
+ * CodeMirror binds to it via `y-codemirror.next`'s `yCollab`, which handles
+ * conflict-free sync, remote cursors (awareness), and local-scoped undo.
+ *
+ * One authoritative Y.Doc per room lives on the shared CasualOffice collab
+ * server (Hocuspocus). A markdown file is never also a .docx, so reusing the
+ * docID as the room is collision-free.
+ *
+ * Returns `null` when no collab params are present — the caller then seeds
+ * CodeMirror from the opened file's bytes and edits stay local.
+ */
+import { useEffect, useMemo, useState } from 'react';
+import * as Y from 'yjs';
+import { HocuspocusProvider } from '@hocuspocus/provider';
+
+export type MarkdownCollabStatus = 'connecting' | 'connected' | 'disconnected';
+
+export interface MarkdownCollab {
+  ytext: Y.Text;
+  undoManager: Y.UndoManager;
+  awareness: HocuspocusProvider['awareness'];
+  status: MarkdownCollabStatus;
+}
+
+export interface UseMarkdownCollabOptions {
+  room: string;
+  backend: string;
+  user: { name: string; color: string };
+  token?: string;
+}
+
+export function useMarkdownCollab(options: UseMarkdownCollabOptions | null): MarkdownCollab | null {
+  // Hooks must run unconditionally, so always construct; the caller passing
+  // `null` yields a disabled session we never read.
+  const room = options?.room ?? '';
+  const backend = options?.backend ?? '';
+  const token = options?.token;
+
+  const { ytext, undoManager, provider } = useMemo(() => {
+    const ydoc = new Y.Doc();
+    const ytext = ydoc.getText('content');
+    const undoManager = new Y.UndoManager(ytext);
+    if (!room || !backend) {
+      return { ydoc, ytext, undoManager, provider: null as HocuspocusProvider | null };
+    }
+    const provider = new HocuspocusProvider({
+      url: backend,
+      name: room,
+      document: ydoc,
+      token: token ?? 'anon',
+    });
+    return { ydoc, ytext, undoManager, provider };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [room, backend, token]);
+
+  const [status, setStatus] = useState<MarkdownCollabStatus>('connecting');
+
+  useEffect(() => {
+    provider?.awareness?.setLocalStateField('user', options?.user);
+  }, [provider, options?.user?.name, options?.user?.color]);
+
+  useEffect(() => {
+    if (!provider) return;
+    const onStatus = (e: { status: MarkdownCollabStatus }) => setStatus(e.status);
+    provider.on('status', onStatus);
+    return () => {
+      provider.off('status', onStatus);
+    };
+  }, [provider]);
+
+  useEffect(() => {
+    return () => {
+      provider?.destroy();
+      undoManager.destroy();
+    };
+  }, [provider, undoManager]);
+
+  if (!options) return null;
+  return { ytext, undoManager, awareness: provider?.awareness ?? null, status };
+}


### PR DESCRIPTION
Follow-up to #72 (which shipped only the .odt path — the markdown commits landed after that PR was squash-merged and were orphaned; this re-raises them off main).

.md/.txt no longer flatten to DOCX. They open in a dedicated CodeMirror source editor with:
- live, sanitized markdown preview (marked + DOMPurify)
- three view modes: source / split / preview (.txt is source-only)
- Download button + Cmd/Ctrl+S to save the source back to file
- collab: content binds to a shared `Y.Text` via `y-codemirror.next`, over the same Hocuspocus path the DocxEditor uses (`?room=…&kind=text`)

Verified: 5 markdown e2e (open, view modes, live preview, .txt source-only, download round-trip) + odt e2e + Y.Text convergence unit tests; typecheck clean; demo build green.