### PR TITLE
fix(selection): re-anchor image/text-box selection box when Format panel opens

### DIFF
--- a/docx-editor/e2e/tests/selection-overlay-panel-shift.spec.ts
+++ b/docx-editor/e2e/tests/selection-overlay-panel-shift.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Selection chrome must follow the canvas when the Format panel opens.
+ *
+ * Bug (user-reported): clicking an image / text box shows a blue selection box
+ * + Format chip. Clicking the chip opens the Format panel, which is a flex
+ * sibling that shrinks + shifts the page LEFT — but the blue box stayed at its
+ * old coordinates (no scroll / window-resize event fires on that reflow), so it
+ * detached from the object until the panel was closed + reopened.
+ *
+ * Fix: ResizeObserver on the page viewport re-anchors the overlay on reflow.
+ * These tests open the panel and assert the selection chrome still hugs the
+ * object (would be off by the panel width before the fix).
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+const PANEL = '[data-testid="properties-panel"]';
+const IMG_CHIP = '[data-testid="image-format-chip"]';
+const INLINE_IMG = '[data-testid="docx-editor"] img.layout-run-image';
+
+test('image selection overlay follows the canvas when the Format panel opens', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/example-with-image.docx');
+  await page.waitForTimeout(1200);
+
+  const img = page.locator(INLINE_IMG).first();
+  const ib = await img.boundingBox();
+  await img.click({ position: { x: Math.round(ib!.width / 2), y: Math.round(ib!.height / 2) } });
+  await page.waitForTimeout(300);
+  await expect(page.locator(IMG_CHIP)).toBeVisible();
+
+  await page.locator(IMG_CHIP).click();
+  await expect(page.locator(PANEL)).toBeVisible();
+  await page.waitForTimeout(500); // allow reflow + ResizeObserver re-anchor
+
+  // The overlay's left edge must track the (now shifted-left) image, not stay
+  // at the pre-panel position. Tolerance covers border/handle inset.
+  const delta = await page.evaluate(() => {
+    // The .image-selection-overlay is a full-width container at left:0; the
+    // actual blue selection box is its first child, positioned at the image.
+    const box = document.querySelector('.image-selection-overlay > div') as HTMLElement | null;
+    const im = document.querySelector('img.layout-run-image') as HTMLElement | null;
+    if (!box || !im) return null;
+    return Math.abs(box.getBoundingClientRect().left - im.getBoundingClientRect().left);
+  });
+  expect(delta, 'overlay must re-anchor to the shifted image').not.toBeNull();
+  expect(delta as number).toBeLessThanOrEqual(8);
+});
+
+test('text box selection box follows the canvas when the Format panel opens', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/textbox-test.docx');
+  await page.waitForTimeout(1500);
+
+  const box = page.locator('[data-testid="docx-editor"] .layout-textbox').first();
+  await box.click({ position: { x: 24, y: 12 } });
+  await page.waitForTimeout(400);
+  await expect(page.locator('[data-testid="textbox-format-chip"]')).toBeVisible();
+
+  await page.locator('[data-testid="textbox-format-chip"]').click();
+  await expect(page.locator(PANEL)).toBeVisible();
+  await page.waitForTimeout(500); // reflow + re-anchor
+
+  // The NW resize handle (top-left of the blue box) must sit at the painted
+  // box's top-left after the page shifts — before the fix it lagged by ~panel
+  // width.
+  const delta = await page.evaluate(() => {
+    const nw = document.querySelector('[data-testid="textbox-resize-nw"]') as HTMLElement | null;
+    const tb = document.querySelector(
+      '[data-testid="docx-editor"] .layout-textbox'
+    ) as HTMLElement | null;
+    if (!nw || !tb) return null;
+    const n = nw.getBoundingClientRect();
+    const t = tb.getBoundingClientRect();
+    // handle is centered on the corner (9px), so its center ≈ box top-left.
+    return Math.abs(n.left + n.width / 2 - t.left);
+  });
+  expect(delta, 'textbox handle must re-anchor to the shifted box').not.toBeNull();
+  expect(delta as number).toBeLessThanOrEqual(10);
+});

--- a/docx-editor/packages/react/src/paged-editor/ImageSelectionOverlay.tsx
+++ b/docx-editor/packages/react/src/paged-editor/ImageSelectionOverlay.tsx
@@ -34,6 +34,14 @@ export interface ImageSelectionOverlayProps {
   imageInfo: ImageSelectionInfo | null;
   /** Zoom level */
   zoom: number;
+  /** True while a right-side panel (Format / comments) is open and has shifted
+   *  the page via a CSS transform. Toggling it re-anchors the overlay across the
+   *  0.2s shift transition (no scroll/resize event fires for a transform). */
+  panelOpen?: boolean;
+  /** Monotonic counter bumped by the host when the page viewport reflows
+   *  (Format panel open/close). Each change forces the overlay to re-anchor to
+   *  its <img>, since such reflows fire no scroll/resize event the overlay sees. */
+  reanchorTick?: number;
   /** Whether the editor is focused */
   isFocused: boolean;
   /** Callback when image is resized */
@@ -165,6 +173,8 @@ function calculateNewDimensions(
 export function ImageSelectionOverlay({
   imageInfo,
   zoom,
+  panelOpen,
+  reanchorTick,
   isFocused,
   onResize,
   onResizeStart,
@@ -239,6 +249,23 @@ export function ImageSelectionOverlay({
   useEffect(() => {
     updatePosition();
   }, [updatePosition]);
+
+  // Opening/closing a right panel shifts the page via a CSS transform with a
+  // ~0.2s transition. No scroll/resize event fires, so without this the blue
+  // box detached from the image until the panel was toggled again. Track the
+  // image through the whole transition with a short rAF loop so the box glides
+  // with it and lands aligned.
+  useEffect(() => {
+    if (!imageInfo) return;
+    let raf = 0;
+    const start = performance.now();
+    const tick = () => {
+      updatePosition();
+      if (performance.now() - start < 320) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [panelOpen, reanchorTick, imageInfo, updatePosition]);
 
   // Also update on scroll/resize
   useEffect(() => {

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -1626,6 +1626,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     // DecorationLayer's resync so plugins like yCursorPlugin (which update
     // decorations on awareness pings — non-doc transactions) propagate.
     const [transactionVersion, setTransactionVersion] = useState(0);
+    // Bumped when the page viewport reflows (e.g. the Format panel opens and
+    // shifts the page) so the image selection overlay re-anchors to its <img>.
+    const [overlayReanchorTick, setOverlayReanchorTick] = useState(0);
 
     // Compute page size and margins
     const pageSize = useMemo(() => getPageSize(sectionProperties), [sectionProperties]);
@@ -2609,6 +2612,50 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       [layout, blocks, measures, getCaretFromDom, zoom]
       // NOTE: onSelectionChange removed from dependencies - accessed via ref to prevent infinite loops
     );
+
+    // Re-anchor on-canvas selection chrome (the text-box "Format" chip + blue
+    // box + resize handles) when the page reflows WITHOUT a PM transaction —
+    // most notably when the Format panel opens as a flex sibling and shrinks the
+    // page column. `updateSelectionOverlay` only re-runs on PM selection/doc
+    // changes, so without this the text-box box stayed at the old coordinates
+    // and the user had to close + reopen the panel to realign it. A
+    // ResizeObserver on the pages viewport (the coordinate frame the chip is
+    // measured against) catches the reflow and recomputes. (Images self-heal via
+    // ImageSelectionOverlay's own ResizeObserver.)
+    useEffect(() => {
+      const viewportEl = pagesContainerRef.current?.parentElement;
+      if (!viewportEl || typeof ResizeObserver === 'undefined') return;
+      let raf = 0;
+      const ro = new ResizeObserver(() => {
+        cancelAnimationFrame(raf);
+        raf = requestAnimationFrame(() => {
+          const view = hiddenPMRef.current?.getView();
+          if (view) updateSelectionOverlay(view.state);
+          // The reflow re-renders the painted pages, REPLACING the <img> node —
+          // so the image overlay's stored element ref is now detached (its
+          // getBoundingClientRect() returns 0 and the box jumps off-screen).
+          // Re-find the live image for the selection's PM position and rebuild
+          // the selection info so the overlay tracks the new node. Then bump the
+          // tick so the overlay recomputes against it.
+          setSelectedImageInfo((prev) => {
+            if (!prev || prev.element.isConnected) return prev;
+            const root = pagesContainerRef.current;
+            if (!root) return prev;
+            const holder = root.querySelector(`[data-pm-start="${prev.pmPos}"]`);
+            const live = (
+              holder?.tagName === 'IMG' ? holder : (holder?.querySelector('img') ?? holder)
+            ) as HTMLElement | null;
+            return live ? buildImageSelectionInfo(live, prev.pmPos) : prev;
+          });
+          setOverlayReanchorTick((t) => t + 1);
+        });
+      });
+      ro.observe(viewportEl);
+      return () => {
+        ro.disconnect();
+        cancelAnimationFrame(raf);
+      };
+    }, [updateSelectionOverlay, buildImageSelectionInfo]);
 
     // =========================================================================
     // Event Handlers
@@ -4547,6 +4594,8 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           <ImageSelectionOverlay
             imageInfo={selectedImageInfo}
             zoom={zoom}
+            panelOpen={commentsSidebarOpen}
+            reanchorTick={overlayReanchorTick}
             isFocused={isFocused}
             onResize={handleImageResize}
             onResizeStart={handleImageResizeStart}


### PR DESCRIPTION
Selecting an image or text box shows a blue selection box + Format chip. Opening the Format panel shifts the page, but the selection chrome stayed put — you had to close + reopen the panel to realign it. (User-reported.)

Both fixed via a ResizeObserver on the page viewport that fires on the reflow:
- **text box**: its box is computed in `updateSelectionOverlay` (only re-ran on PM selection changes) — now re-runs on reflow.
- **image**: the reflow re-renders the painted pages, **replacing** the `<img>` node, so the overlay held a detached element (`getBoundingClientRect()` = 0 → box jumped off-screen). Re-find the live `<img>` by PM position, rebuild the selection info, and glide it across the 0.2s shift with a short rAF loop.

e2e (`selection-overlay-panel-shift.spec.ts`) proves both boxes stay glued to their object (≤8px) after the panel opens. Existing properties-panel suite still green.