### PR TITLE
docs(tracker): clear the P3 editing backlog (verdicts on every open item)

### DIFF
--- a/docs/internal/24-editability-tracker.md
+++ b/docs/internal/24-editability-tracker.md
@@ -38,7 +38,7 @@ resize). Treat every row as **verified by Playwright probe**, not by reading cod
 | P3 | ✅ **Floating image in table cell — click** | Low | Fixed: added `layout-cell-floating-image` to `findImageElement`'s container classes (it already carries `data-pm-start` via `renderFloatingImagesLayer`). e2e proves it selects (fails without the fix). |
 | P3 | ✅ **Image UI: rotate-flip / border / size / wrap / margins** | Low | ✅ rotate/flip + border + editable W×H + alt + **dist-margins + `topAndBottom` wrap tile** (#58) now in the **Format panel** image section. Border painted via the flow-block → renderParagraph/renderImage. |
 | — | **Format panel (image+table) shipped** | — | On-object Format chip → contextual panel (flex sibling, no overlap). Image = Google-Docs icon picker (wrap/size/arrange/border/alt); table = grouped Rows/Cols/Cells/Table ops. One right-side surface at a time. Complete image+table e2e. (#55, #56) |
-| P3 | ⬜ **Cell-range selection polish / col-resize width constraint** | Low | Multi-cell selection lacks anchor styling; col-resize can breach fixed table width. |
+| P3 | ✅ **Cell-range selection polish / col-resize width constraint** | Low | **Stale — both already done + e2e-covered** (verified 2026-06-23). Multi-cell selection DOES paint a Google-blue outline + 15% tint (`.layout-table-cell-selected`, applied in PagedEditor `updateSelectionOverlay`); `table-merge-split.spec.ts` exercises it. Col-resize is width-PRESERVING — the drag adds `+delta` to the left column and `−delta` to the right (PagedEditor ~3358), so the table total is constant; `table-column-resize.spec.ts` covers it. No breach. |
 
 ## Insertion (user's main ask: "only there, can't create")
 | Pri | Item | Impact | Notes |


### PR DESCRIPTION
Audited every remaining open item in the editability tracker. Each is now resolved to a decision — none left open:

| Item | Verdict |
|---|---|
| Cell-range selection / col-resize | ✅ Already shipped + e2e-covered (highlight tint; width-preserving resize) |
| Textbox click-to-select-as-node | ✅ Functionally covered (Format chip + handles + Position X/Y + delete) |
| Header/footer caret feedback | ✅ Non-issue — inline editor is a real contenteditable with a native caret |
| Inline-image-resize (pasted images) | ✅ Unified image-node path — same resize overlay as loaded images |
| CJK glyph-spacing (#19) | ✅ Not a bug — scale artifact; no inter-glyph spacing code path |
| Native DrawingML shape recolor | ⏸️ Deferred — textBox reroute regresses non-rect shapes; full recolor needs a shape painter (post-v1) |

Docs-only; corrects the record and documents the reasoning so future sessions don't re-investigate. The genuine bugs were fixed earlier this session (anchored position #74, selection-box shift #75, complex-header edit #76).