### PR TITLE
fix(layout): center the page so the vertical ruler reads near-canvas at every width

### DIFF
--- a/docx-editor/e2e/tests/page-centering.spec.ts
+++ b/docx-editor/e2e/tests/page-centering.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * The page (and its rulers) center in the full window at every width that fits
+ * it — Google-Docs style. Previously the outline-button reserved a symmetric
+ * left "lane", so at medium widths the page was pushed into that lane and the
+ * vertical ruler jammed against the window's left corner instead of sitting
+ * just-left of a centered page. (User-reported; the #16 ruler item.)
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+async function pageLeftAt(page: import('@playwright/test').Page, vw: number) {
+  await page.setViewportSize({ width: vw, height: 900 });
+  await page.waitForTimeout(500);
+  return page.evaluate(() => {
+    const pg = document.querySelector('.layout-page') as HTMLElement | null;
+    if (!pg) return null;
+    const r = pg.getBoundingClientRect();
+    return { left: Math.round(r.left), width: Math.round(r.width), vw: window.innerWidth };
+  });
+}
+
+test('the page centers in the window at medium widths (no left-corner lane)', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/demo.docx');
+  await page.waitForTimeout(800);
+
+  // At a medium width where the page still fits, it must be centered — not held
+  // in a left lane. Tolerance covers the ~20px ruler gutter + rounding.
+  for (const vw of [1000, 1200]) {
+    const m = await pageLeftAt(page, vw);
+    expect(m, `measurable at ${vw}`).not.toBeNull();
+    const expectedCenter = Math.round((m!.vw - m!.width) / 2);
+    expect(
+      Math.abs(m!.left - expectedCenter),
+      `page should be centered at vw=${vw} (left=${m!.left}, expected≈${expectedCenter})`
+    ).toBeLessThanOrEqual(22);
+  }
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -44,11 +44,7 @@ import { FocusModeBar } from './FocusModeBar';
 import { useStatPrefs } from './statbar-prefs';
 import { READABILITY_PLUGIN_KEY, readabilityPlugin } from '../lib/quality/readabilityPlugin';
 import { pointsToHalfPoints } from './ui/FontSizePicker';
-import {
-  DocumentOutline,
-  OUTLINE_BUTTON_RESERVED_SPACE,
-  OUTLINE_RESERVED_SPACE,
-} from './DocumentOutline';
+import { DocumentOutline, OUTLINE_RESERVED_SPACE } from './DocumentOutline';
 import { SIDEBAR_DOCUMENT_SHIFT } from './sidebar/constants';
 import { VersionHistoryPanel } from './sidebar/VersionHistoryPanel';
 import { PropertiesPanel, type PropertiesTargetKind } from './sidebar/PropertiesPanel';
@@ -1579,7 +1575,9 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     placeholder,
     loadingIndicator,
     showOutline: showOutlineProp = false,
-    showOutlineButton = true,
+    // showOutlineButton is a vestigial prop (the outline now lives in the
+    // right-edge PanelRail); kept on the props type for API compatibility but no
+    // longer consumed here.
     fontFamilies,
     showPrintButton = true,
     printOptions: _printOptions,
@@ -7945,11 +7943,15 @@ body { background: white; }
   const sidebarOpen = showCommentsSidebar || allSidebarItems.length > 0;
   // Reserve 2× the left-edge allowance so the centered page clears whatever
   // outline UI is showing, without forcing a shift on wide viewports.
-  const outlineLeftAllowance = showOutline
-    ? OUTLINE_RESERVED_SPACE
-    : showOutlineButton
-      ? OUTLINE_BUTTON_RESERVED_SPACE
-      : 20;
+  // Google-Docs-style centering: the page centers in the FULL window at every
+  // width; the ruler + outline BUTTON are overlays in the page's left gutter, so
+  // they don't reserve flow space and may scroll off-screen-left when the window
+  // is too narrow to fit the page. Only the expanded outline PANEL is a real
+  // left panel, so only it reserves a (symmetric, to keep the page centered)
+  // lane. Previously the outline-button case reserved a 2×button-space lane,
+  // which pushed the page into a left "lane" at medium widths and jammed the
+  // ruler against the window's left corner instead of centering.
+  const outlineLeftAllowance = showOutline ? OUTLINE_RESERVED_SPACE : 0;
   const minLayoutWidth =
     2 * outlineLeftAllowance + DEFAULT_PAGE_WIDTH + (sidebarOpen ? SIDEBAR_DOCUMENT_SHIFT * 2 : 0);
 


### PR DESCRIPTION
User-reported (#16 ruler): on medium-width windows the page was held in a left 'lane' and the vertical ruler jammed against the window's left corner, while wide windows centered nicely.

Root cause: `minLayoutWidth` reserved a symmetric `2× outline-button space` lane even when only the outline *button* (an overlay) was shown. Now only the **expanded outline panel** (a real left panel) reserves a lane; the ruler + outline button are overlays in the page's left gutter that scroll off-left when the window can't fit the page — matching Google Docs (which the user asked to mirror).

Result: the page centers at every fitting width (VW900 pageLeft 96→42, VW1000→92 — exactly centered); overflows + scrolls below page width. `showOutlineButton` was already vestigial (outline moved to the right PanelRail) — dropped its unused consumption.

Verified: new `page-centering` guard e2e + vertical-ruler-position + hf-toolbar suites green; typecheck clean; screenshots confirm the ruler now sits just-left of the centered page.