### PR TITLE
feat(track-changes): per-author change colors + recover Phase-A roadmap audit

### DIFF
--- a/docs/internal/ROADMAP.md
+++ b/docs/internal/ROADMAP.md
@@ -43,10 +43,22 @@ The features that close the gap with Google Docs / OnlyOffice for `.docx` workfl
    accept/reject sidebar + accept-all/reject-all, Yjs-synced marks. Full-flow e2e in
    `track-changes-flow.spec.ts`. Remaining *polish*: `<w:pPrChange>` paragraph-format-change
    display, per-author color coding, prev/next-change navigation, general round-trip fixture.
-2. **Named version history** — milestone snapshots on the Yjs history; "named versions"
-   filter. Cheap on the CRDT, high perceived value. (Next biggest Phase-A item to build.)
-3. **Opt-in Strict / paragraph-lock co-editing mode** (OnlyOffice pattern) — prevents
-   distant concurrent reflow on long docs; *also* mitigates the large-doc drift in Phase B.
+2. **Named version history** — ✅ **ALREADY SHIPPED** (audited 2026-06-24). IDB-backed
+   `version-history/` module: **auto** snapshots (~10-min idle while dirty) + **manual named**
+   snapshots (`saveNamedVersion`), restore, rename, collab-aware author attribution, and a
+   `ServerVersionBackend` for host-side revisions. `VersionHistoryPanel` in the right rail.
+   e2e: `version-history.spec.ts` + `version-history-audit.spec.ts`.
+3. **Opt-in Strict / paragraph-lock co-editing mode** (OnlyOffice pattern) — ⬜ **the one
+   genuinely-unbuilt Phase-A item.** Focusing a paragraph locks it for peers (Yjs awareness);
+   others see it locked / read-only. Prevents distant concurrent reflow on long docs; *also*
+   mitigates the large-doc drift in Phase B. Collab-only, so verify with a 2-Y.Doc convergence
+   test at the data layer (multi-peer UI e2e is impractical without a live server).
+
+**Reality check (2026-06-24 audit):** the editor is far more complete than a from-scratch
+roadmap implies — Phase A #1 and #2 were already built; only #3 (Strict mode) remains. The
+near-term "build" backlog across the project is small (Strict mode, Phase B extreme-corpus
+fidelity, Phase D breadth); most "to-do" features turn out to need *verification + e2e
+coverage*, not implementation. Audit before building.
 
 ### Phase B — Extreme-corpus visual fidelity (dedicated, riskier)
 The CJK-SDS / dense-form corpus (~53) — the user's real-world documents. Per-font

--- a/docx-editor/packages/core/src/layout-painter/renderParagraph.ts
+++ b/docx-editor/packages/core/src/layout-painter/renderParagraph.ts
@@ -29,6 +29,7 @@ import {
   type TabStop as TabCalcStop,
 } from '../prosemirror/utils/tabCalculator';
 import { resolveFontFamily } from '../utils/fontResolver';
+import { colorForAuthor } from '../utils/changeAuthorColor';
 
 /**
  * CSS class names for paragraph rendering
@@ -243,10 +244,15 @@ function applyRunStyles(
     }
   }
 
-  // Tracked insertion styling — light green background with dashed border
+  // Per-author color ("by author", Word/Google-Docs style); null → no author,
+  // fall back to the classic green-insert / red-delete styling.
+  const changeColor = run.isInsertion || run.isDeletion ? colorForAuthor(run.changeAuthor) : null;
+
+  // Tracked insertion — light author-tint background + dashed underline in the
+  // author's color (default green when anonymous). Decoration = underline.
   if (run.isInsertion) {
-    element.style.backgroundColor = 'rgba(52, 168, 83, 0.08)';
-    element.style.borderBottom = '2px dashed #2e7d32';
+    element.style.backgroundColor = changeColor?.bg ?? 'rgba(52, 168, 83, 0.08)';
+    element.style.borderBottom = `2px dashed ${changeColor?.solid ?? '#2e7d32'}`;
     element.style.paddingBottom = '1px';
     element.classList.add('docx-insertion');
     if (run.changeAuthor) element.dataset.changeAuthor = run.changeAuthor;
@@ -254,12 +260,14 @@ function applyRunStyles(
     if (run.changeRevisionId != null) element.dataset.revisionId = String(run.changeRevisionId);
   }
 
-  // Tracked deletion styling — light red background with strikethrough
+  // Tracked deletion — light author-tint background + strikethrough in the
+  // author's color (default red when anonymous). Decoration = strikethrough.
   if (run.isDeletion) {
-    element.style.backgroundColor = 'rgba(211, 47, 47, 0.08)';
-    element.style.color = '#c62828';
+    const del = changeColor?.solid ?? '#c62828';
+    element.style.backgroundColor = changeColor?.bg ?? 'rgba(211, 47, 47, 0.08)';
+    element.style.color = del;
     if (!decorations.includes('line-through')) decorations.push('line-through');
-    element.style.textDecorationColor = '#c62828';
+    element.style.textDecorationColor = del;
     element.classList.add('docx-deletion');
     if (run.changeAuthor) element.dataset.changeAuthor = run.changeAuthor;
     if (run.changeDate) element.dataset.changeDate = run.changeDate;

--- a/docx-editor/packages/core/src/utils/changeAuthorColor.test.ts
+++ b/docx-editor/packages/core/src/utils/changeAuthorColor.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from 'bun:test';
+import { colorForAuthor } from './changeAuthorColor';
+
+test('no author → null (caller uses the default green/red styling)', () => {
+  expect(colorForAuthor(undefined)).toBeNull();
+  expect(colorForAuthor(null)).toBeNull();
+  expect(colorForAuthor('')).toBeNull();
+});
+
+test('same author always maps to the same color (stable)', () => {
+  const a = colorForAuthor('Alice');
+  const b = colorForAuthor('Alice');
+  expect(a).not.toBeNull();
+  expect(a).toEqual(b!);
+});
+
+test('different authors generally get different colors', () => {
+  // Across a handful of names we expect at least 2 distinct hues (the palette
+  // has 8 slots; collisions are possible but not for all of these).
+  const names = ['Alice', 'Bob', 'Carol', 'Dave', 'Erin', 'Frank'];
+  const solids = new Set(names.map((n) => colorForAuthor(n)!.solid));
+  expect(solids.size).toBeGreaterThan(1);
+});
+
+test('returns both a solid line color and a faint bg tint', () => {
+  const c = colorForAuthor('Reviewer')!;
+  expect(c.solid).toMatch(/^#[0-9a-f]{6}$/i);
+  expect(c.bg).toContain('rgba(');
+});

--- a/docx-editor/packages/core/src/utils/changeAuthorColor.ts
+++ b/docx-editor/packages/core/src/utils/changeAuthorColor.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-author colors for tracked changes — the Word / Google-Docs "by author"
+ * convention: each reviewer's suggestions get a distinct, stable color, and the
+ * decoration carries insert-vs-delete (underline = insertion, strikethrough =
+ * deletion). This lets multiple reviewers' changes be told apart at a glance.
+ *
+ * When the change has no author (anonymous / single-user), the caller falls back
+ * to the classic green-insert / red-delete styling.
+ */
+
+/** Saturated line/decoration color + a faint background tint, per author slot. */
+export interface ChangeColor {
+  solid: string;
+  bg: string;
+}
+
+// 8 distinct, reasonably color-blind-distinguishable hues (Google-Docs-ish).
+const CHANGE_AUTHOR_PALETTE: readonly ChangeColor[] = [
+  { solid: '#1a73e8', bg: 'rgba(26, 115, 232, 0.10)' }, // blue
+  { solid: '#188038', bg: 'rgba(24, 128, 56, 0.10)' }, // green
+  { solid: '#9334e6', bg: 'rgba(147, 52, 230, 0.10)' }, // purple
+  { solid: '#e8710a', bg: 'rgba(232, 113, 10, 0.10)' }, // orange
+  { solid: '#12a4af', bg: 'rgba(18, 164, 175, 0.10)' }, // teal
+  { solid: '#d93025', bg: 'rgba(217, 48, 37, 0.10)' }, // red
+  { solid: '#a142f4', bg: 'rgba(161, 66, 244, 0.10)' }, // violet
+  { solid: '#b06000', bg: 'rgba(176, 96, 0, 0.10)' }, // brown
+];
+
+/** Stable string hash (djb2-ish) so the same author always maps to the same slot. */
+function hashAuthor(author: string): number {
+  let h = 0;
+  for (let i = 0; i < author.length; i++) {
+    h = (h * 31 + author.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+/**
+ * Color for a tracked-change author, or `null` when there's no author (the
+ * caller then uses the default green-insert / red-delete styling).
+ */
+export function colorForAuthor(author?: string | null): ChangeColor | null {
+  if (!author) return null;
+  return CHANGE_AUTHOR_PALETTE[hashAuthor(author) % CHANGE_AUTHOR_PALETTE.length];
+}


### PR DESCRIPTION
Two things (both track-changes / Phase A):

**Per-author change colors** — tracked insertions/deletions now render in a stable per-author color (8-hue palette hashed from the author name), the Word/Google-Docs 'by author' convention: multiple reviewers' suggestions are now distinguishable (underline = insertion, strikethrough = deletion, both in the author's color). Anonymous/single-user changes keep the classic green-insert / red-delete styling. New `changeAuthorColor` util + unit test; `track-changes-flow` e2e still green.

**Roadmap audit recovery** — re-adds the Phase-A audit note that got orphaned when #84 squash-merged (named version history is already shipped; only Strict co-editing remains unbuilt; audit before building).