### PR TITLE
fix(ui): keep right-click context menus inside the viewport

### DIFF
--- a/docx-editor/e2e/tests/context-menu-viewport.spec.ts
+++ b/docx-editor/e2e/tests/context-menu-viewport.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * The right-click context menu must stay within the viewport — when opened near
+ * the bottom edge it should clamp up (and cap its height + scroll internally)
+ * rather than spilling below the window. (User-reported: "context menu goes
+ * below the tab and can scroll".)
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test('text context menu stays within the viewport when opened near the bottom', async ({
+  page,
+}) => {
+  // A short viewport makes overflow likely if the menu didn't clamp.
+  await page.setViewportSize({ width: 1000, height: 560 });
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/demo.docx');
+  await page.waitForTimeout(1000);
+
+  // Right-click low in the viewport (a few px above the bottom edge).
+  await page.mouse.click(420, 430, { button: 'right' });
+
+  const menu = page.locator('.docx-text-context-menu');
+  await expect(menu).toBeVisible();
+
+  const box = await menu.boundingBox();
+  const vh = page.viewportSize()!.height;
+  const vw = page.viewportSize()!.width;
+  expect(box, 'menu measurable').not.toBeNull();
+  // Fully inside the viewport on all sides (allow a 1px rounding slack).
+  expect(box!.y).toBeGreaterThanOrEqual(-1);
+  expect(box!.x).toBeGreaterThanOrEqual(-1);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(vh + 1);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(vw + 1);
+});

--- a/docx-editor/packages/react/src/components/ContextMenu.tsx
+++ b/docx-editor/packages/react/src/components/ContextMenu.tsx
@@ -5,7 +5,7 @@
  * Shows AI options like rewrite, expand, summarize, translate, etc.
  */
 
-import React, { useEffect, useRef, useCallback, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useCallback, useState } from 'react';
 import type { AIAction, SelectionContext } from '@eigenpal/docx-core/types/agentApi';
 import { getActionDescription, DEFAULT_AI_ACTIONS } from '@eigenpal/docx-core/types/agentApi';
 import { useTranslation } from '../i18n';
@@ -375,6 +375,10 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
   const menuRef = useRef<HTMLDivElement>(null);
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [showPromptDialog, setShowPromptDialog] = useState(false);
+  // Actual rendered size, measured after mount, so the viewport clamp is exact
+  // (the action-count × 36 estimate is wrong with separators/submenus, which let
+  // the menu spill below the viewport and gain an internal scrollbar).
+  const [measured, setMeasured] = useState<{ w: number; h: number } | null>(null);
   const { t } = useTranslation();
 
   // All available actions including custom
@@ -440,40 +444,59 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
     }
   }, [isOpen]);
 
-  // Position the menu to stay within viewport
+  // Measure the actual rendered size once the menu mounts so the viewport clamp
+  // below uses the real height (not the per-action estimate). useLayoutEffect
+  // runs before paint, so the corrected position is applied without a flicker.
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      setMeasured(null);
+      return;
+    }
+    const el = menuRef.current;
+    if (el) {
+      const r = el.getBoundingClientRect();
+      setMeasured((prev) =>
+        prev && Math.abs(prev.h - r.height) < 1 && Math.abs(prev.w - r.width) < 1
+          ? prev
+          : { w: r.width, h: r.height }
+      );
+    }
+  }, [isOpen, allActions.length, showPromptDialog]);
+
+  // Position the menu to stay within the viewport, and never let it grow past
+  // the viewport — a too-tall menu caps to the available height and scrolls
+  // internally instead of spilling below the window.
   const getMenuStyle = useCallback((): React.CSSProperties => {
-    const menuWidth = 200;
-    const menuHeight = allActions.length * 36 + 16; // Approximate height
+    const vw = typeof window !== 'undefined' ? window.innerWidth : 1024;
+    const vh = typeof window !== 'undefined' ? window.innerHeight : 768;
+    const MARGIN = 10;
+    const maxH = Math.max(120, vh - 2 * MARGIN);
+    const menuWidth = measured?.w ?? 200;
+    const menuHeight = Math.min(measured?.h ?? allActions.length * 36 + 16, maxH);
 
     let x = position.x;
     let y = position.y;
-
-    // Adjust for viewport boundaries
-    if (typeof window !== 'undefined') {
-      if (x + menuWidth > window.innerWidth) {
-        x = window.innerWidth - menuWidth - 10;
-      }
-      if (y + menuHeight > window.innerHeight) {
-        y = window.innerHeight - menuHeight - 10;
-      }
-      if (x < 10) x = 10;
-      if (y < 10) y = 10;
-    }
+    if (x + menuWidth > vw) x = vw - menuWidth - MARGIN;
+    if (y + menuHeight > vh) y = vh - menuHeight - MARGIN;
+    if (x < MARGIN) x = MARGIN;
+    if (y < MARGIN) y = MARGIN;
 
     return {
       position: 'fixed',
       top: y,
       left: x,
-      minWidth: menuWidth,
+      minWidth: 200,
+      maxHeight: maxH,
+      overflowY: 'auto',
+      overflowX: 'hidden',
       background: 'var(--doc-surface, white)',
       border: '1px solid var(--doc-border-light)',
       borderRadius: '8px',
       boxShadow: '0 2px 10px rgba(0, 0, 0, 0.15)',
       zIndex: Z_INDEX.contextMenu,
       padding: '4px 0',
-      overflow: 'hidden',
     };
-  }, [position, allActions.length]);
+  }, [position, allActions.length, measured]);
 
   const handleActionClick = (action: AIAction) => {
     if (action === 'custom') {

--- a/docx-editor/packages/react/src/components/TextContextMenu.tsx
+++ b/docx-editor/packages/react/src/components/TextContextMenu.tsx
@@ -5,7 +5,7 @@
  * Shows Cut, Copy, Paste, and other text editing options.
  */
 
-import React, { useCallback, useEffect, useRef, useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState, useMemo } from 'react';
 import { useTranslation } from '../i18n';
 import type { TranslationKey } from '../i18n';
 import defaultLocale from '../../i18n/en.json';
@@ -609,30 +609,53 @@ export const TextContextMenu: React.FC<TextContextMenuProps> = ({
     }
   }, [isOpen]);
 
-  // Position menu to stay within viewport
+  // Measure the actual rendered size so the viewport clamp is exact — the
+  // per-item estimate is wrong with separators/long items, which let the menu
+  // spill below the window and gain an internal scrollbar. useLayoutEffect runs
+  // before paint, so the corrected position lands without a flicker.
+  const [measured, setMeasured] = useState<{ w: number; h: number } | null>(null);
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      setMeasured(null);
+      return;
+    }
+    const el = menuRef.current;
+    if (el) {
+      const r = el.getBoundingClientRect();
+      setMeasured((prev) =>
+        prev && Math.abs(prev.h - r.height) < 1 && Math.abs(prev.w - r.width) < 1
+          ? prev
+          : { w: r.width, h: r.height }
+      );
+    }
+  }, [isOpen, menuItems.length]);
+
+  // Position menu to stay within the viewport, and never let it grow past the
+  // window — a too-tall menu caps to the available height and scrolls internally
+  // instead of spilling below the window edge.
   const getMenuStyle = useCallback((): React.CSSProperties => {
-    const menuWidth = 220;
-    const menuHeight = menuItems.length * 36 + 16;
+    const vw = typeof window !== 'undefined' ? window.innerWidth : 1024;
+    const vh = typeof window !== 'undefined' ? window.innerHeight : 768;
+    const MARGIN = 10;
+    const maxH = Math.max(120, vh - 2 * MARGIN);
+    const menuWidth = measured?.w ?? 220;
+    const menuHeight = Math.min(measured?.h ?? menuItems.length * 36 + 16, maxH);
 
     let x = position.x;
     let y = position.y;
-
-    if (typeof window !== 'undefined') {
-      if (x + menuWidth > window.innerWidth) {
-        x = window.innerWidth - menuWidth - 10;
-      }
-      if (y + menuHeight > window.innerHeight) {
-        y = window.innerHeight - menuHeight - 10;
-      }
-      if (x < 10) x = 10;
-      if (y < 10) y = 10;
-    }
+    if (x + menuWidth > vw) x = vw - menuWidth - MARGIN;
+    if (y + menuHeight > vh) y = vh - menuHeight - MARGIN;
+    if (x < MARGIN) x = MARGIN;
+    if (y < MARGIN) y = MARGIN;
 
     return {
       position: 'fixed',
       top: y,
       left: x,
-      minWidth: menuWidth,
+      minWidth: 220,
+      maxHeight: maxH,
+      overflowY: 'auto',
+      overflowX: 'hidden',
       background: 'var(--doc-surface, white)',
       color: 'var(--doc-text-on-surface, #1f2937)',
       border: '1px solid var(--doc-border-light)',
@@ -640,9 +663,8 @@ export const TextContextMenu: React.FC<TextContextMenuProps> = ({
       boxShadow: 'var(--doc-shadow, 0 2px 10px rgba(0, 0, 0, 0.15))',
       zIndex: Z_INDEX.contextMenu,
       padding: '4px 0',
-      overflow: 'hidden',
     };
-  }, [position, menuItems.length]);
+  }, [position, menuItems.length, measured]);
 
   const handleItemClick = (item: TextContextMenuItem) => {
     if (item.disabled) return;


### PR DESCRIPTION
User-reported: the context menu sometimes goes below the window edge and gets an internal scrollbar that runs off-screen.

Both right-click menus (TextContextMenu + the AI ContextMenu) positioned with a rough per-item height *estimate* and no max-height, so a tall menu near the bottom spilled below the window. Now: measure the actual rendered size (useLayoutEffect, pre-paint → no flicker) for an exact viewport clamp, and cap maxHeight to the viewport with overflow-y:auto so a genuinely-tall menu scrolls WITHIN the window. e2e asserts the menu stays fully on-screen when opened near the bottom of a short viewport.