### PR TITLE
fix(panel): version-row kebab menu opens under its trigger

### DIFF
--- a/docx-editor/.changeset/fix-panel-kebab.md
+++ b/docx-editor/.changeset/fix-panel-kebab.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix the version-history row's three-dot (kebab) menu opening off-screen / in a non-obvious spot: the RightDockPanel retained a resting transform that made it the containing block for the menu's fixed positioning (and clipped it via overflow:hidden). The fixed-dropdown helper now also positions synchronously and right-anchors without a width-measuring frame, removing a one-frame flash.

--- a/docx-editor/packages/react/src/components/RightDockPanel.tsx
+++ b/docx-editor/packages/react/src/components/RightDockPanel.tsx
@@ -61,7 +61,14 @@ const ROOT_STYLE: CSSProperties = {
   borderRadius: 'var(--radius-lg)',
   boxShadow: 'var(--shadow-2)',
   color: 'var(--doc-text-on-surface)',
-  animation: 'docPanelSlideIn var(--doc-anim-slow) both',
+  // `backwards`, NOT `both`: `both` retains the `to` keyframe's
+  // `transform: translateX(0)` at rest, which makes this panel the
+  // containing block for any `position: fixed` descendant (e.g. the
+  // version-row kebab menu) AND clips it via `overflow: hidden` — so the
+  // menu opened off-screen / invisible. `backwards` reverts to the base
+  // style (no transform) once the slide-in ends, and is visually
+  // identical (opacity 1, translateX 0 ≡ none).
+  animation: 'docPanelSlideIn var(--doc-anim-slow) backwards',
   overflow: 'hidden',
   minHeight: 0,
 };

--- a/docx-editor/packages/react/src/components/ui/useFixedDropdown.ts
+++ b/docx-editor/packages/react/src/components/ui/useFixedDropdown.ts
@@ -6,7 +6,7 @@
  * overflow-x-auto container.
  */
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useLayoutEffect, useCallback } from 'react';
 import type { CSSProperties, RefObject } from 'react';
 
 interface UseFixedDropdownOptions {
@@ -30,25 +30,24 @@ export function useFixedDropdown({
 }: UseFixedDropdownOptions): UseFixedDropdownReturn {
   const containerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const [pos, setPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const [pos, setPos] = useState<{ top: number; left?: number; right?: number } | null>(null);
 
-  // Calculate position when opening
-  useEffect(() => {
-    if (!isOpen || !containerRef.current) return;
+  // Position the moment the dropdown mounts, BEFORE the browser paints
+  // (useLayoutEffect), so it never flashes at the top-left origin. Right
+  // alignment anchors the dropdown's right edge to the trigger's right
+  // edge via the CSS `right` offset — no width measurement, so no second
+  // frame / rAF is needed (the old rAF caused a one-frame (0,0) flash).
+  useLayoutEffect(() => {
+    if (!isOpen || !containerRef.current) {
+      setPos(null);
+      return;
+    }
     const rect = containerRef.current.getBoundingClientRect();
+    const top = rect.bottom + 4;
     if (align === 'right') {
-      // We need the dropdown width to right-align, but it's not rendered yet.
-      // Use a rAF to measure after first paint.
-      requestAnimationFrame(() => {
-        if (dropdownRef.current) {
-          const dropRect = dropdownRef.current.getBoundingClientRect();
-          setPos({ top: rect.bottom + 4, left: rect.right - dropRect.width });
-        } else {
-          setPos({ top: rect.bottom + 4, left: rect.left });
-        }
-      });
+      setPos({ top, right: Math.max(0, window.innerWidth - rect.right) });
     } else {
-      setPos({ top: rect.bottom + 4, left: rect.left });
+      setPos({ top, left: rect.left });
     }
   }, [isOpen, align]);
 
@@ -114,9 +113,12 @@ export function useFixedDropdown({
 
   const dropdownStyle: CSSProperties = {
     position: 'fixed',
-    top: pos.top,
-    left: pos.left,
+    top: pos?.top ?? 0,
+    ...(pos?.right != null ? { right: pos.right } : { left: pos?.left ?? 0 }),
     zIndex: 10000,
+    // Until positioned (first layout tick), keep it out of sight so it
+    // never paints at the origin.
+    visibility: pos ? 'visible' : 'hidden',
   };
 
   return { containerRef, dropdownRef, dropdownStyle, handleMouseDown };


### PR DESCRIPTION
The version-history row's three-dot (⋮) menu opened off-screen / in a non-obvious place ("not evident"), because the RightDockPanel kept `transform: translateX(0)` at rest (`animation … both`). That makes the panel the containing block for the menu's `position: fixed`, and `overflow: hidden` then clips it.

- RightDockPanel: `both` → `backwards` fill — no resting transform (visually identical: opacity 1, translateX 0 ≡ none).
- useFixedDropdown: position synchronously in `useLayoutEffect` and right-anchor via the CSS `right` offset instead of a width-measuring rAF — removes a one-frame (0,0) flash.

Verified: the kebab now opens directly under its trigger (screenshot). Toolbar/table/color/font dropdowns that share useFixedDropdown still pass (fonts + colors + alignment specs green).