### PR TITLE
fix(ruler): vertical margin marker follows the drag

### DIFF
--- a/docx-editor/.changeset/fix-vertical-ruler-drag.md
+++ b/docx-editor/.changeset/fix-vertical-ruler-drag.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix the vertical ruler's top/bottom margin marker staying pinned while the page reflowed when dragged. The marker read initialSectionProperties (sections[0].properties) but margin drags only update finalSectionProperties, so on any document with a section the marker didn't follow the pointer. It now reads the live finalSectionProperties, matching the horizontal ruler.

--- a/docx-editor/e2e/tests/vertical-ruler-margin-drag.spec.ts
+++ b/docx-editor/e2e/tests/vertical-ruler-margin-drag.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Vertical-ruler top-margin marker must FOLLOW the drag.
+ *
+ * Regression: the vertical ruler read `initialSectionProperties`
+ * (sections[0].properties) while margin drags only write to
+ * `finalSectionProperties` — so for any doc with a section the top/bottom
+ * margin marker stayed pinned while the page content reflowed ("blue arrow
+ * doesn't move with the cursor"). The marker now reads the live
+ * finalSectionProperties, like the horizontal ruler.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test('dragging the top-margin marker moves the marker with the pointer', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  // demo.docx carries a section (sections[0].properties) — the case that
+  // reproduced the stuck marker.
+  await editor.loadDocxFile('fixtures/demo.docx');
+  await page.waitForTimeout(1200);
+
+  const marker = page.locator('.docx-ruler-marker-topMargin');
+  await expect(marker).toBeVisible();
+  const before = await marker.boundingBox();
+  expect(before).not.toBeNull();
+
+  // Drag the top-margin marker down ~60px.
+  const startX = before!.x + before!.width / 2;
+  const startY = before!.y + before!.height / 2;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX, startY + 60, { steps: 8 });
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+
+  const after = await marker.boundingBox();
+  expect(after).not.toBeNull();
+  // The marker itself must have moved down (it used to stay put).
+  expect(after!.y - before!.y).toBeGreaterThan(30);
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -8473,7 +8473,13 @@ body { background: white; }
                                 }}
                               >
                                 <VerticalRuler
-                                  sectionProps={initialSectionProperties}
+                                  // Live section props (NOT initialSectionProperties):
+                                  // margin drags write to finalSectionProperties, and the
+                                  // horizontal ruler reads the same. initialSectionProperties
+                                  // resolves to sections[0].properties for docs that have a
+                                  // section, which the drag never updates — so the top/bottom
+                                  // margin marker stayed pinned while the page reflowed.
+                                  sectionProps={finalSectionProperties ?? initialSectionProperties}
                                   zoom={state.zoom}
                                   unit={rulerUnit}
                                   editable={!readOnly}


### PR DESCRIPTION
Dragging the vertical ruler's top/bottom **margin marker** reflowed the page but left the marker pinned in place ("the blue arrow doesn't move while the content moves").

Cause: the vertical ruler was fed `initialSectionProperties`, which resolves to `sections[0].properties` for any document that has a section — but margin-marker drags write only to `finalSectionProperties` (and the horizontal ruler already reads `finalSectionProperties`). So the marker read a value the drag never updated.

Fix: feed the vertical ruler the live `finalSectionProperties` (falling back to initial). One-line change; the marker now tracks the pointer like the horizontal ruler's markers do.

e2e: `vertical-ruler-margin-drag.spec.ts` — loads a sectioned doc, drags the top-margin marker, asserts the marker itself moved.