### PR TITLE
fix(icons): add missing 'star' icon for named-version badge

### DIFF
--- a/docx-editor/.changeset/fix-star-icon.md
+++ b/docx-editor/.changeset/fix-star-icon.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Add the missing `star` icon to the icon map so the "named version" badge in version history renders its amber star instead of a blank gap.

--- a/docx-editor/packages/react/src/components/ui/Icons.tsx
+++ b/docx-editor/packages/react/src/components/ui/Icons.tsx
@@ -911,6 +911,14 @@ export function IconHistory(props: IconProps) {
   );
 }
 
+export function IconStar(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M480-272 314-172q-15 9-32-3t-13-30l44-189-147-127q-14-12-8.5-30t24.5-20l194-17 75-179q7-17 26.5-17t26.5 17l75 179 194 17q19 2 24.5 20t-8.5 30L654-394l44 189q4 18-13 30t-32 3L480-272Z" />
+    </SvgIcon>
+  );
+}
+
 export function IconLightMode(props: IconProps) {
   return (
     <SvgIcon {...props}>
@@ -1066,6 +1074,7 @@ const iconMap: Record<string, React.ComponentType<IconProps>> = {
   info: IconInfo,
   bug_report: IconBugReport,
   history: IconHistory,
+  star: IconStar,
   // Theme toggle (title bar)
   light_mode: IconLightMode,
   dark_mode: IconDarkMode,


### PR DESCRIPTION
The version-history manual-version badge renders `<MaterialSymbol name="star">`, but `star` wasn't registered in the icon map, so it degraded to a blank slot — named versions showed no star. Adds the filled Material Symbols star and registers it. Verified: the amber star now renders next to a named version (screenshot).