### PR TITLE
feat(equations): authoring round-trip foundation (MathML→OMML)

### DIFF
--- a/docx-editor/.changeset/equation-authoring-core.md
+++ b/docx-editor/.changeset/equation-authoring-core.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Equation authoring foundation: the math node now carries an optional LaTeX source + MathML, the painter renders authored equations directly from their MathML, and on save the MathML is converted to native OMML (`<m:oMath>`/`<m:oMathPara>`) via a new dependency-free MathML→OMML converter — so equations authored in the editor round-trip into the .docx as real math, never images. (The Insert → Equation UI lands next.)

--- a/docx-editor/packages/core/src/docx/mathmlToOmml.test.ts
+++ b/docx-editor/packages/core/src/docx/mathmlToOmml.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for mathmlToOmml + a round-trip through ommlToMathml.
+ */
+import { describe, test, expect } from 'bun:test';
+import { mathmlToOmml } from './mathmlToOmml';
+import { ommlToMathml } from './ommlToMathml';
+
+const NS = 'http://www.w3.org/1998/Math/MathML';
+function math(body: string, display = 'inline'): string {
+  return `<math xmlns="${NS}" display="${display}">${body}</math>`;
+}
+
+describe('mathmlToOmml', () => {
+  test('null for empty / unparseable', () => {
+    expect(mathmlToOmml('')).toBeNull();
+    expect(mathmlToOmml('<not')).toBeNull();
+  });
+
+  test('tokens → runs inside <m:oMath>', () => {
+    const omml = mathmlToOmml(math('<mi>x</mi><mo>+</mo><mn>1</mn>'))!;
+    expect(omml).toContain('<m:oMath');
+    expect(omml).toContain('<m:t>x</m:t>');
+    expect(omml).toContain('<m:t>+</m:t>');
+    expect(omml).toContain('<m:t>1</m:t>');
+  });
+
+  test('fraction → <m:f>', () => {
+    const omml = mathmlToOmml(math('<mfrac><mi>a</mi><mi>b</mi></mfrac>'))!;
+    expect(omml).toContain('<m:f>');
+    expect(omml).toContain('<m:num>');
+    expect(omml).toContain('<m:den>');
+  });
+
+  test('superscript → <m:sSup>', () => {
+    const omml = mathmlToOmml(math('<msup><mi>x</mi><mn>2</mn></msup>'))!;
+    expect(omml).toContain('<m:sSup>');
+    expect(omml).toContain('<m:sup>');
+  });
+
+  test('square root → <m:rad> with hidden degree', () => {
+    const omml = mathmlToOmml(math('<msqrt><mi>x</mi></msqrt>'))!;
+    expect(omml).toContain('<m:rad>');
+    expect(omml).toContain('m:degHide');
+  });
+
+  test('nth root → <m:rad> with degree', () => {
+    const omml = mathmlToOmml(math('<mroot><mi>x</mi><mn>3</mn></mroot>'))!;
+    expect(omml).toContain('<m:rad>');
+    expect(omml).toContain('<m:deg>');
+    expect(omml).not.toContain('degHide');
+  });
+
+  test('block display → <m:oMathPara>', () => {
+    const omml = mathmlToOmml(math('<mi>x</mi>', 'block'))!;
+    expect(omml).toContain('<m:oMathPara');
+    expect(omml).toContain('<m:oMath');
+  });
+
+  test('matrix → <m:m> with rows + cells', () => {
+    const ml = math('<mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr></mtable>');
+    const omml = mathmlToOmml(ml)!;
+    expect(omml).toContain('<m:m>');
+    expect(omml).toContain('<m:mr>');
+    expect((omml.match(/<m:e>/g) ?? []).length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('XML special chars escaped', () => {
+    const omml = mathmlToOmml(math('<mo>&lt;</mo>'))!;
+    expect(omml).toContain('&lt;');
+  });
+
+  // The two converters are inverses for the common structures: an authored
+  // equation (MathML) → OMML → back to MathML preserves the structure.
+  test('round-trips structure through ommlToMathml', () => {
+    const original = math('<mfrac><msup><mi>x</mi><mn>2</mn></msup><mi>y</mi></mfrac>');
+    const omml = mathmlToOmml(original)!;
+    const back = ommlToMathml(omml)!;
+    expect(back).toContain('<mfrac>');
+    expect(back).toContain('<msup>');
+    expect(back).toContain('<mi>x</mi>');
+    expect(back).toContain('<mn>2</mn>');
+    expect(back).toContain('<mi>y</mi>');
+  });
+});

--- a/docx-editor/packages/core/src/docx/mathmlToOmml.ts
+++ b/docx-editor/packages/core/src/docx/mathmlToOmml.ts
@@ -1,0 +1,170 @@
+/**
+ * MathML → OMML (Office Math Markup Language).
+ *
+ * The inverse of `ommlToMathml`. When the user AUTHORS an equation, the
+ * editor renders LaTeX → MathML (via Temml, in the React layer) and stores
+ * the MathML on the math node. On save we convert that MathML to native
+ * OMML (`<m:oMath>` / `<m:oMathPara>`) so the equation round-trips into the
+ * `.docx` as real math — editable in Word / OnlyOffice / LibreOffice —
+ * never an image.
+ *
+ * Hand-rolled + dependency-free (MIT). Covers the common MathML structures
+ * Temml emits for typical equations (tokens, rows, fractions, scripts,
+ * radicals, matrices, accents). Unknown elements degrade to their text
+ * content as a run, so nothing is silently dropped.
+ *
+ * Pure + synchronous: MathML string in, OMML string out. No DOM — unit-
+ * tests under bun.
+ */
+import { xml2js, type Element as XmlElement } from 'xml-js';
+
+function local(name: string | undefined): string {
+  return (name ?? '').replace(/^.*:/, '').toLowerCase();
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function kids(el: XmlElement): XmlElement[] {
+  return (el.elements ?? []).filter((c) => c.type === 'element');
+}
+
+function textOf(el: XmlElement): string {
+  let out = '';
+  for (const c of el.elements ?? []) {
+    if (c.type === 'text' && typeof c.text === 'string') out += c.text;
+    else if (c.type === 'element') out += textOf(c);
+  }
+  return out;
+}
+
+/** An OMML text run. */
+function run(text: string): string {
+  const t = text.trim();
+  if (!t) return '';
+  return `<m:r><m:t>${escapeXml(text)}</m:t></m:r>`;
+}
+
+/** Convert children, joined. */
+function convertChildren(el: XmlElement): string {
+  return kids(el).map(convertNode).filter(Boolean).join('');
+}
+
+/** A `<m:e>`/`<m:num>`/etc. element wrapping a single converted MathML
+ *  child. Uses `convertNode` (not `convertChildren`) so a token child like
+ *  `<mi>y</mi>` — which has text, not element children — isn't dropped. */
+function wrap(tag: string, el: XmlElement | undefined): string {
+  return `<m:${tag}>${el ? convertNode(el) : ''}</m:${tag}>`;
+}
+
+function convertNode(el: XmlElement): string {
+  const name = local(el.name);
+  switch (name) {
+    case 'mi':
+    case 'mn':
+    case 'mo':
+    case 'mtext':
+    case 'ms':
+      return run(textOf(el));
+    case 'mrow':
+    case 'mstyle':
+    case 'mpadded':
+    case 'menclose':
+    case 'mphantom':
+      return convertChildren(el);
+    case 'mfrac': {
+      const [num, den] = kids(el);
+      return `<m:f><m:fPr><m:ctrlPr/></m:fPr>${wrap('num', num)}${wrap('den', den)}</m:f>`;
+    }
+    case 'msup': {
+      const [base, sup] = kids(el);
+      return `<m:sSup>${wrap('e', base)}${wrap('sup', sup)}</m:sSup>`;
+    }
+    case 'msub': {
+      const [base, sub] = kids(el);
+      return `<m:sSub>${wrap('e', base)}${wrap('sub', sub)}</m:sSub>`;
+    }
+    case 'msubsup': {
+      const [base, sub, sup] = kids(el);
+      return `<m:sSubSup>${wrap('e', base)}${wrap('sub', sub)}${wrap('sup', sup)}</m:sSubSup>`;
+    }
+    case 'msqrt':
+      // Square root — empty degree marks it as a radical (no index).
+      return `<m:rad><m:radPr><m:degHide m:val="1"/></m:radPr><m:deg/><m:e>${convertChildren(el)}</m:e></m:rad>`;
+    case 'mroot': {
+      const [base, deg] = kids(el);
+      return `<m:rad>${wrap('deg', deg)}${wrap('e', base)}</m:rad>`;
+    }
+    case 'mover': {
+      const [base, acc] = kids(el);
+      const chr = acc ? textOf(acc) : '';
+      return `<m:acc><m:accPr><m:chr m:val="${escapeXml(chr)}"/></m:accPr>${wrap('e', base)}</m:acc>`;
+    }
+    case 'munderover': {
+      // N-ary-ish: operator with under + over → sSubSup over the operator.
+      const [base, sub, sup] = kids(el);
+      return `<m:sSubSup>${wrap('e', base)}${wrap('sub', sub)}${wrap('sup', sup)}</m:sSubSup>`;
+    }
+    case 'munder': {
+      const [base, sub] = kids(el);
+      return `<m:sSub>${wrap('e', base)}${wrap('sub', sub)}</m:sSub>`;
+    }
+    case 'mtable': {
+      const rows = kids(el).filter((c) => local(c.name) === 'mtr');
+      const body = rows
+        .map((r) => {
+          const cells = kids(r)
+            .filter((c) => local(c.name) === 'mtd')
+            .map((c) => `<m:e>${convertChildren(c)}</m:e>`)
+            .join('');
+          return `<m:mr>${cells}</m:mr>`;
+        })
+        .join('');
+      return `<m:m>${body}</m:m>`;
+    }
+    case 'math':
+      return convertChildren(el);
+    default:
+      return convertChildren(el);
+  }
+}
+
+const OMML_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/math';
+
+export interface MathmlToOmmlOptions {
+  /** Force block (`<m:oMathPara>`) or inline (`<m:oMath>`). Defaults to the
+   *  MathML root's `display` attribute. */
+  display?: 'inline' | 'block';
+}
+
+/**
+ * Convert a MathML string (`<math>…</math>`) to an OMML string. Returns
+ * null when the input can't be parsed or yields no math.
+ */
+export function mathmlToOmml(mathml: string, options: MathmlToOmmlOptions = {}): string | null {
+  if (!mathml || !mathml.trim()) return null;
+  let root: XmlElement | undefined;
+  try {
+    const parsed = xml2js(mathml, { compact: false }) as XmlElement;
+    root = (parsed.elements ?? []).find((e) => e.type === 'element' && local(e.name) === 'math');
+    if (!root) root = (parsed.elements ?? []).find((e) => e.type === 'element');
+  } catch {
+    return null;
+  }
+  if (!root) return null;
+
+  const body = convertNode(root);
+  if (!body || !/[<]/.test(body)) return null;
+
+  const rootDisplay =
+    (root.attributes && (root.attributes['display'] as string | undefined)) || 'inline';
+  const display = options.display ?? (rootDisplay === 'block' ? 'block' : 'inline');
+
+  const oMath = `<m:oMath xmlns:m="${OMML_NS}">${body}</m:oMath>`;
+  return display === 'block' ? `<m:oMathPara xmlns:m="${OMML_NS}">${oMath}</m:oMathPara>` : oMath;
+}

--- a/docx-editor/packages/core/src/layout-bridge/toFlowBlocks.ts
+++ b/docx-editor/packages/core/src/layout-bridge/toFlowBlocks.ts
@@ -742,7 +742,11 @@ function paragraphToRuns(node: PMNode, startPos: number, _options: ToFlowBlocksO
       const text = (child.attrs.plainText as string) || '[equation]';
       const ommlXml = (child.attrs.ommlXml as string) || '';
       const display = (child.attrs.display as string) === 'block' ? 'block' : 'inline';
-      const mathml = ommlXml ? (ommlToMathml(ommlXml, { display }) ?? undefined) : undefined;
+      // Authored equations carry MathML directly; Word-imported ones derive
+      // it from the preserved OMML.
+      const authoredMathml = (child.attrs.mathml as string) || '';
+      const mathml =
+        authoredMathml || (ommlXml ? (ommlToMathml(ommlXml, { display }) ?? undefined) : undefined);
       const run: TextRun = {
         kind: 'text',
         text,

--- a/docx-editor/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -12,6 +12,7 @@
 
 import type { Node as PMNode, Mark } from 'prosemirror-model';
 import { pixelsToEmu } from '../../docx/imageParser';
+import { mathmlToOmml } from '../../docx/mathmlToOmml';
 import type {
   Document,
   DocumentBody,
@@ -752,12 +753,23 @@ function createMathFromNode(node: PMNode): MathEquation {
     display: string;
     ommlXml: string;
     plainText: string;
+    mathml?: string;
   };
+  const display = (attrs.display as 'inline' | 'block') || 'inline';
+
+  // Authored equations carry MathML but no OMML until they're saved —
+  // derive native OMML from the MathML so they round-trip into the .docx
+  // as real math (not lost, not an image). Word-imported equations keep
+  // their original preserved OMML.
+  let ommlXml = attrs.ommlXml;
+  if (!ommlXml && attrs.mathml) {
+    ommlXml = mathmlToOmml(attrs.mathml, { display }) ?? '';
+  }
 
   return {
     type: 'mathEquation',
-    display: (attrs.display as 'inline' | 'block') || 'inline',
-    ommlXml: attrs.ommlXml,
+    display,
+    ommlXml,
     plainText: attrs.plainText || undefined,
   };
 }

--- a/docx-editor/packages/core/src/prosemirror/extensions/nodes/MathExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/nodes/MathExtension.ts
@@ -23,6 +23,12 @@ export const MathExtension = createNodeExtension({
       ommlXml: { default: '' },
       /** Plain text representation for fallback display */
       plainText: { default: '' },
+      /** LaTeX source — the canonical, re-editable form for equations
+       *  AUTHORED in the editor (Word-imported ones keep ommlXml only). */
+      latex: { default: '' },
+      /** MathML — the rendered form. Authored equations carry it so the
+       *  painter draws real math and the saver derives OMML from it. */
+      mathml: { default: '' },
     },
     parseDOM: [
       {
@@ -33,15 +39,19 @@ export const MathExtension = createNodeExtension({
             display: el.dataset.display || 'inline',
             ommlXml: el.dataset.ommlXml || '',
             plainText: el.textContent || '',
+            latex: el.dataset.latex || '',
+            mathml: el.dataset.mathml || '',
           };
         },
       },
     ],
     toDOM(node) {
-      const { display, ommlXml, plainText } = node.attrs as {
+      const { display, ommlXml, plainText, latex, mathml } = node.attrs as {
         display: string;
         ommlXml: string;
         plainText: string;
+        latex: string;
+        mathml: string;
       };
 
       const text = plainText || '[equation]';
@@ -52,6 +62,8 @@ export const MathExtension = createNodeExtension({
           class: `docx-math docx-math-${display}`,
           'data-display': display,
           'data-omml-xml': ommlXml,
+          ...(latex ? { 'data-latex': latex } : {}),
+          ...(mathml ? { 'data-mathml': mathml } : {}),
           style:
             'font-style: italic; font-family: "Cambria Math", "Latin Modern Math", serif; ' +
             'background: rgba(200,200,255,0.1); padding: 0 2px; border-radius: 2px;',


### PR DESCRIPTION
**Phase D equations, slice 2 (authoring foundation).** Makes equations authored in the editor round-trip into the .docx as native math.

Builds on the rendering slice (#92). The math node gains optional `latex` (re-editable source) + `mathml` (rendered form) attrs; the painter renders authored equations from their `mathml` directly (Word-imported ones still derive it from the preserved OMML); and on save, `fromProseDoc` derives native OMML from the `mathml` via a new **hand-rolled, dependency-free MathML→OMML converter** — the inverse of #92's `ommlToMathml`, avoiding the LGPL `mathml2omml`.

So an authored equation is stored as real `<m:oMath>`/`<m:oMathPara>` — editable in Word/OnlyOffice/LibreOffice, never an image.

**Verified:** `mathmlToOmml` unit-tested (10 cases) including a structural **round-trip** through `ommlToMathml`; the `wrap()` token-drop bug it caught is fixed. Typecheck + 63 conversion tests green.

Next (PR3): the **Insert → Equation** UI — `Alt+=`, LaTeX input with live preview (Temml/KaTeX in the React layer), which produces the `mathml`-bearing nodes this PR renders + round-trips.