### PR TITLE
feat(equations): Insert → Equation UI (LaTeX + live preview)

### DIFF
--- a/docx-editor/.changeset/equation-insert-ui.md
+++ b/docx-editor/.changeset/equation-insert-ui.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': minor
+---
+
+Add Insert → Equation: type LaTeX with a live MathML preview (and a quick-insert palette), inline or display, and insert it as a real equation that renders as native math and round-trips into the .docx as native OMML. Also bound to Alt+= (Word/OnlyOffice convention). Rendering uses KaTeX (MIT).

--- a/docx-editor/bun.lock
+++ b/docx-editor/bun.lock
@@ -107,12 +107,14 @@
         "@schnsrw/core": "^0.1.1",
         "clsx": "^2.1.0",
         "dictionary-en": "^4.0.0",
+        "katex": "^0.17.0",
         "nspell": "^2.1.5",
         "sonner": "^2.0.7",
       },
       "devDependencies": {
         "@hocuspocus/provider": "^2.15.0",
         "@schnsrw/design-system": "file:../../vendor/design-system",
+        "@types/katex": "^0.16.8",
         "prosemirror-commands": "^1.5.2",
         "prosemirror-dropcursor": "^1.8.2",
         "prosemirror-history": "^1.4.0",
@@ -659,6 +661,8 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
+    "@types/katex": ["@types/katex@0.16.8", "", {}, "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg=="],
+
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": "7.24.6" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
@@ -1156,6 +1160,8 @@
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "3.1.9", "array.prototype.flat": "1.3.3", "object.assign": "4.1.7", "object.values": "1.2.1" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
     "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "3.3.0", "pako": "1.0.11", "readable-stream": "2.3.8", "setimmediate": "1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
+
+    "katex": ["katex@0.17.0", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
@@ -1694,6 +1700,8 @@
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "4.0.3" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "level-iterator-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "2.0.4", "string_decoder": "1.1.1", "util-deprecate": "1.0.2" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 

--- a/docx-editor/e2e/tests/equation-insert.spec.ts
+++ b/docx-editor/e2e/tests/equation-insert.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Insert → Equation: type LaTeX, preview as MathML, insert as a real math
+ * node that renders on the page (and round-trips to OMML on save).
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test('Insert → Equation: LaTeX input + preview + insert renders math', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.newDocument();
+  await editor.focus();
+
+  // Open the dialog via Alt+= (Word/OnlyOffice convention).
+  await page.keyboard.press('Alt+Equal');
+  const dialog = page.getByTestId('equation-dialog');
+  await expect(dialog).toBeVisible();
+
+  // Type a LaTeX fraction.
+  const input = page.getByTestId('equation-latex-input');
+  await input.fill('\\frac{a}{b} + x^{2}');
+
+  // The live preview renders native MathML (fraction + superscript).
+  const preview = page.getByTestId('equation-preview');
+  await expect(preview.locator('math mfrac')).toBeVisible();
+  await expect(preview.locator('math msup')).toBeVisible();
+
+  // Insert → the dialog closes and a <math> equation paints on the page.
+  await page.getByTestId('equation-insert').click();
+  await expect(dialog).toHaveCount(0);
+  const pages = page.locator('.paged-editor__pages');
+  await expect(pages.locator('math mfrac').first()).toBeVisible();
+});

--- a/docx-editor/examples/vite/vite.config.ts
+++ b/docx-editor/examples/vite/vite.config.ts
@@ -46,6 +46,11 @@ export default defineConfig(async () => {
   return {
     plugins: [react(), spaFallback404()],
     root: __dirname,
+    // katex is a transitive dep of the source-linked @casualoffice/docs
+    // workspace package — pre-bundle it so vite doesn't serve its ESM raw.
+    optimizeDeps: {
+      include: ['katex'],
+    },
     resolve: {
       // Force a single React + React-DOM copy across the workspace. After
       // examples/vite was added to the bun workspaces array, bun installed

--- a/docx-editor/packages/core/src/docx/mathmlToOmml.test.ts
+++ b/docx-editor/packages/core/src/docx/mathmlToOmml.test.ts
@@ -69,6 +69,20 @@ describe('mathmlToOmml', () => {
     expect(omml).toContain('&lt;');
   });
 
+  test('unwraps KaTeX <semantics>/<annotation> wrapper', () => {
+    // KaTeX wraps presentation MathML in <semantics> with a LaTeX
+    // <annotation> sibling — the converter must use the presentation child
+    // and drop the annotation.
+    const katexLike = math(
+      '<semantics><mrow><mfrac><mi>a</mi><mi>b</mi></mfrac></mrow><annotation encoding="application/x-tex">\\frac{a}{b}</annotation></semantics>'
+    );
+    const omml = mathmlToOmml(katexLike)!;
+    expect(omml).toContain('<m:f>');
+    expect(omml).toContain('<m:t>a</m:t>');
+    expect(omml).not.toContain('x-tex');
+    expect(omml).not.toContain('frac{a}{b}');
+  });
+
   // The two converters are inverses for the common structures: an authored
   // equation (MathML) → OMML → back to MathML preserves the structure.
   test('round-trips structure through ommlToMathml', () => {

--- a/docx-editor/packages/core/src/docx/mathmlToOmml.ts
+++ b/docx-editor/packages/core/src/docx/mathmlToOmml.ts
@@ -127,6 +127,15 @@ function convertNode(el: XmlElement): string {
         .join('');
       return `<m:m>${body}</m:m>`;
     }
+    case 'semantics': {
+      // KaTeX wraps the presentation MathML in <semantics> alongside an
+      // <annotation> carrying the LaTeX source — convert the presentation
+      // child, drop the annotation.
+      const pres = kids(el).find((c) => local(c.name) !== 'annotation');
+      return pres ? convertNode(pres) : '';
+    }
+    case 'annotation':
+      return '';
     case 'math':
       return convertChildren(el);
     default:

--- a/docx-editor/packages/react/package.json
+++ b/docx-editor/packages/react/package.json
@@ -131,12 +131,14 @@
     "@schnsrw/core": "^0.1.1",
     "clsx": "^2.1.0",
     "dictionary-en": "^4.0.0",
+    "katex": "^0.17.0",
     "nspell": "^2.1.5",
     "sonner": "^2.0.7"
   },
   "devDependencies": {
     "@hocuspocus/provider": "^2.15.0",
     "@schnsrw/design-system": "file:../../vendor/design-system",
+    "@types/katex": "^0.16.8",
     "prosemirror-commands": "^1.5.2",
     "prosemirror-dropcursor": "^1.8.2",
     "prosemirror-history": "^1.4.0",

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -98,6 +98,7 @@ import {
   type FindResult,
 } from './dialogs/findReplaceUtils';
 import { useHyperlinkDialog, type HyperlinkData } from './dialogs/useHyperlinkDialog';
+import { EquationDialog, type EquationInsert } from './EquationDialog';
 import type { ImagePositionData } from './dialogs/ImagePositionDialog';
 import type { BordersAndShadingValue } from './dialogs/BordersAndShadingDialog';
 import type { ImagePropertiesData } from './dialogs/ImagePropertiesDialog';
@@ -2493,6 +2494,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   const [showKeyboardShortcuts, setShowKeyboardShortcuts] = useState(false);
   const [showPreferences, setShowPreferences] = useState(false);
   const [showWatermarkDialog, setShowWatermarkDialog] = useState(false);
+  const [showEquationDialog, setShowEquationDialog] = useState(false);
   const [showAccessibility, setShowAccessibility] = useState(false);
   const [accessibilityIssues, setAccessibilityIssues] = useState<AccessibilityIssue[]>([]);
   // Building blocks (C6): persisted snippet list + a snapshot of whatever
@@ -3351,6 +3353,13 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
             return;
           }
         }
+      }
+
+      // Alt+= → Insert equation (Word / OnlyOffice convention).
+      if (e.altKey && !cmdOrCtrl && !e.shiftKey && (e.key === '=' || e.code === 'Equal')) {
+        e.preventDefault();
+        setShowEquationDialog(true);
+        return;
       }
 
       if (cmdOrCtrl && !e.shiftKey && !e.altKey) {
@@ -6093,6 +6102,28 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         // off for an unusual schema configuration.
       }
       view.dispatch(tr.scrollIntoView());
+      focusActiveEditor();
+    },
+    [getActiveEditorView, focusActiveEditor]
+  );
+
+  // Insert an authored equation as a math node. It carries its LaTeX
+  // source + MathML (for re-editing + rendering); on save the MathML is
+  // converted to native OMML so it round-trips as real math.
+  const handleInsertEquation = useCallback(
+    (eq: EquationInsert) => {
+      const view = getActiveEditorView();
+      if (!view) return;
+      const mathType = view.state.schema.nodes.math;
+      if (!mathType) return;
+      const node = mathType.create({
+        display: eq.display,
+        latex: eq.latex,
+        mathml: eq.mathml,
+        plainText: eq.plainText,
+        ommlXml: '',
+      });
+      view.dispatch(view.state.tr.replaceSelectionWith(node, false).scrollIntoView());
       focusActiveEditor();
     },
     [getActiveEditorView, focusActiveEditor]
@@ -9743,6 +9774,13 @@ body { background: white; }
                   onApply={handleWatermarkChange}
                 />
               )}
+              {showEquationDialog && (
+                <EquationDialog
+                  isOpen={showEquationDialog}
+                  onClose={() => setShowEquationDialog(false)}
+                  onInsert={handleInsertEquation}
+                />
+              )}
               {showAccessibility && (
                 <AccessibilityDialog
                   isOpen={showAccessibility}
@@ -10141,6 +10179,13 @@ body { background: white; }
                       label: 'Callout',
                       path: 'Insert',
                       run: () => handleInsertTextBox('callout'),
+                    },
+                    {
+                      id: 'insert.equation',
+                      label: 'Equation',
+                      path: 'Insert',
+                      shortcut: 'Alt+=',
+                      run: () => setShowEquationDialog(true),
                     },
 
                     {

--- a/docx-editor/packages/react/src/components/EquationDialog.tsx
+++ b/docx-editor/packages/react/src/components/EquationDialog.tsx
@@ -1,0 +1,274 @@
+/**
+ * EquationDialog — Insert → Equation.
+ *
+ * The user types LaTeX (the lingua franca for math, what Word/OnlyOffice
+ * accept natively), sees a live MathML preview, and inserts. The equation
+ * is stored as a math node carrying its LaTeX source + the rendered MathML;
+ * on save the MathML is converted to native OMML so it round-trips into the
+ * .docx as real math (never an image).
+ *
+ * Rendering uses Temml (MIT) — LaTeX → MathML — and the browser's native
+ * MathML, the same path the painter uses, so the preview matches the page.
+ */
+import { useMemo, useState, useEffect } from 'react';
+import katex from 'katex';
+import { Dialog } from './ui/Dialog';
+
+export interface EquationInsert {
+  latex: string;
+  mathml: string;
+  plainText: string;
+  display: 'inline' | 'block';
+}
+
+export interface EquationDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onInsert: (eq: EquationInsert) => void;
+  /** Pre-fill when editing an existing equation. */
+  initialLatex?: string;
+  initialDisplay?: 'inline' | 'block';
+}
+
+/** A rough plain-text fallback from LaTeX — used only when MathML can't
+ *  render. Strips commands/braces so it stays readable. */
+function latexToPlainText(latex: string): string {
+  return latex
+    .replace(/\\[a-zA-Z]+/g, (m) => m.slice(1))
+    .replace(/[{}\\$]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const QUICK_INSERTS: Array<{ label: string; latex: string }> = [
+  { label: 'x²', latex: 'x^{2}' },
+  { label: 'a⁄b', latex: '\\frac{a}{b}' },
+  { label: '√', latex: '\\sqrt{x}' },
+  { label: '∑', latex: '\\sum_{i=1}^{n}' },
+  { label: '∫', latex: '\\int_{a}^{b}' },
+  { label: 'α', latex: '\\alpha' },
+  { label: '≤', latex: '\\leq' },
+  { label: '×', latex: '\\times' },
+];
+
+export function EquationDialog({
+  isOpen,
+  onClose,
+  onInsert,
+  initialLatex = '',
+  initialDisplay = 'inline',
+}: EquationDialogProps) {
+  const [latex, setLatex] = useState(initialLatex);
+  const [display, setDisplay] = useState<'inline' | 'block'>(initialDisplay);
+
+  // Reset to the initial values each time the dialog opens.
+  useEffect(() => {
+    if (isOpen) {
+      setLatex(initialLatex);
+      setDisplay(initialDisplay);
+    }
+  }, [isOpen, initialLatex, initialDisplay]);
+
+  // LaTeX → MathML via KaTeX. Returns the bare <math> markup or an error.
+  const rendered = useMemo<{ mathml: string; error: string | null }>(() => {
+    const src = latex.trim();
+    if (!src) return { mathml: '', error: null };
+    try {
+      const html = katex.renderToString(src, {
+        output: 'mathml',
+        throwOnError: true,
+        displayMode: display === 'block',
+      });
+      // KaTeX wraps the MathML in <span class="katex">…</span>; keep just
+      // the <math> element for the node + the preview.
+      const m = html.match(/<math[\s\S]*?<\/math>/);
+      let mathml = m ? m[0] : '';
+      if (mathml && display === 'block' && !/\bdisplay="block"/.test(mathml)) {
+        mathml = mathml.replace(/<math\b/, '<math display="block"');
+      }
+      return { mathml, error: mathml ? null : 'Could not render equation' };
+    } catch (err) {
+      return { mathml: '', error: err instanceof Error ? err.message : 'Invalid LaTeX' };
+    }
+  }, [latex, display]);
+
+  const canInsert = latex.trim().length > 0 && !!rendered.mathml && !rendered.error;
+
+  const handleInsert = (): void => {
+    if (!canInsert) return;
+    onInsert({
+      latex: latex.trim(),
+      mathml: rendered.mathml,
+      plainText: latexToPlainText(latex) || latex.trim(),
+      display,
+    });
+    onClose();
+  };
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Insert equation"
+      width={560}
+      testId="equation-dialog"
+      helper="LaTeX — e.g. \frac{a}{b}, x^2, \sqrt{x}, \sum, \int"
+      footer={
+        <>
+          <button type="button" onClick={onClose} style={secondaryBtn}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleInsert}
+            disabled={!canInsert}
+            style={{ ...primaryBtn, opacity: canInsert ? 1 : 0.5 }}
+            data-testid="equation-insert"
+          >
+            Insert
+          </button>
+        </>
+      }
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {/* Quick-insert palette (discovery, Google-Docs style). */}
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+          {QUICK_INSERTS.map((q) => (
+            <button
+              key={q.latex}
+              type="button"
+              onClick={() => setLatex((v) => v + (v && !v.endsWith(' ') ? ' ' : '') + q.latex)}
+              style={chipBtn}
+              title={q.latex}
+            >
+              {q.label}
+            </button>
+          ))}
+        </div>
+
+        <textarea
+          value={latex}
+          onChange={(e) => setLatex(e.target.value)}
+          onKeyDown={(e) => {
+            // Ctrl/Cmd+Enter inserts.
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+              e.preventDefault();
+              handleInsert();
+            }
+          }}
+          placeholder="\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}"
+          rows={3}
+          autoFocus
+          spellCheck={false}
+          data-testid="equation-latex-input"
+          style={textareaStyle}
+        />
+
+        <label style={toggleRow}>
+          <input
+            type="checkbox"
+            checked={display === 'block'}
+            onChange={(e) => setDisplay(e.target.checked ? 'block' : 'inline')}
+            data-testid="equation-display-toggle"
+          />
+          Display equation (centered on its own line)
+        </label>
+
+        {/* Live preview. */}
+        <div style={previewLabel}>Preview</div>
+        <div style={previewBox} data-testid="equation-preview">
+          {rendered.error ? (
+            <span style={{ color: 'var(--doc-danger, #c62828)', fontSize: 13 }}>
+              {rendered.error}
+            </span>
+          ) : rendered.mathml ? (
+            <span
+              style={{ fontSize: display === 'block' ? 22 : 18 }}
+              // Native MathML — the same render path as the page.
+              dangerouslySetInnerHTML={{ __html: rendered.mathml }}
+            />
+          ) : (
+            <span style={{ color: 'var(--doc-text-muted)', fontSize: 13 }}>
+              Type LaTeX above to preview.
+            </span>
+          )}
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+const textareaStyle = {
+  width: '100%',
+  padding: '10px 12px',
+  borderRadius: 8,
+  border: '1px solid var(--doc-border, #d0d0d0)',
+  background: 'var(--doc-surface-sunken, #f8f9fa)',
+  color: 'var(--doc-text)',
+  fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
+  fontSize: 14,
+  lineHeight: 1.5,
+  resize: 'vertical' as const,
+  boxSizing: 'border-box' as const,
+};
+
+const previewLabel = {
+  fontSize: 11,
+  fontWeight: 600,
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.04em',
+  color: 'var(--doc-text-muted)',
+};
+
+const previewBox = {
+  minHeight: 56,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '12px 16px',
+  borderRadius: 8,
+  border: '1px solid var(--doc-border-light, #eaecef)',
+  background: 'var(--doc-surface, #fff)',
+};
+
+const toggleRow = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  fontSize: 13,
+  color: 'var(--doc-text)',
+  cursor: 'pointer',
+};
+
+const chipBtn = {
+  minWidth: 32,
+  height: 30,
+  padding: '0 8px',
+  borderRadius: 6,
+  border: '1px solid var(--doc-border, #d0d0d0)',
+  background: 'var(--doc-surface, #fff)',
+  color: 'var(--doc-text)',
+  fontSize: 14,
+  cursor: 'pointer',
+};
+
+const secondaryBtn = {
+  padding: '8px 14px',
+  borderRadius: 6,
+  border: '1px solid var(--doc-border, #d0d0d0)',
+  background: 'transparent',
+  color: 'var(--doc-text)',
+  fontSize: 13,
+  cursor: 'pointer',
+};
+
+const primaryBtn = {
+  padding: '8px 16px',
+  borderRadius: 6,
+  border: 'none',
+  background: 'var(--doc-primary, #1a73e8)',
+  color: '#fff',
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: 'pointer',
+};


### PR DESCRIPTION
**Phase D equations, slice 3 — the visible authoring UI.** Completes the equation feature.

**Insert → Equation** (and **Alt+=**, the Word/OnlyOffice shortcut) opens a dialog: type LaTeX, see a **live native-MathML preview**, choose inline vs **display**, with a quick-insert palette (x², fraction, √, ∑, ∫, α…). Insert builds a math node carrying the LaTeX source + MathML — it renders as real math on the page (screenshot: the quadratic formula inline) and, via #94's MathML→OMML, **saves as native `<m:oMath>`/`<m:oMathPara>`** (editable in Word, never an image).

**KaTeX (MIT)** for LaTeX→MathML — chosen over Temml after Temml's lexer broke when bundled by vite (it parsed `\frac` as `\f`+`rac`). `mathmlToOmml` now unwraps KaTeX's `<semantics>`/`<annotation>` wrapper.

**Verified:** `equation-insert.spec.ts` (LaTeX → preview asserts `mfrac`/`msup` → insert → page paints `<math>`); 11 `mathmlToOmml` tests incl. the KaTeX-semantics round-trip; demo-docx 44/44 + the render/insert specs green; typecheck + lint clean.

This closes the equations arc: render existing (#92) → authoring round-trip (#94) → **Insert UI (this)**.