### PR TITLE
feat(equations): edit an existing equation (double-click → reopen prefilled)

### DIFF
--- a/docx-editor/.changeset/equation-edit.md
+++ b/docx-editor/.changeset/equation-edit.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Edit an existing equation: double-click a rendered equation (or select it and reopen Insert → Equation / Alt+=) to reopen the equation dialog prefilled with its LaTeX, and inserting replaces it in place.

--- a/docx-editor/e2e/tests/equation-edit.spec.ts
+++ b/docx-editor/e2e/tests/equation-edit.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * Editing an existing equation: double-click a painted equation re-opens the
+ * dialog prefilled with its LaTeX; inserting replaces it in place.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test('double-click an equation re-opens it prefilled and replaces on insert', async ({ page }) => {
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.newDocument();
+  await editor.focus();
+
+  // Insert an equation: a/b.
+  await page.keyboard.press('Alt+Equal');
+  await page.getByTestId('equation-latex-input').fill('\\frac{a}{b}');
+  await page.getByTestId('equation-insert').click();
+  const pages = page.locator('.paged-editor__pages');
+  await expect(pages.locator('math mfrac').first()).toBeVisible();
+
+  // Double-click the painted equation → dialog re-opens PREFILLED with its LaTeX.
+  await pages.locator('.docx-math').first().dblclick();
+  const input = page.getByTestId('equation-latex-input');
+  await expect(input).toHaveValue('\\frac{a}{b}');
+
+  // Edit to a superscript and insert → replaces the equation in place.
+  await input.fill('x^{2}');
+  await page.getByTestId('equation-insert').click();
+  await expect(page.getByTestId('equation-dialog')).toHaveCount(0);
+
+  // The fraction is gone; a superscript took its place (still ONE equation).
+  await expect(pages.locator('math mfrac')).toHaveCount(0);
+  await expect(pages.locator('math msup').first()).toBeVisible();
+  expect(await pages.locator('math').count()).toBe(1);
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -2495,6 +2495,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   const [showPreferences, setShowPreferences] = useState(false);
   const [showWatermarkDialog, setShowWatermarkDialog] = useState(false);
   const [showEquationDialog, setShowEquationDialog] = useState(false);
+  // Equation dialog prefill — empty for a new insert, or the selected math
+  // node's LaTeX/display when editing an existing equation.
+  const [equationInitial, setEquationInitial] = useState<{
+    latex: string;
+    display: 'inline' | 'block';
+  }>({ latex: '', display: 'inline' });
   const [showAccessibility, setShowAccessibility] = useState(false);
   const [accessibilityIssues, setAccessibilityIssues] = useState<AccessibilityIssue[]>([]);
   // Building blocks (C6): persisted snippet list + a snapshot of whatever
@@ -3355,9 +3361,20 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         }
       }
 
-      // Alt+= → Insert equation (Word / OnlyOffice convention).
+      // Alt+= → equation dialog (Word / OnlyOffice). Prefill when a math
+      // node is selected so it edits in place; otherwise insert new.
       if (e.altKey && !cmdOrCtrl && !e.shiftKey && (e.key === '=' || e.code === 'Equal')) {
         e.preventDefault();
+        const eqView = getActiveEditorView();
+        const eqSel = eqView?.state.selection;
+        if (eqView && eqSel instanceof NodeSelection && eqSel.node.type.name === 'math') {
+          setEquationInitial({
+            latex: (eqSel.node.attrs.latex as string) || '',
+            display: (eqSel.node.attrs.display as string) === 'block' ? 'block' : 'inline',
+          });
+        } else {
+          setEquationInitial({ latex: '', display: 'inline' });
+        }
         setShowEquationDialog(true);
         return;
       }
@@ -6107,9 +6124,10 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     [getActiveEditorView, focusActiveEditor]
   );
 
-  // Insert an authored equation as a math node. It carries its LaTeX
-  // source + MathML (for re-editing + rendering); on save the MathML is
-  // converted to native OMML so it round-trips as real math.
+  // Insert (or, when a math node is selected, REPLACE) an authored equation
+  // as a math node. It carries its LaTeX source + MathML (for re-editing +
+  // rendering); on save the MathML is converted to native OMML so it
+  // round-trips as real math.
   const handleInsertEquation = useCallback(
     (eq: EquationInsert) => {
       const view = getActiveEditorView();
@@ -6123,10 +6141,52 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         plainText: eq.plainText,
         ommlXml: '',
       });
-      view.dispatch(view.state.tr.replaceSelectionWith(node, false).scrollIntoView());
+      const sel = view.state.selection;
+      const tr =
+        sel instanceof NodeSelection && sel.node.type.name === 'math'
+          ? view.state.tr.replaceWith(sel.from, sel.to, node) // edit existing
+          : view.state.tr.replaceSelectionWith(node, false); // insert new
+      view.dispatch(tr.scrollIntoView());
       focusActiveEditor();
     },
     [getActiveEditorView, focusActiveEditor]
+  );
+
+  // Open the equation dialog. If a math node is selected, prefill it (edit);
+  // otherwise start blank (insert).
+  const openEquationDialog = useCallback(() => {
+    const view = getActiveEditorView();
+    const sel = view?.state.selection;
+    if (view && sel instanceof NodeSelection && sel.node.type.name === 'math') {
+      setEquationInitial({
+        latex: (sel.node.attrs.latex as string) || '',
+        display: (sel.node.attrs.display as string) === 'block' ? 'block' : 'inline',
+      });
+    } else {
+      setEquationInitial({ latex: '', display: 'inline' });
+    }
+    setShowEquationDialog(true);
+  }, [getActiveEditorView]);
+
+  // Double-click a painted equation → select it + open the dialog prefilled.
+  const handleEditEquation = useCallback(
+    (pos: number) => {
+      const view = getActiveEditorView();
+      if (!view) return;
+      const node = view.state.doc.nodeAt(pos);
+      if (!node || node.type.name !== 'math') return;
+      try {
+        view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos)));
+      } catch {
+        return;
+      }
+      setEquationInitial({
+        latex: (node.attrs.latex as string) || '',
+        display: (node.attrs.display as string) === 'block' ? 'block' : 'inline',
+      });
+      setShowEquationDialog(true);
+    },
+    [getActiveEditorView]
   );
 
   const handleInsertCitation = useCallback(
@@ -8682,6 +8742,7 @@ body { background: white; }
                           onOpenProperties={() => openRightPanel('properties')}
                           onResizeTextBox={handleTextBoxSetSize}
                           onEditFootnote={handleEditFootnote}
+                          onEditEquation={handleEditEquation}
                           onEditEndnote={handleEditEndnote}
                           commentsSidebarOpen={sidebarOpen}
                           onAnchorPositionsChange={setAnchorPositions}
@@ -9779,6 +9840,8 @@ body { background: white; }
                   isOpen={showEquationDialog}
                   onClose={() => setShowEquationDialog(false)}
                   onInsert={handleInsertEquation}
+                  initialLatex={equationInitial.latex}
+                  initialDisplay={equationInitial.display}
                 />
               )}
               {showAccessibility && (
@@ -10185,7 +10248,7 @@ body { background: white; }
                       label: 'Equation',
                       path: 'Insert',
                       shortcut: 'Alt+=',
-                      run: () => setShowEquationDialog(true),
+                      run: openEquationDialog,
                     },
 
                     {

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -358,6 +358,9 @@ export interface PagedEditorProps {
   onResizeTextBox?: (width: number, height: number) => void;
   /** Open the footnote text editor for the footnote double-clicked at page bottom. */
   onEditFootnote?: (footnoteId: number) => void;
+  /** Double-click a painted equation → edit it. Receives the math node's
+   *  ProseMirror position (from the painted span's data-pm-start). */
+  onEditEquation?: (pmPos: number) => void;
   /** Open the endnote text editor for the endnote double-clicked at document end. */
   onEditEndnote?: (endnoteId: number) => void;
   /** Callback with pre-computed Y positions for comment/tracked-change anchors (for sidebar positioning without DOM queries). */
@@ -1402,6 +1405,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       onOpenProperties,
       onResizeTextBox,
       onEditFootnote,
+      onEditEquation,
       onEditEndnote,
       onAnchorPositionsChange,
       onTotalPagesChange,
@@ -1478,20 +1482,33 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     documentRef.current = document;
     const onEditFootnoteRef = useRef(onEditFootnote);
     onEditFootnoteRef.current = onEditFootnote;
+    const onEditEquationRef = useRef(onEditEquation);
+    onEditEquationRef.current = onEditEquation;
     // Double-click a painted footnote at page bottom → open its text editor.
+    // Double-click a painted equation → re-open the equation editor.
     useEffect(() => {
       const el = pagesContainerRef.current;
       if (!el) return;
       const onDbl = (e: MouseEvent) => {
-        const fnEl = (e.target as HTMLElement | null)?.closest(
-          '.layout-footnote[data-footnote-id]'
-        ) as HTMLElement | null;
-        if (!fnEl) return;
-        const id = Number(fnEl.dataset.footnoteId);
-        if (!Number.isNaN(id)) {
-          e.preventDefault();
-          e.stopPropagation();
-          onEditFootnoteRef.current?.(id);
+        const target = e.target as HTMLElement | null;
+        const fnEl = target?.closest('.layout-footnote[data-footnote-id]') as HTMLElement | null;
+        if (fnEl) {
+          const id = Number(fnEl.dataset.footnoteId);
+          if (!Number.isNaN(id)) {
+            e.preventDefault();
+            e.stopPropagation();
+            onEditFootnoteRef.current?.(id);
+          }
+          return;
+        }
+        const mathEl = target?.closest('.docx-math[data-pm-start]') as HTMLElement | null;
+        if (mathEl) {
+          const pos = Number(mathEl.dataset.pmStart);
+          if (!Number.isNaN(pos)) {
+            e.preventDefault();
+            e.stopPropagation();
+            onEditEquationRef.current?.(pos);
+          }
         }
       };
       el.addEventListener('dblclick', onDbl);


### PR DESCRIPTION
Completes the equation authoring UX — equations are now **editable**, not just insertable.

**Double-click** a rendered equation to reopen the equation dialog **prefilled with its LaTeX**; edit and Insert **replaces it in place**. Reopening via **Insert → Equation / Alt+=** while an equation is selected also prefills (vs. a blank new insert otherwise).

Wired through PagedEditor's existing dblclick handler (the painted math span carries `data-pm-start`, mirroring the footnote-edit path); `handleInsertEquation` does a node replace when a math `NodeSelection` is active, else a fresh insert.

**Verified:** `equation-edit.spec.ts` — insert `a/b` → double-click → input prefilled `\frac{a}{b}` → edit to `x^2` → fraction replaced by superscript, still exactly one equation. Typecheck + lint clean; demo-docx 44/44 + insert/render specs green.

Equations arc: render (#92) → authoring round-trip (#94) → Insert UI (#95) → **edit existing (this)**.