### PR TITLE
docs(roadmap): equations shipped + desktop folded; Phase A complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,61 +4,63 @@
 
 Solo / personal project named **Casual Editor**. The path contains `melp/` as a folder name only — **not** a company or product. Do not call this project "melp" or imply organizational context.
 
-A casual, real-time collaborative `.docx` editor, built on a local fork of `eigenpal/docx-editor` (MIT, React + ProseMirror with OOXML-preserving model) with a custom Go backend providing the Yjs CRDT sync, presence, and `.docx` snapshots. Document persistence is delegated to a pluggable host integration (inline for v0; WOPI / JWT-API later).
+A casual, real-time collaborative `.docx` editor, built on a local fork of `eigenpal/docx-editor` (MIT, React + ProseMirror with OOXML-preserving model). Real-time sync, presence, and snapshots are provided by the shared **Node** collab server **`CasualOffice/collab`** (Hocuspocus + Yjs on Fastify — a format-agnostic server also powering Casual Sheets), which the editor reaches through `HocuspocusProvider`. Document persistence is delegated to a pluggable host integration (WOPI / JWT-API). _A legacy in-repo Go y-websocket gateway lives under `backend/` (predates the collab server, still built by CI) — it is superseded; **new sync / presence / persistence work goes to the Node collab server, not `backend/`.**_
 
-## Architecture (locked)
+## Architecture
 
 ```
 Browser
    ├─ <DocxEditor> (our fork of eigenpal/docx-editor, MIT, in docx-editor/)
    │      schema: ProseMirror, layout: their layout-painter (preserves OOXML)
-   ├─ y-prosemirror ySyncPlugin
-   └─ Y.Doc  ⇄  y-websocket transport
+   ├─ y-prosemirror ySyncPlugin + yCursorPlugin (presence)
+   └─ Y.Doc  ⇄  HocuspocusProvider (y-websocket protocol over WS)
                        │
                        ▼
-   Go backend (this repo, backend/) — STATELESS
-   ├─ WS gateway speaking y-websocket protocol (backend/internal/yws)
-   ├─ Room manager (backend/internal/room) — one in-memory Y.Doc per
-   │  live session, dropped when last client disconnects
-   ├─ host.Integration interface (backend/internal/host) with concrete
-   │  inline impl (backend/internal/host/inline) for v0
-   ├─ REST upload/download for the v0 share-link flow
-   └─ Snapshot worker → host on room drain (Y.Doc → .docx)
+   Collab server — Node / TypeScript (CasualOffice/collab, SEPARATE repo) — STATELESS
+   ├─ Hocuspocus WS server on Fastify — one in-memory Y.Doc per live room,
+   │  dropped when the last client disconnects
+   ├─ Auth + WOPI + pluggable storage hooks
+   └─ Snapshot / versioning on room drain (Y.Doc → .docx)
                        │
                        ▼
    Storage host (external, pluggable)
-   - v0: inline (in-process map) — share-link self-contained model
-   - v1+: WOPI host (GetFile / PutFile) or JWT-secured REST API
+   - WOPI host (GetFile / PutFile) or JWT-secured REST API
 ```
 
-**Stateless invariant:** the backend has no DB and no on-disk update log. Document persistence is owned by the host. The backend's only state is the in-memory Y.Doc for currently-active sessions — gone when all clients disconnect, gone again on process restart (clients re-upload via /api/docs or the host re-seeds).
+**Stateless invariant:** the collab server has no DB and no on-disk update log. Document persistence is owned by the host. Its only state is the in-memory Y.Doc for currently-active sessions — gone when all clients disconnect, gone again on process restart (the host re-seeds).
 
 ## Working rules for Claude in this repo
 
 1. **Never write technical claims about external systems from memory.** Read the actual source first; cite file paths.
 2. **The editor is a fork we modify.** When filling fidelity gaps in the editor (text-box rendering is the known weak spot): write a Playwright test reproducing the gap, fix in the right place per `docx-editor/CLAUDE.md`'s "Key File Map", open a PR upstream. Fork-and-diverge only if upstream rejects or stalls.
 3. **Yjs + `y-prosemirror` is the chosen CRDT.** Do not propose Automerge/Loro/custom alternatives without explicit user direction.
-4. **MIT only on the editor side.** The AGPL `@eigenpal/docx-editor-agents` package and everything that depended on it has been removed from our fork. Do not reintroduce. (The Go backend is Apache-2.0; fine.)
+4. **MIT only on the editor side.** The AGPL `@eigenpal/docx-editor-agents` package and everything that depended on it has been removed from our fork. Do not reintroduce. (The Node `CasualOffice/collab` server is permissive; fine.)
 5. **Editor toolchain is Bun.** `bun install`, `bun run dev` (localhost:5173), `bun run build`, `bun run typecheck`. Tests via `npx playwright test`. Bun is installed locally (1.3.x) so verify-before-ship works.
-6. **Backend language is Go.** Don't suggest Node or Rust. Module: `github.com/schnsrw/docx/backend`. `go vet ./... && go test -race ./...` from `backend/`.
-7. **No live document model on the server.** Y.Doc updates in, updates out. Snapshots produced by an offloaded worker on room drain.
-8. **Default new editor-side code to the fork** (`docx-editor/`); default new sync/persistence/auth code to `backend/`.
+6. **The collab server is Node, not Go.** Real-time sync/presence/snapshots are owned by the shared **Node/TypeScript** server `CasualOffice/collab` (Hocuspocus + Yjs on Fastify) — a SEPARATE repo. Do not describe the backend as Go. (The in-repo `backend/` Go gateway is legacy/superseded; don't extend it.)
+7. **No live document model on the server.** Y.Doc updates in, updates out. Snapshots produced on room drain.
+8. **Default new editor-side code to the fork** (`docx-editor/`); new sync / presence / persistence work goes to the **`CasualOffice/collab`** Node server, NOT the legacy `backend/`.
 9. **Don't install software via `curl | bash` from a remote URL without explicit user consent.** Use Homebrew, npm, or other reviewable package managers; ask the user which install method they prefer before running.
 10. **Docs are first-class.** When a doc-tracked fact changes (status block, fidelity score, working set, milestone state), update the relevant doc in the same commit or right after. Stale docs poison every future session that opens them.
 
 ## Where things live
 
 - `docx-editor/` — working fork of `eigenpal/docx-editor`. **Inlined into this repo** (no separate `.git/`; tracked as part of the outer repo per the `.gitignore`). AGPL `agent-use` package and dependents purged. Push to `git@github.com:schnsrw/docx.git`.
-- `backend/` — Go y-websocket gateway. Module `github.com/schnsrw/docx/backend`. Entry point `cmd/gateway/main.go`. Internal packages: `room`, `yws`, `host` (with `inline` impl).
+- **Collab server** — the **Node/TypeScript** `CasualOffice/collab` repo (Hocuspocus + Yjs on Fastify): real-time sync, presence, auth, WOPI, snapshots/versioning. The editor connects via `HocuspocusProvider` (`docx-editor/packages/react/src/collab/useCollab.ts`). This is THE backend for collaboration.
+- `backend/` — **legacy** in-repo Go y-websocket gateway, superseded by `CasualOffice/collab`. Still builds in CI; do not extend it. (Removal pending a decision.)
 - `docs/` — outer (architecture, deployment, co-editing, roundtrip) — sustained-reading docs that mirror what's on the site.
 - `docs/internal/` — engineering notes (overview, fidelity gaps, gap matrix, pipeline, backend design, CI recovery, etc.).
-- `docker-compose.yml` — local dev stack. **No DB** — service is stateless; storage delegated. Backend service + editor SPA bundled into one image.
+- `docker-compose.yml` — local dev stack. **No DB** — stateless; storage delegated. (Collaboration is served by the Node `CasualOffice/collab` server, run separately.)
 
 ## Status (2026-06-08)
 
+> **Backend note:** the collaboration/sync backend is the **Node** `CasualOffice/collab`
+> server (Hocuspocus + Yjs on Fastify). The `backend/` (Go) entries below + in the Phase
+> records are the **legacy in-repo gateway** that predates and is superseded by it —
+> historical, not the current sync path.
+
 - **Editor fork** — **39 of 39 fixtures round-trip pristine**; the ≥ 90 % desktop-ship floor is cleared. VML cluster closed via raw-XML envelope capture (`302c210`). Remaining gaps are visual (floating-image-wrap, table-overlap-text), not round-trip.
 - **Home page** — Template gallery (14 templates × 4 categories, LibreOffice PNG previews). Recent-files strip shipped. Auto-reopen banner shipped (`2988b89`) — "Reopen `<name>`?" above the landing when the most-recently-opened doc is < 7 days old; sessionStorage-sticky dismissal.
-- **Backend** — Go gateway in `backend/`. M1 inline share-link surface (`/api/docs`, `/doc/{id}` WS). Per-IP rate limiting + `MAX_ROOMS` cap.
+- **Collab server** — Node `CasualOffice/collab` (Hocuspocus + Yjs + Fastify): realtime sync, presence, auth, WOPI, snapshots/versioning. _(Legacy: the in-repo Go gateway under `backend/` — M1 inline share-link `/api/docs`, `/doc/{id}` WS, per-IP rate limiting + `MAX_ROOMS` — superseded.)_
 - **CI** — green. Go toolchain pinned to 1.25 (`ec9a2e7`, recovered from a stealth Phase-C-Batch-1 regression).
 - **Live deploys** — single-user demo at https://doc.schnsrw.live/.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,7 +40,7 @@ System design for Casual Editor. For deployment notes, see [`DEPLOYMENT.md`](./D
                                    │ WebSocket  /doc/:docId
                                    │ HTTP       /api/docs
                                    ▼
-┌──────────────────────────── Go gateway (backend/) ───────────────────────────┐
+┌─── LEGACY Go gateway (backend/) — superseded by the Node CasualOffice/collab ─┐
 │                                                                              │
 │  REST + static                                                               │
 │  ├─ GET  /                            editor SPA bundle                      │
@@ -135,14 +135,14 @@ backend/
 
 ## Key decisions
 
-| Decision | Value | Why |
-|---|---|---|
-| Editor model | OOXML-preserving ProseMirror schema | Round-trip fidelity matters more than schema purity |
-| Layout | Custom layout-painter, separate from `toDOM` | Word-style pagination, headers/footers, section breaks |
-| CRDT | Yjs + `y-prosemirror` | Documented integration, mature, fast convergence |
-| Transport | y-websocket protocol | Standard for Yjs over WS — works with Hocuspocus, custom servers, etc. |
-| Backend language | Go | IO-bound workload, mature WS ecosystem |
-| Backend state | None on disk; in-memory Y.Doc per active room | Stateless = trivial to scale + restart cleanly |
-| Persistence | Delegated to host integration | inline / WOPI / JWT-API — keeps the gateway storage-agnostic |
-| Editor toolchain | Bun | Fast install, fast test, native TS |
-| Test runner | Playwright (Chromium) | 836 e2e tests on the editor, plus `go test -race ./...` on the backend; both gate every push |
+| Decision         | Value                                         | Why                                                                                          |
+| ---------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Editor model     | OOXML-preserving ProseMirror schema           | Round-trip fidelity matters more than schema purity                                          |
+| Layout           | Custom layout-painter, separate from `toDOM`  | Word-style pagination, headers/footers, section breaks                                       |
+| CRDT             | Yjs + `y-prosemirror`                         | Documented integration, mature, fast convergence                                             |
+| Transport        | y-websocket protocol                          | Standard for Yjs over WS — works with Hocuspocus, custom servers, etc.                       |
+| Backend language | Go                                            | IO-bound workload, mature WS ecosystem                                                       |
+| Backend state    | None on disk; in-memory Y.Doc per active room | Stateless = trivial to scale + restart cleanly                                               |
+| Persistence      | Delegated to host integration                 | inline / WOPI / JWT-API — keeps the gateway storage-agnostic                                 |
+| Editor toolchain | Bun                                           | Fast install, fast test, native TS                                                           |
+| Test runner      | Playwright (Chromium)                         | 836 e2e tests on the editor, plus `go test -race ./...` on the backend; both gate every push |

--- a/docs/CO-EDITING.md
+++ b/docs/CO-EDITING.md
@@ -15,13 +15,14 @@ Y.Doc ⇄ ySyncPlugin ⇄ ProseMirror
   └──── y-websocket ───────┘
               │
               ▼
-       Go gateway
-       (per-docId room)
+   Node collab server
+   (Hocuspocus + Yjs, CasualOffice/collab)
+   per-docId room
 ```
 
 - Each open document maps to a single `Y.Doc` shared by all peers in the room.
 - `y-prosemirror`'s `ySyncPlugin` keeps the Y.Doc and ProseMirror state coherent in both directions — local edits become Y.Doc updates; remote Y.Doc updates become PM transactions.
-- Updates travel over the [y-websocket protocol](https://github.com/yjs/y-websocket) — a binary message format the gateway forwards verbatim.
+- Updates travel over the [y-websocket protocol](https://github.com/yjs/y-websocket) — a binary message format the server forwards verbatim.
 
 The gateway never interprets CRDT contents. It is a **pure relay** that fans incoming WS frames out to every other peer in the same room.
 
@@ -74,8 +75,14 @@ This belt-and-suspenders design means a malicious client editing the bundle stil
 
 ---
 
-## Why y-websocket (and not Hocuspocus)
+## The collab server: Hocuspocus (Node)
 
-The y-websocket protocol is a small, frozen binary format. Implementing it in Go is straightforward and lets the gateway stay dependency-free — no Node runtime, no JS dependencies, no library version drift.
+Real-time sync, presence, auth, and snapshots are served by the shared **Node/TypeScript**
+collab server **`CasualOffice/collab`** — [Hocuspocus](https://tiptap.dev/hocuspocus) + Yjs on
+Fastify, a format-agnostic server shared with Casual Sheets. The editor connects to it with
+`HocuspocusProvider` (`docx-editor/packages/react/src/collab/useCollab.ts`), still speaking the
+y-websocket protocol on the wire.
 
-We get the y-protocol benefits (efficient sync, awareness, partial updates) without inheriting Hocuspocus's extension model, which is designed for a Node deployment topology we don't need.
+Hocuspocus gives us a maintained extension model (auth hooks, WOPI, pluggable storage,
+snapshots/versioning) and one server reused across products. (An earlier in-repo **Go**
+y-websocket gateway under `backend/` predates this and is superseded — historical only.)

--- a/docs/internal/ROADMAP.md
+++ b/docs/internal/ROADMAP.md
@@ -6,7 +6,12 @@ Consolidates the resolved fidelity/editability/collab trackers (now in
 phase-wise plan. Living reference/design docs (backend, storage, SDK, iframe,
 writing-assistant, snapshot, collab-scale) stay as-is alongside this.
 
-Last updated: 2026-06-24.
+Last updated: 2026-06-25.
+
+**Recently shipped (2026-06-24→25):** Phase A is **complete** (track-changes, version history +
+Google-Docs preview/panel, Strict co-editing). Phase D **equations** is complete (render +
+author + edit + OMML round-trip). Desktop (Tauri) web-bridge folded into `main`, offline-first.
+Fixes: context-menu clamp, vertical-ruler margin-drag, kebab positioning, star icon.
 
 ---
 
@@ -94,14 +99,25 @@ calibration is **exhausted** (Calibri/empty-para shipped; Arial null because SDS
 
 ### Phase D — Feature breadth (close gaps vs LibreOffice)
 From the competitive matrix — the capabilities desktop suites have that we don't:
-native **equations / LaTeX** (a cheap differentiator the cloud editors lack), **mail
-merge**, **forms**, broader styles/sections. Prioritize by user demand.
+- **Equations / LaTeX** — ✅ **SHIPPED** (2026-06-25). Existing OMML equations render as real
+  math (#92); authoring round-trips MathML→OMML via a dependency-free converter (#94);
+  Insert → Equation UI with LaTeX input + live KaTeX preview + Alt+= + inline/display (#95);
+  double-click an equation to edit it in place (#96). `ommlToMathml`/`mathmlToOmml` unit-tested;
+  insert/edit/render e2e. The cheap differentiator cloud editors lack. *Known gap:* editing a
+  Word-IMPORTED equation opens the dialog blank (no OMML→LaTeX yet — you can replace, not see
+  the source).
+- **Mail merge**, **forms** (content controls / SDT), broader styles/sections — ⬜ remaining.
+  Prioritize by user demand.
 
 ### Phase E — Platform & reach
 1. **File System Access folder integration** (Chromium progressive enhancement).
 2. **Accessibility on by default** — screen-reader/braille support without manual enable
    (beats all three competitors on first run).
-3. **Tauri desktop binary** — *paused by directive*; ships once the team signals.
+3. **Tauri desktop binary** — the desktop shell lives in the separate `CasualOffice/desktop`
+   repo (Tauri 2). The editor-side web bridge (`window.__deskApp__`) + offline-first flag
+   (collab fully off in desktop; history etc. on) are folded into `main` (#93); the desktop
+   CI builds the editor from `main`. Active desktop *feature* dev stays paused by directive —
+   the fold just ended the separate-branch maintenance.
 
 ---
 

--- a/docs/internal/ROADMAP.md
+++ b/docs/internal/ROADMAP.md
@@ -17,16 +17,16 @@ Fixes: context-menu clamp, vertical-ruler margin-drag, kebab positioning, star i
 
 ## Where we are (shipped & verified)
 
-| Pillar | State |
-|---|---|
-| **Round-trip fidelity** | ✅ 39/39 fixtures byte-pristine; save→reload stable |
-| **Editability / insertion** | ✅ Backlog cleared — text/format, tables, images (wrap/anchor/border/rotate), text boxes (resize + Position X/Y move), footnotes/endnotes, comments, shapes-as-textboxes. (archived `24-editability-tracker`) |
-| **Visual fidelity — everyday docs** | ✅ Representative corpus **87.2 local / 87.6 CI**, floor locked at 0.80 (archived `21-vf-to-80`) |
-| **Visual fidelity — extreme corpus** | 🟡 CJK SDS / dense forms ~53 — safe per-font levers exhausted; residual is structural (see Phase B) |
-| **Real-time collab (Yjs/Hocuspocus)** | ✅ Presence, cursors, comments, footnotes/endnotes, doc-properties — all editable surfaces sync (archived `25-collab-coverage`) |
-| **Storage modes** | ✅ WOPI (host lock/refresh), Personal (auth + per-user files), Browser |
-| **Formats** | ✅ `.docx` native; `.odt` (WASM convert); `.md`/`.txt` (dedicated source+preview editor with collab) |
-| **UX** | ✅ Google-Docs-style thin toolbar + contextual Format side-panel (one right-surface at a time); on-object chips |
+| Pillar                                | State                                                                                                                                                                                                         |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Round-trip fidelity**               | ✅ 39/39 fixtures byte-pristine; save→reload stable                                                                                                                                                           |
+| **Editability / insertion**           | ✅ Backlog cleared — text/format, tables, images (wrap/anchor/border/rotate), text boxes (resize + Position X/Y move), footnotes/endnotes, comments, shapes-as-textboxes. (archived `24-editability-tracker`) |
+| **Visual fidelity — everyday docs**   | ✅ Representative corpus **87.2 local / 87.6 CI**, floor locked at 0.80 (archived `21-vf-to-80`)                                                                                                              |
+| **Visual fidelity — extreme corpus**  | 🟡 CJK SDS / dense forms ~53 — safe per-font levers exhausted; residual is structural (see Phase B)                                                                                                           |
+| **Real-time collab (Yjs/Hocuspocus)** | ✅ Presence, cursors, comments, footnotes/endnotes, doc-properties — all editable surfaces sync (archived `25-collab-coverage`)                                                                               |
+| **Storage modes**                     | ✅ WOPI (host lock/refresh), Personal (auth + per-user files), Browser                                                                                                                                        |
+| **Formats**                           | ✅ `.docx` native; `.odt` (WASM convert); `.md`/`.txt` (dedicated source+preview editor with collab)                                                                                                          |
+| **UX**                                | ✅ Google-Docs-style thin toolbar + contextual Format side-panel (one right-surface at a time); on-object chips                                                                                               |
 
 **Competitive position** (from `26-competitive-analysis`): our defensible moats are
 **pristine `.docx` round-trip**, **uncapped permissive self-host**, and **Yjs-native
@@ -41,12 +41,14 @@ by the project's non-negotiables (round-trip stays 39/39; no editor-safety/colla
 regression; metrics changes revert-by-default unless they net positive).
 
 ### Phase A — Collaboration parity (highest competitive value)
+
 The features that close the gap with Google Docs / OnlyOffice for `.docx` workflows.
+
 1. **Suggestions / track-changes with Word interop** — ✅ **CORE ALREADY SHIPPED** (audited
    2026-06-24). Suggesting mode (toolbar dropdown + Ctrl+Shift+E), insertion/deletion marks
    rendered on the painted page, `<w:ins>`/`<w:del>`/`<w:delText>` OOXML round-trip,
    accept/reject sidebar + accept-all/reject-all, Yjs-synced marks. Full-flow e2e in
-   `track-changes-flow.spec.ts`. Remaining *polish*: `<w:pPrChange>` paragraph-format-change
+   `track-changes-flow.spec.ts`. Remaining _polish_: `<w:pPrChange>` paragraph-format-change
    display, per-author color coding, prev/next-change navigation, general round-trip fixture.
 2. **Named version history** — ✅ **SHIPPED** (audited 2026-06-24). IDB-backed
    `version-history/` module: **auto** snapshots (~10-min idle while dirty) + **manual named**
@@ -64,12 +66,12 @@ The features that close the gap with Google Docs / OnlyOffice for `.docx` workfl
      `VersionSnapshot.author` store change). e2e: `version-panel-layout.spec.ts`.
 3. **Opt-in Strict / paragraph-lock co-editing mode** (OnlyOffice pattern) — ✅ **SHIPPED**
    (PR #90, 2026-06-25). A peer's cursor locks its paragraph for the local user: dashed outline
-   + faint tint in the peer's colour + name badge (OnlyOffice representation, researched);
-   local edits to it are blocked, remote sync never is. Local policy derived from existing
-   cursor awareness (`peerLocks.ts`); enforcement core (`strictCoEditing.ts`) is unit-tested
-   with injected locks (the data-layer verification — multi-peer UI e2e needs a live server).
-   View-menu toggle "Strict co-editing: on/off" (shown only in collab); public API
-   `setStrictCoEditing` / `isStrictCoEditingEnabled` for host toggles.
+   - faint tint in the peer's colour + name badge (OnlyOffice representation, researched);
+     local edits to it are blocked, remote sync never is. Local policy derived from existing
+     cursor awareness (`peerLocks.ts`); enforcement core (`strictCoEditing.ts`) is unit-tested
+     with injected locks (the data-layer verification — multi-peer UI e2e needs a live server).
+     View-menu toggle "Strict co-editing: on/off" (shown only in collab); public API
+     `setStrictCoEditing` / `isStrictCoEditingEnabled` for host toggles.
 
 **Phase A is COMPLETE** — track-changes (#84/#85), version history + Google-Docs preview
 (#87), and Strict co-editing (#90) all shipped.
@@ -77,13 +79,15 @@ The features that close the gap with Google Docs / OnlyOffice for `.docx` workfl
 **Reality check (2026-06-24 audit):** the editor is far more complete than a from-scratch
 roadmap implies — Phase A #1 and #2 were already built; only #3 (Strict mode) remains. The
 near-term "build" backlog across the project is small (Strict mode, Phase B extreme-corpus
-fidelity, Phase D breadth); most "to-do" features turn out to need *verification + e2e
-coverage*, not implementation. Audit before building.
+fidelity, Phase D breadth); most "to-do" features turn out to need _verification + e2e
+coverage_, not implementation. Audit before building.
 
 ### Phase B — Extreme-corpus visual fidelity (dedicated, riskier)
+
 The CJK-SDS / dense-form corpus (~53) — the user's real-world documents. Per-font
 calibration is **exhausted** (Calibri/empty-para shipped; Arial null because SDS pins
 `lineRule="exact"`; table-rows are diffuse drift). The residual is **structural**:
+
 1. **Exact-line box model** — reproduce LibreOffice's `lineRule="exact"` line height for
    the SDS body (the dominant lever; today bypasses font metrics).
 2. **Measured table-row-height correction** — close the ~2–3px/row over-height that
@@ -92,31 +96,35 @@ calibration is **exhausted** (Calibri/empty-para shipped; Arial null because SDS
    differ first; gate every step against the 39 pristine fixtures + the editor-safety suite.
 
 ### Phase C — Durability & scale
+
 1. **Server-side snapshot-on-drain fallback** — last-interval edits survive when no client
    is around to push a save (design in `18-server-snapshot-design`).
 2. **Collab at scale** — large-doc latency, consistency, server-side versioning
    (`22-collab-scale-persistence`).
 
 ### Phase D — Feature breadth (close gaps vs LibreOffice)
+
 From the competitive matrix — the capabilities desktop suites have that we don't:
+
 - **Equations / LaTeX** — ✅ **SHIPPED** (2026-06-25). Existing OMML equations render as real
   math (#92); authoring round-trips MathML→OMML via a dependency-free converter (#94);
   Insert → Equation UI with LaTeX input + live KaTeX preview + Alt+= + inline/display (#95);
   double-click an equation to edit it in place (#96). `ommlToMathml`/`mathmlToOmml` unit-tested;
-  insert/edit/render e2e. The cheap differentiator cloud editors lack. *Known gap:* editing a
+  insert/edit/render e2e. The cheap differentiator cloud editors lack. _Known gap:_ editing a
   Word-IMPORTED equation opens the dialog blank (no OMML→LaTeX yet — you can replace, not see
   the source).
 - **Mail merge**, **forms** (content controls / SDT), broader styles/sections — ⬜ remaining.
   Prioritize by user demand.
 
 ### Phase E — Platform & reach
+
 1. **File System Access folder integration** (Chromium progressive enhancement).
 2. **Accessibility on by default** — screen-reader/braille support without manual enable
    (beats all three competitors on first run).
 3. **Tauri desktop binary** — the desktop shell lives in the separate `CasualOffice/desktop`
    repo (Tauri 2). The editor-side web bridge (`window.__deskApp__`) + offline-first flag
    (collab fully off in desktop; history etc. on) are folded into `main` (#93); the desktop
-   CI builds the editor from `main`. Active desktop *feature* dev stays paused by directive —
+   CI builds the editor from `main`. Active desktop _feature_ dev stays paused by directive —
    the fold just ended the separate-branch maintenance.
 
 ---

--- a/docx-editor/packages/react/src/components/render/DocImage.tsx
+++ b/docx-editor/packages/react/src/components/render/DocImage.tsx
@@ -160,8 +160,7 @@ export function DocImage({
             : image.title || image.alt || 'Image'
         }
       >
-        [{label}]
-        {image.filename && <br />}
+        [{label}]{image.filename && <br />}
         {image.filename && <small>{image.filename}</small>}
       </span>
     );


### PR DESCRIPTION
Roadmap consolidation after this cycle:
- **Phase D equations** marked **shipped** (render #92 / author #94 / insert UI #95 / edit #96), with the known Word-imported-equation edit gap (no OMML→LaTeX yet) noted.
- **Desktop** (Tauri) web-bridge folded into `main` (#93), offline-first; CI builds the editor from `main`. Active desktop feature dev stays paused — the fold just ended the branch-maintenance.
- **Phase A** noted complete; recently-shipped summary + date bump.

Docs-only.