### PR TITLE
docs: banner legacy Go-gateway docs; point to Node @casualoffice/collab

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -8,6 +8,14 @@ If you're new to the project, start with §[Quickstart](#quickstart).
 For production hosting (TLS, reverse proxy, scale), jump to
 §[Production hosting](#production-hosting).
 
+> **Backend note.** Where this guide describes the **Go** gateway / `backend/`
+> image, that is the legacy in-repo gateway, now **superseded** by the shared
+> **Node/TypeScript** `@casualoffice/collab` server (Hocuspocus + Yjs on Fastify).
+> The deployment shapes still apply; the collab service is run from the separate
+> `@casualoffice/collab` repo. See
+> [internal/23-collab-server-migration](internal/23-collab-server-migration.md)
+> and [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
 ---
 
 ## Quickstart

--- a/docs/internal/00-overview.md
+++ b/docs/internal/00-overview.md
@@ -2,7 +2,17 @@
 
 ## Goal
 
-A real-time collaborative `.docx` editor service. Browser-side: a fork of `eigenpal/docx-editor` (MIT, React + ProseMirror with OOXML-preserving model). Backend: a **stateless** Go service providing Yjs-CRDT sync, presence, and snapshot generation. Document persistence is delegated to a pluggable host integration (inline for v0; WOPI / JWT-API later).
+A real-time collaborative `.docx` editor service. Browser-side: a fork of `eigenpal/docx-editor` (MIT, React + ProseMirror with OOXML-preserving model). Backend: the shared **Node/TypeScript** collab server **`@casualoffice/collab`** (Hocuspocus + Yjs on Fastify, Apache-2.0) — a stateless, format-agnostic server, also powering Casual Sheets, that holds one authoritative `Y.Doc` per room and produces snapshots/versioning. Document persistence is a pluggable host backend (`memory` / `local` / `s3` / `postgres` / WOPI).
+
+> **Backend note (current).** Real-time sync/presence/snapshots are owned by the Node
+> `@casualoffice/collab` server (Hocuspocus + Yjs on Fastify); the editor connects via
+> `HocuspocusProvider` (`packages/react/src/collab/useCollab.ts`). A legacy in-repo **Go**
+> y-websocket gateway under `backend/` predates this and is **superseded** — it still builds
+> in CI but new sync/persistence work goes to the collab server, not `backend/`. The
+> "Architecture (committed)", "Decisions (locked, 2026-05-16)", "Resolved questions", and the
+> Go-specific milestone rows **below are a historical record of that legacy gateway**. For the
+> current backend see [23-collab-server-migration](23-collab-server-migration.md) and
+> [`ARCHITECTURE.md`](../ARCHITECTURE.md).
 
 ## Why this shape
 
@@ -88,7 +98,7 @@ This shifts the durability story entirely to the host. We become a pure realtime
 |---|---|---|
 | **Released version** | unreleased (M1 backend + client-push snapshot shipped) | **v0.1.0** — first version-bumped release |
 | **Editor base** | Fork of `eigenpal/docx-editor` (MIT) + custom layout-painter | Univer OSS 0.24.x (Apache-2.0) + custom Office-style chrome |
-| **CRDT** | Yjs + `y-prosemirror`, own Go y-websocket gateway | Yjs + Hocuspocus (Node) |
+| **CRDT** | Yjs + `y-prosemirror`, shared Node `@casualoffice/collab` (Hocuspocus + Yjs) | Yjs + Hocuspocus (Node) — same server |
 | **Persistence** | `host.Integration` interface; `inline` + per-user `personal` (Phase C) + `wopi` (Phase D) all shipped | Same interface shape; **4 backends shipped** — `memory` · `local` · `s3` (AWS/MinIO/R2/B2) · `postgres` |
 | **WOPI / JWT** | **Shipped** (Phase D) — WOPI client, JWKS JWT verifier, embed redirect, `WopiFileSource`, `host.Locker` Lock/Unlock/RefreshLock; Personal auth (Phase C) JWT/session shipped too | **Shipped** — CheckFileInfo / GetFile / PutFile + JWT claims (role / permissions / features / per-file lateral guard) |
 | **Admin panel** | `casual-docs` CLI + `/admin/users` routes (Phase C Batch 5) | Shipped — `/admin`, env-gated, 7 sections (branding · storage · networking · room limits · auth · webhooks · base path) |

--- a/docs/internal/05-backend-design.md
+++ b/docs/internal/05-backend-design.md
@@ -1,5 +1,14 @@
 # 05 — Backend design: y-websocket gateway in Go
 
+> **Legacy / historical.** This document describes the in-repo **Go**
+> y-websocket gateway under `backend/`. That gateway is **superseded** by the
+> shared **Node/TypeScript** `@casualoffice/collab` server (Hocuspocus + Yjs on
+> Fastify), which now owns real-time sync, presence, and snapshots. The Go
+> gateway still builds in CI but receives no new sync/persistence work. For the
+> current backend see [23-collab-server-migration](23-collab-server-migration.md)
+> and [`ARCHITECTURE.md`](../ARCHITECTURE.md). The design below is kept as a
+> record of the legacy gateway.
+
 > Resolves the open backend questions from `00-overview.md`.
 > Originally written before any Go code existed, to lock the design
 > so future work didn't re-derive these decisions.

--- a/docs/internal/11-storage-modes.md
+++ b/docs/internal/11-storage-modes.md
@@ -9,6 +9,14 @@ the two products stay legible side-by-side; the differences sit in
 the language stack (Go gateway vs Bun/Fastify) and the file format
 (`.docx` vs `.xlsx`), not the deployment story.
 
+> **Backend note.** References below to a **Go gateway** describe the legacy
+> in-repo `backend/`, now **superseded** by the shared **Node/TypeScript**
+> `@casualoffice/collab` server (Hocuspocus + Yjs on Fastify). The three storage
+> modes and the `host.Integration` contract carry over unchanged; only the server
+> that hosts them differs. See
+> [23-collab-server-migration](23-collab-server-migration.md) and
+> [`ARCHITECTURE.md`](../ARCHITECTURE.md).
+
 ---
 
 ## The three modes

--- a/docs/internal/22-collab-scale-persistence.md
+++ b/docs/internal/22-collab-scale-persistence.md
@@ -5,6 +5,14 @@ content drops, no divergence, low edit latency on large docs, fast sync for new
 peers, and version history. "Everything in place." This is the design + sequenced
 plan. Grounded in the current code, not from memory.
 
+> **Backend note.** This doc analyzes the legacy in-repo **Go** gateway
+> (`backend/`), which is **superseded** by the shared **Node/TypeScript**
+> `@casualoffice/collab` server (Hocuspocus + Yjs on Fastify). The consistency,
+> large-doc-latency, server-snapshot, and versioning concerns below remain valid
+> design drivers, but the implementation target is now the collab server, not
+> `backend/`. See [23-collab-server-migration](23-collab-server-migration.md) and
+> [`ARCHITECTURE.md`](../ARCHITECTURE.md).
+
 ## Where we are (verified)
 
 - **Edit transport is already incremental.** Editing flows PM transaction → Yjs


### PR DESCRIPTION
## What

The in-repo **Go** y-websocket gateway (`backend/`) is superseded by the shared **Node/TypeScript** `@casualoffice/collab` server (Hocuspocus + Yjs on Fastify). Several docs still described the Go gateway as the live sync path. This adds a clear "legacy / current backend" banner to each, pointing readers to `internal/23-collab-server-migration.md` and `ARCHITECTURE.md`.

## Changes

- **00-overview.md** — Goal/backend paragraph rewritten to name the Node collab server; historical-record banner marks the Go-specific architecture/decisions/milestone sections below as legacy.
- **05-backend-design.md** — title doc is explicitly the legacy Go gateway; top banner marks it superseded.
- **11-storage-modes.md** — Go-vs-Bun language-stack note clarified; storage modes + `host.Integration` contract carry over unchanged.
- **22-collab-scale-persistence.md** — design drivers retargeted from `backend/` to the collab server.
- **DEPLOYMENT.md** — Go gateway image marked legacy; deployment shapes still apply.

Docs-only; no code changes. Completes the legacy-Go documentation sweep started in #97.