### PR TITLE
feat(wopi): point WopiFileSource at collab WOPI host endpoints + client-push save

### DIFF
--- a/docx-editor/.changeset/wopi-collab-endpoints.md
+++ b/docx-editor/.changeset/wopi-collab-endpoints.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': minor
+---
+
+WopiFileSource now talks directly to the collab server's WOPI host endpoints (`/wopi/files/:id` CheckFileInfo, `/wopi/files/:id/contents` GetFile/PutFile) instead of the legacy Go gateway's `/api/docs/{id}/download`. `save()` is now implemented as a WOPI PutFile (client-push, with `X-WOPI-ItemVersion` optimistic-write guard) rather than throwing; a host-side version conflict surfaces as the new exported `WopiSaveConflictError`.

--- a/docx-editor/packages/react/src/file-source/index.ts
+++ b/docx-editor/packages/react/src/file-source/index.ts
@@ -38,7 +38,12 @@ export {
   type AutoSaveStatus as FileSourceAutoSaveStatus,
 } from './useFileSourceAutoSave';
 export { AutosaveStatus, type AutosaveStatusProps } from './AutosaveStatus';
-export { WopiFileSource, WopiNotSupportedError, type WopiFileSourceOptions } from './wopi';
+export {
+  WopiFileSource,
+  WopiNotSupportedError,
+  WopiSaveConflictError,
+  type WopiFileSourceOptions,
+} from './wopi';
 export {
   chooseFileSource,
   extractWopiContext,

--- a/docx-editor/packages/react/src/file-source/select.ts
+++ b/docx-editor/packages/react/src/file-source/select.ts
@@ -110,8 +110,8 @@ export async function chooseFileSource(opts: ChooseFileSourceOptions = {}): Prom
     opts.fetchImpl ?? (((input, init) => fetch(input, init)) as typeof fetch);
 
   // 1. WOPI probe — the URL alone is enough to pick this branch.
-  //    The token's validity is the gateway's problem; if it's bad,
-  //    the eventual /api/docs/{id}/download call will surface a
+  //    The token's validity is collab's problem; if it's bad, the
+  //    eventual /wopi/files/{id}/contents call will surface a
   //    403 / 401 and the editor's error boundary takes over.
   const wopi = opts.wopiContext ?? extractWopiContext();
   if (wopi) {

--- a/docx-editor/packages/react/src/file-source/wopi.test.ts
+++ b/docx-editor/packages/react/src/file-source/wopi.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
-import { WopiFileSource, WopiNotSupportedError } from './wopi';
+import { WopiFileSource, WopiNotSupportedError, WopiSaveConflictError } from './wopi';
 
 type Call = { url: string; init: RequestInit | undefined };
 
@@ -76,13 +76,15 @@ describe('WopiFileSource', () => {
     });
   });
 
-  it('open() proxies through the gateway download with the access_token query', async () => {
+  it('open() GETs collab /wopi/files/:id/contents with the access_token query', async () => {
     const h = makeHarness({ fileName: 'Notes.docx' });
     const bytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04]);
-    h.setRespond(() => new Response(bytes, { status: 200, headers: { ETag: 'v7' } }));
+    h.setRespond(
+      () => new Response(bytes, { status: 200, headers: { 'X-WOPI-ItemVersion': 'v7' } })
+    );
     const result = await h.source.open('aHR0cDovL2hvc3QvZmlsZXMvYWJj');
     expect(h.calls[0].url).toContain(
-      '/api/docs/aHR0cDovL2hvc3QvZmlsZXMvYWJj/download?access_token=tok-jwt'
+      '/wopi/files/aHR0cDovL2hvc3QvZmlsZXMvYWJj/contents?access_token=tok-jwt'
     );
     expect(result.name).toBe('Notes.docx');
     expect(result.etag).toBe('v7');
@@ -99,9 +101,9 @@ describe('WopiFileSource', () => {
     }
   });
 
-  it('save() / rename() / delete() throw WopiNotSupportedError', async () => {
+  it('rename() / delete() throw WopiNotSupportedError (host owns lifecycle)', async () => {
     const { source } = makeHarness();
-    for (const op of [() => source.save(), () => source.rename(), () => source.delete()] as Array<
+    for (const op of [() => source.rename(), () => source.delete()] as Array<
       () => Promise<unknown>
     >) {
       try {
@@ -110,6 +112,60 @@ describe('WopiFileSource', () => {
       } catch (err) {
         expect(err).toBeInstanceOf(WopiNotSupportedError);
       }
+    }
+  });
+
+  it('save() POSTs PutFile and sends the opened version as X-WOPI-ItemVersion', async () => {
+    const h = makeHarness({ fileName: 'Notes.docx' });
+    // First open so the source retains the item version for If-Match.
+    h.setRespond(
+      () =>
+        new Response(new Uint8Array([1]), { status: 200, headers: { 'X-WOPI-ItemVersion': 'v1' } })
+    );
+    await h.source.open('aHR0cDovL2hvc3QvZmlsZXMvYWJj');
+
+    h.setRespond(
+      () => new Response(JSON.stringify({ ok: true, version: 'v2', bytes: 4 }), { status: 200 })
+    );
+    const out = new Uint8Array([0x50, 0x4b, 0x03, 0x04]).buffer;
+    const result = await h.source.save('aHR0cDovL2hvc3QvZmlsZXMvYWJj', out);
+
+    const putCall = h.calls[1];
+    expect(putCall.url).toContain(
+      '/wopi/files/aHR0cDovL2hvc3QvZmlsZXMvYWJj/contents?access_token=tok-jwt'
+    );
+    expect(putCall.init?.method).toBe('POST');
+    const headers = putCall.init?.headers as Record<string, string>;
+    expect(headers['X-WOPI-ItemVersion']).toBe('v1');
+    expect(headers['Content-Type']).toBe('application/octet-stream');
+    expect(result).toEqual({ id: 'aHR0cDovL2hvc3QvZmlsZXMvYWJj', etag: 'v2' });
+  });
+
+  it('save() surfaces a 409 as WopiSaveConflictError with expected/actual', async () => {
+    const h = makeHarness();
+    h.setRespond(
+      () =>
+        new Response(JSON.stringify({ error: 'version_mismatch', expected: 'v3', actual: 'v9' }), {
+          status: 409,
+        })
+    );
+    try {
+      await h.source.save('aHR0cDovL2hvc3QvZmlsZXMvYWJj', new Uint8Array([1]).buffer);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(WopiSaveConflictError);
+      expect((err as WopiSaveConflictError).expected).toBe('v3');
+      expect((err as WopiSaveConflictError).actual).toBe('v9');
+    }
+  });
+
+  it('save() with a foreign docId throws WopiNotSupportedError', async () => {
+    const { source } = makeHarness();
+    try {
+      await source.save('some-other-id', new Uint8Array([1]).buffer);
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(WopiNotSupportedError);
     }
   });
 

--- a/docx-editor/packages/react/src/file-source/wopi.ts
+++ b/docx-editor/packages/react/src/file-source/wopi.ts
@@ -1,37 +1,43 @@
 /**
  * WopiFileSource — the FileSource implementation for Mode 2 (WOPI).
  *
- * In Mode 2 the editor is embedded inside a host (SharePoint,
- * Nextcloud, custom storage) that owns the file's lifecycle. The
- * user arrives via the gateway's /wopi/host redirect with two pieces
- * of state in the URL:
+ * In Mode 2 the editor is embedded by a host that owns the file's
+ * lifecycle. The user arrives with two pieces of state in the URL
+ * (parsed by `extractWopiContext()` in select.ts):
  *
- *   docId        — base64url-encoded WOPI source URL
- *   accessToken  — JWT issued by the host
+ *   docId        — the host file id (the WOPI `:id` path segment)
+ *   accessToken  — JWT issued by the host / collab admin
  *
- * Both are surfaced via `extractWopiContext()` in select.ts and
- * passed to the constructor.
+ * This source talks DIRECTLY to the collab server's WOPI host
+ * endpoints (the same contract Casual Sheets uses):
  *
- * What this source DOES support:
+ *   GET  /wopi/files/:id             → CheckFileInfo (JSON metadata)
+ *   GET  /wopi/files/:id/contents    → GetFile (raw bytes)
+ *   POST /wopi/files/:id/contents    → PutFile (raw bytes; X-WOPI-ItemVersion)
  *
- *   - `kind` + `label` for UI branching
- *   - `open(docId)` — proxies through the gateway's
- *     /api/docs/{docId}/download endpoint with `?access_token=…`
- *     attached. The gateway's WOPI client makes the outbound call
- *     to the host.
- *   - `list()` — returns a single entry for the embedded doc; the
- *     host owns file discovery so there's nothing else to list.
+ * The JWT rides as `?access_token=…` on every call; collab verifies the
+ * signature, that the token's `file_id` claim equals `:id`, and the
+ * per-route permission (read for GET, write for PutFile).
+ *
+ * What this source supports:
+ *
+ *   - `kind` + `label` for UI branching.
+ *   - `open(docId)` — GetFile; the item version comes back in the
+ *     `X-WOPI-ItemVersion` header and is retained for optimistic-write
+ *     protection on the next save.
+ *   - `save(docId, bytes)` — PutFile, sending the retained version as
+ *     `X-WOPI-ItemVersion` (If-Match). A 409 from collab means the host
+ *     copy moved underneath us; surfaced as `WopiSaveConflictError`.
+ *   - `list()` — a single entry for the embedded doc (the host owns
+ *     file discovery), enriched with CheckFileInfo name + size.
  *   - `watchRecent` / `rememberLastOpened` / `lastOpened` — same
  *     localStorage-backed prefs as BrowserFileSource.
  *
- * What this source DOES NOT support:
+ * What it does NOT support:
  *
- *   - `save()` — WOPI snapshots happen server-side on room drain.
- *     The client doesn't initiate them; calling here throws so the
- *     editor doesn't paper over a wiring bug.
- *   - `rename()` / `delete()` — host owns lifecycle. WOPI 1.x has
- *     RenameFile semantics we don't expose yet; deletion is never
- *     a WOPI client operation.
+ *   - `rename()` / `delete()` — the host owns the file's lifecycle.
+ *     WOPI's core contents endpoints don't expose either, so calling
+ *     here throws rather than silently no-op'ing.
  */
 
 import { RecentObserver, readLastOpened, writeLastOpened } from './local-prefs';
@@ -39,30 +45,26 @@ import type { FileEntry, FileSource } from './types';
 
 export interface WopiFileSourceOptions {
   /**
-   * The opaque docID minted by the gateway's /wopi/host redirect.
-   * Already base64url-encoded; we pass it through verbatim to the
-   * /api/docs/{docId}/download endpoint without any further mangling.
+   * The host file id — the `:id` path segment on the collab WOPI
+   * routes. Passed through verbatim; the embedding host decides its
+   * shape (and the JWT's `file_id` claim must match it).
    */
   docId: string;
   /**
-   * The JWT the WOPI host issued. Attached as `?access_token=…` on
-   * every outbound call so the gateway's WOPI client can pass it
-   * to the host.
+   * The JWT the host issued. Attached as `?access_token=…` on every
+   * call so collab can verify it and scope access to this file.
    */
   accessToken: string;
   /**
    * Filename for the embedded doc, if the embed surface knew it at
-   * boot. Optional — when missing, list() returns the docID as the
-   * name and the editor's title bar falls back to that. The host's
-   * CheckFileInfo round-trip on the WS preflight is what actually
-   * lands the real filename in the editor.
+   * boot. Optional — when missing, list()/open() fall back to the
+   * CheckFileInfo `BaseFileName`, then to the docId.
    */
   fileName?: string;
   /**
-   * Origin of the gateway. Defaults to "" (same-origin) which is the
-   * production deploy shape — the editor SPA is served from the
-   * same Docker image as the gateway. Local-dev with Vite on :5173
-   * points to http://localhost:8080.
+   * Origin of the collab server. Defaults to "" (same-origin) — the
+   * production shape where the editor SPA is served from the collab
+   * image. Local dev with Vite on :5173 points at the collab origin.
    */
   baseUrl?: string;
   /**
@@ -84,17 +86,44 @@ export class WopiNotSupportedError extends Error {
   }
 }
 
+/**
+ * Thrown when PutFile is rejected because the host's item version no
+ * longer matches the one we opened (collab returns 409 with the
+ * expected / actual versions). The host app can catch this to show a
+ * "the document changed elsewhere" conflict prompt.
+ */
+export class WopiSaveConflictError extends Error {
+  readonly expected?: string;
+  readonly actual?: string;
+  constructor(expected?: string, actual?: string) {
+    super('WopiFileSource: save rejected — item version mismatch');
+    this.name = 'WopiSaveConflictError';
+    this.expected = expected;
+    this.actual = actual;
+  }
+}
+
+/** CheckFileInfo subset we read off the collab response. */
+interface CheckFileInfo {
+  BaseFileName?: string;
+  Size?: number;
+  Version?: string;
+  UserCanWrite?: boolean;
+}
+
 export class WopiFileSource implements FileSource {
   readonly kind = 'wopi' as const;
   readonly label: string;
 
   private readonly docId: string;
   private readonly accessToken: string;
-  private readonly fileName: string;
+  private fileName: string;
   private readonly baseUrl: string;
   private readonly fetchImpl: typeof fetch;
   private readonly recent = new RecentObserver();
   private readonly scope: string;
+  /** Latest item version, retained from open()/save() for If-Match. */
+  private version: string | undefined;
 
   constructor(opts: WopiFileSourceOptions) {
     this.docId = opts.docId;
@@ -116,7 +145,13 @@ export class WopiFileSource implements FileSource {
   }
 
   async list(): Promise<FileEntry[]> {
-    const entry = this.singleEntry();
+    // CheckFileInfo gives us the authoritative name + size. Best-effort:
+    // a failure (e.g. a read-scoped token that still opens fine) must
+    // not break the single-entry list the embed needs.
+    const info = await this.checkFileInfo().catch(() => null);
+    if (info?.BaseFileName) this.fileName = info.BaseFileName;
+    if (info?.Version) this.version = info.Version;
+    const entry = this.singleEntry(info?.Size);
     this.recent.set([entry]);
     return [entry];
   }
@@ -128,22 +163,53 @@ export class WopiFileSource implements FileSource {
     if (id !== this.docId) {
       throw new WopiNotSupportedError(`open(${id}) — only the embed's docId is reachable`);
     }
-    const url = this.urlFor(`/api/docs/${encodeURIComponent(id)}/download`);
-    const res = await this.fetchImpl(url);
+    const res = await this.fetchImpl(this.urlFor(`/wopi/files/${encodeURIComponent(id)}/contents`));
     if (!res.ok) {
-      throw new Error(`WopiFileSource: download failed (${res.status})`);
+      throw new Error(`WopiFileSource: GetFile failed (${res.status})`);
     }
     const bytes = await res.arrayBuffer();
-    const etag = res.headers.get('ETag') ?? undefined;
-    return { bytes, name: this.fileName, etag };
+    // collab stamps the item version on GetFile; retain it so the next
+    // save can send it as the If-Match guard.
+    const version = res.headers.get('X-WOPI-ItemVersion') ?? undefined;
+    if (version) this.version = version;
+    return { bytes, name: this.fileName, etag: version };
   }
 
-  async save(): Promise<{ id: string; etag: string }> {
-    // WOPI snapshots happen on room drain server-side. A client-
-    // initiated save here would race the auto-snapshot and produce
-    // the wrong wire shape. Throw so the call site is fixed rather
-    // than silently no-op'd.
-    throw new WopiNotSupportedError('save (use the implicit room-drain snapshot)');
+  async save(
+    id: string | null,
+    bytes: ArrayBuffer,
+    opts?: { etag?: string; name?: string }
+  ): Promise<{ id: string; etag: string }> {
+    // WOPI never mints ids client-side — the host owns the file id, so
+    // a first-save (id === null) is meaningless here.
+    if (id !== null && id !== this.docId) {
+      throw new WopiNotSupportedError(`save(${id}) — only the embed's docId is writable`);
+    }
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/octet-stream',
+    };
+    // Optimistic-write guard: prefer the caller's etag, else the version
+    // we last saw. Omitted on the very first save if we never opened.
+    const ifMatch = opts?.etag ?? this.version;
+    if (ifMatch) headers['X-WOPI-ItemVersion'] = ifMatch;
+
+    const res = await this.fetchImpl(
+      this.urlFor(`/wopi/files/${encodeURIComponent(this.docId)}/contents`),
+      { method: 'POST', headers, body: bytes }
+    );
+    if (res.status === 409) {
+      const body = (await res.json().catch(() => ({}))) as { expected?: string; actual?: string };
+      throw new WopiSaveConflictError(body.expected, body.actual);
+    }
+    if (!res.ok) {
+      throw new Error(`WopiFileSource: PutFile failed (${res.status})`);
+    }
+    const body = (await res.json().catch(() => ({}))) as { version?: string };
+    // collab returns the new version in the body and the header; trust
+    // the body, fall back to the header, then to whatever we had.
+    const next = body.version ?? res.headers.get('X-WOPI-ItemVersion') ?? this.version ?? '';
+    this.version = next || undefined;
+    return { id: this.docId, etag: next };
   }
 
   async rename(): Promise<void> {
@@ -166,8 +232,15 @@ export class WopiFileSource implements FileSource {
     return readLastOpened(this.scope);
   }
 
+  /** CheckFileInfo round-trip — JSON metadata for the embedded file. */
+  private async checkFileInfo(): Promise<CheckFileInfo | null> {
+    const res = await this.fetchImpl(this.urlFor(`/wopi/files/${encodeURIComponent(this.docId)}`));
+    if (!res.ok) return null;
+    return (await res.json()) as CheckFileInfo;
+  }
+
   /**
-   * Builds an absolute URL on the gateway with the access_token
+   * Builds an absolute URL on the collab server with the access_token
    * query param attached. Preserves any existing query the path
    * already carries (none today, but cheap to handle).
    */
@@ -176,11 +249,11 @@ export class WopiFileSource implements FileSource {
     return `${this.baseUrl}${path}${sep}access_token=${encodeURIComponent(this.accessToken)}`;
   }
 
-  private singleEntry(): FileEntry {
+  private singleEntry(size = 0): FileEntry {
     return {
       id: this.docId,
       name: this.fileName,
-      size: 0,
+      size,
       modifiedAt: Date.now(),
       source: 'wopi',
     };

--- a/docx-editor/packages/react/src/index.ts
+++ b/docx-editor/packages/react/src/index.ts
@@ -178,6 +178,7 @@ export {
   PersonalFileSourceError,
   WopiFileSource,
   WopiNotSupportedError,
+  WopiSaveConflictError,
   AuthClient,
   PersonalAuthGate,
   PersonalAuthGateModal,


### PR DESCRIPTION
## What

Reworks the editor's Mode 2 (WOPI) `WopiFileSource` to talk directly to the **collab server's WOPI host endpoints** — the contract Casual Sheets already uses — instead of the legacy Go gateway's embed-proxy routes. This unblocks the WOPI half of the Go→collab cutover.

## Endpoint changes

| Op | Before (Go gateway) | After (collab) |
|---|---|---|
| open | `GET /api/docs/{id}/download` | `GET /wopi/files/:id/contents` |
| version | `ETag` header | `X-WOPI-ItemVersion` header |
| save | threw `WopiNotSupportedError` | `POST /wopi/files/:id/contents` + `X-WOPI-ItemVersion` If-Match |
| name/size | WS preflight only | `GET /wopi/files/:id` (CheckFileInfo) |

`save()` is now the client-push snapshot the autosave hook already drives. A host-side version conflict (collab 409) surfaces as the new exported `WopiSaveConflictError` (with `expected`/`actual`). The JWT still rides as `?access_token=`; collab enforces `file_id == :id` and per-route read/write. Boot/probe (`extractWopiContext`, `/doc/{id}?access_token=`) is unchanged; `rename()`/`delete()` still throw since the host owns lifecycle.

Verified: typecheck, lint (0 errors), 57 file-source unit tests (WOPI contract incl. PutFile If-Match + 409 conflict), and build all pass locally.