### PR TITLE
feat(personal): cut Mode 3 over to the collab auth + files contract

### DIFF
--- a/docx-editor/.changeset/personal-mode3-collab.md
+++ b/docx-editor/.changeset/personal-mode3-collab.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': minor
+---
+
+Mode 3 (Personal/Standalone) now talks to the collab server's auth + files contract instead of the legacy Go gateway. `PersonalFileSource`, `AuthClient`, and the personal-auth UI cut over to collab's shapes: wrapped envelopes (`{ user }` / `{ files }` / `{ file }` / `{ profile }`), the `{ error }` error envelope, `id`/`name`/`etag`/`modifiedAt` file fields, multipart `POST /files` create, `POST /files/:id` replace with `If-Match`, and `PATCH /auth/profile`. Authentication is now by **username** (collab has no email login); the profile dialog's language preference moves into `preferences.locale`. `AuthCredentials` is now `{ username, password }` and `PersonalFileSourceOptions.user` is `{ id, username }`.

--- a/docx-editor/e2e/tests/autosave-indicator.spec.ts
+++ b/docx-editor/e2e/tests/autosave-indicator.spec.ts
@@ -12,15 +12,12 @@ import { expect, test } from '@playwright/test';
 
 async function mockAuthAlwaysSignedIn(page: import('@playwright/test').Page) {
   await page.route('**/auth/me', async (route) => {
+    // collab wraps /auth/me as { user } with a numeric id + username.
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
-        userId: 'user_42',
-        email: 'alex@example.com',
-        displayName: 'Alex',
-        isAdmin: false,
-        createdAt: '2026-01-01T00:00:00Z',
+        user: { id: 42, username: 'alex', isAdmin: false, createdAt: 1_700_000_000_000 },
       }),
     });
   });

--- a/docx-editor/e2e/tests/personal-auth-gate.spec.ts
+++ b/docx-editor/e2e/tests/personal-auth-gate.spec.ts
@@ -1,44 +1,48 @@
 /**
  * PersonalAuthGate end-to-end: drives the React modal at
  * /examples/vite/src/App.tsx in `?e2e=auth-gate` mode against a
- * mocked Casual gateway.
+ * mocked collab server.
  *
- * The Casual gateway isn't running during the Playwright suite —
+ * The collab server isn't running during the Playwright suite —
  * `page.route()` intercepts every /auth/* request and replies with a
- * fixture matching the real backend's JSON envelope shape (see
- * backend/internal/auth/personal/routes.go).
+ * fixture matching collab's JSON envelope shape (see
+ * CasualOffice/collab src/auth/personal-routes.ts): users wrap as
+ * `{ user }`, profiles as `{ user, profile }` / `{ profile }`, errors
+ * as `{ error }`. collab authenticates by username, not email.
  *
  * Each scenario tests one flow:
  *   - login happy path → modal hides, signed-in surface renders
  *   - login wrong password → inline error
  *   - login → toggle to signup → create account → modal hides
  *   - signup weak password → inline error
- *   - email already signed in (/auth/me 200 first) → modal never renders
+ *   - already signed in (/auth/me 200 first) → modal never renders
  */
 import { expect, test } from '@playwright/test';
 
 interface AuthState {
   /** Mocked /auth/me result. Starts unauth'd; flips to signed-in after login/signup. */
   signedIn: boolean;
-  user: { userId: string; email: string; displayName: string; isAdmin: boolean; createdAt: string };
+  user: { id: number; username: string; isAdmin: boolean; createdAt: number };
 }
 
 const DEFAULT_USER = {
-  userId: 'user_42',
-  email: 'alex@example.com',
-  displayName: 'Alex',
+  id: 42,
+  username: 'alex',
   isAdmin: false,
-  createdAt: '2026-01-01T00:00:00Z',
+  createdAt: 1_700_000_000_000,
 };
 
-async function mockAuth(page: import('@playwright/test').Page, opts?: {
-  /** Initial signed-in state. Default false (gate opens immediately). */
-  signedInAtBoot?: boolean;
-  /** Override the password the login mock accepts. Default 'passw0rd!'. */
-  goodPassword?: string;
-  /** Override the email the signup mock rejects as taken. Default null. */
-  takenEmail?: string;
-}) {
+async function mockAuth(
+  page: import('@playwright/test').Page,
+  opts?: {
+    /** Initial signed-in state. Default false (gate opens immediately). */
+    signedInAtBoot?: boolean;
+    /** Override the password the login mock accepts. Default 'passw0rd!'. */
+    goodPassword?: string;
+    /** Override the username the signup mock rejects as taken. Default null. */
+    takenUsername?: string;
+  }
+) {
   const state: AuthState = {
     signedIn: opts?.signedInAtBoot ?? false,
     user: { ...DEFAULT_USER },
@@ -47,12 +51,16 @@ async function mockAuth(page: import('@playwright/test').Page, opts?: {
 
   await page.route('**/auth/me', async (route) => {
     if (state.signedIn) {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state.user) });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ user: state.user }),
+      });
     } else {
       await route.fulfill({
         status: 401,
         contentType: 'application/json',
-        body: JSON.stringify({ code: 'not_authenticated', message: 'no session' }),
+        body: JSON.stringify({ error: 'unauthenticated' }),
       });
     }
   });
@@ -63,22 +71,26 @@ async function mockAuth(page: import('@playwright/test').Page, opts?: {
       await route.fulfill({
         status: 401,
         contentType: 'application/json',
-        body: JSON.stringify({ code: 'invalid_credentials', message: 'no match' }),
+        body: JSON.stringify({ error: 'invalid-credentials' }),
       });
       return;
     }
     state.signedIn = true;
-    state.user.email = body.email;
-    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(state.user) });
+    state.user.username = body.username;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ user: state.user }),
+    });
   });
 
   await page.route('**/auth/signup', async (route) => {
     const body = JSON.parse(route.request().postData() ?? '{}');
-    if (opts?.takenEmail && body.email === opts.takenEmail) {
+    if (opts?.takenUsername && body.username === opts.takenUsername) {
       await route.fulfill({
         status: 409,
         contentType: 'application/json',
-        body: JSON.stringify({ code: 'email_taken', message: 'already' }),
+        body: JSON.stringify({ error: 'username-taken' }),
       });
       return;
     }
@@ -86,14 +98,17 @@ async function mockAuth(page: import('@playwright/test').Page, opts?: {
       await route.fulfill({
         status: 400,
         contentType: 'application/json',
-        body: JSON.stringify({ code: 'weak_password', message: 'too short' }),
+        body: JSON.stringify({ error: 'weak-password' }),
       });
       return;
     }
     state.signedIn = true;
-    state.user.email = body.email;
-    if (body.displayName) state.user.displayName = body.displayName;
-    await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(state.user) });
+    state.user.username = body.username;
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({ user: state.user }),
+    });
   });
 }
 
@@ -102,7 +117,7 @@ test.describe('PersonalAuthGate', () => {
     await mockAuth(page);
     await page.goto('/?e2e=auth-gate');
     await expect(page.getByTestId('personal-auth-gate')).toBeVisible();
-    await expect(page.getByTestId('personal-auth-email')).toBeVisible();
+    await expect(page.getByTestId('personal-auth-username')).toBeVisible();
     await expect(page.getByTestId('personal-auth-password')).toBeVisible();
     // Submit disabled until both fields are filled.
     await expect(page.getByTestId('personal-auth-submit')).toBeDisabled();
@@ -111,7 +126,7 @@ test.describe('PersonalAuthGate', () => {
   test('login happy path → modal hides + signed-in content renders', async ({ page }) => {
     await mockAuth(page);
     await page.goto('/?e2e=auth-gate');
-    await page.getByTestId('personal-auth-email').fill('alex@example.com');
+    await page.getByTestId('personal-auth-username').fill('alex');
     await page.getByTestId('personal-auth-password').fill('passw0rd!');
     await page.getByTestId('personal-auth-submit').click();
     await expect(page.getByTestId('signed-in-content')).toBeVisible();
@@ -121,7 +136,7 @@ test.describe('PersonalAuthGate', () => {
   test('login wrong password → inline error, modal stays open', async ({ page }) => {
     await mockAuth(page);
     await page.goto('/?e2e=auth-gate');
-    await page.getByTestId('personal-auth-email').fill('alex@example.com');
+    await page.getByTestId('personal-auth-username').fill('alex');
     await page.getByTestId('personal-auth-password').fill('wrongpass');
     await page.getByTestId('personal-auth-submit').click();
     await expect(page.getByTestId('personal-auth-error')).toContainText(/don.t match/i);
@@ -134,9 +149,8 @@ test.describe('PersonalAuthGate', () => {
     await page.getByTestId('personal-auth-toggle').click();
     // Submit button label flips after toggle.
     await expect(page.getByTestId('personal-auth-submit')).toContainText(/create account/i);
-    await page.getByTestId('personal-auth-email').fill('new@example.com');
+    await page.getByTestId('personal-auth-username').fill('newuser');
     await page.getByTestId('personal-auth-password').fill('passw0rd!');
-    await page.getByTestId('personal-auth-displayname').fill('New User');
     await page.getByTestId('personal-auth-submit').click();
     await expect(page.getByTestId('signed-in-content')).toBeVisible();
   });
@@ -145,18 +159,15 @@ test.describe('PersonalAuthGate', () => {
     await mockAuth(page);
     await page.goto('/?e2e=auth-gate');
     await page.getByTestId('personal-auth-toggle').click();
-    await page.getByTestId('personal-auth-email').fill('new@example.com');
-    // 8+ chars satisfies the HTML5 minLength so we POST and the
-    // server-side check kicks in. Here we fake "weak" via 9 chars
-    // that the mock treats as too short by forcing a 400.
+    await page.getByTestId('personal-auth-username').fill('newuser');
+    // 8 chars satisfies the HTML5 minLength so we POST; the mock below
+    // forces the server-side weak-password rejection.
     await page.getByTestId('personal-auth-password').fill('passw0rd');
-    // Override the mock to reject this length: set up a fresh route
-    // that always returns weak_password.
     await page.route('**/auth/signup', async (route) => {
       await route.fulfill({
         status: 400,
         contentType: 'application/json',
-        body: JSON.stringify({ code: 'weak_password', message: 'too short' }),
+        body: JSON.stringify({ error: 'weak-password' }),
       });
     });
     await page.getByTestId('personal-auth-submit').click();
@@ -170,11 +181,11 @@ test.describe('PersonalAuthGate', () => {
     await expect(page.getByTestId('personal-auth-gate')).toBeHidden();
   });
 
-  test('UserMenu — shows displayName and toggles dropdown', async ({ page }) => {
+  test('UserMenu — shows the username and toggles dropdown', async ({ page }) => {
     await mockAuth(page, { signedInAtBoot: true });
     await page.goto('/?e2e=auth-gate');
     await expect(page.getByTestId('user-menu')).toBeVisible();
-    await expect(page.getByTestId('user-menu')).toContainText('Alex');
+    await expect(page.getByTestId('user-menu')).toContainText('alex');
     // Dropdown is hidden until the trigger is clicked.
     await expect(page.getByTestId('user-menu-dropdown')).toBeHidden();
     await page.getByTestId('user-menu').click();
@@ -185,8 +196,6 @@ test.describe('PersonalAuthGate', () => {
   test('sign-out → /auth/logout fires + modal returns', async ({ page }) => {
     let logoutCalled = false;
     await mockAuth(page, { signedInAtBoot: true });
-    // Wire the logout mock — flips the shared state back to
-    // unauth'd so the gate re-renders the modal.
     await page.route('**/auth/logout', async (route) => {
       logoutCalled = true;
       // Re-route /auth/me to 401 so the gate's next probe sees the
@@ -195,7 +204,7 @@ test.describe('PersonalAuthGate', () => {
         await subroute.fulfill({
           status: 401,
           contentType: 'application/json',
-          body: JSON.stringify({ code: 'not_authenticated', message: 'no session' }),
+          body: JSON.stringify({ error: 'unauthenticated' }),
         });
       });
       await route.fulfill({ status: 204 });
@@ -217,13 +226,13 @@ test.describe('PersonalAuthGate', () => {
     await mockAuth(page, { signedInAtBoot: true });
 
     let profileGets = 0;
-    let putBody: Record<string, unknown> | null = null;
-    const profileState = {
-      userId: 'user_42',
-      email: 'alex@example.com',
+    let patchBody: Record<string, unknown> | null = null;
+    const profile = {
       displayName: 'Alex',
+      email: 'alex@example.com',
       timezone: 'America/Los_Angeles',
-      locale: 'en-US',
+      hasAvatar: false,
+      preferences: { locale: 'en-US' } as Record<string, unknown>,
     };
     await page.route('**/auth/profile', async (route) => {
       const req = route.request();
@@ -232,15 +241,15 @@ test.describe('PersonalAuthGate', () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify(profileState),
+          body: JSON.stringify({ user: DEFAULT_USER, profile }),
         });
-      } else if (req.method() === 'PUT') {
-        putBody = JSON.parse(req.postData() ?? '{}');
-        Object.assign(profileState, putBody);
+      } else if (req.method() === 'PATCH') {
+        patchBody = JSON.parse(req.postData() ?? '{}');
+        Object.assign(profile, patchBody);
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify(profileState),
+          body: JSON.stringify({ profile }),
         });
       } else {
         await route.fallback();
@@ -262,12 +271,13 @@ test.describe('PersonalAuthGate', () => {
     await page.getByTestId('profile-settings-timezone').fill('UTC');
     await page.getByTestId('profile-settings-save').click();
 
-    // Dialog closes + PUT carried the patch + UserMenu updated.
+    // Dialog closes + PATCH carried the patch (locale preserved in
+    // preferences) + UserMenu updated.
     await expect(page.getByTestId('profile-settings')).toBeHidden();
-    expect(putBody).toEqual({
+    expect(patchBody).toEqual({
       displayName: 'Alex Tomato',
       timezone: 'UTC',
-      locale: 'en-US',
+      preferences: { locale: 'en-US' },
     });
     await expect(page.getByTestId('user-menu')).toContainText('Alex Tomato');
   });
@@ -280,14 +290,18 @@ test.describe('PersonalAuthGate', () => {
           status: 200,
           contentType: 'application/json',
           body: JSON.stringify({
-            userId: 'u',
-            email: 'alex@example.com',
-            displayName: 'Alex',
-            timezone: 'UTC',
+            user: DEFAULT_USER,
+            profile: {
+              displayName: 'Alex',
+              email: 'alex@example.com',
+              timezone: 'UTC',
+              hasAvatar: false,
+              preferences: {},
+            },
           }),
         });
       } else {
-        // PUT should never fire from this test.
+        // PATCH should never fire from this test.
         await route.fulfill({ status: 500, body: 'should not be called' });
       }
     });
@@ -297,8 +311,8 @@ test.describe('PersonalAuthGate', () => {
     await page.getByTestId('profile-settings-displayname').fill('changed-but-cancelled');
     await page.getByTestId('profile-settings-cancel').click();
     await expect(page.getByTestId('profile-settings')).toBeHidden();
-    // UserMenu still shows the original name.
-    await expect(page.getByTestId('user-menu')).toContainText('Alex');
+    // UserMenu still shows the original identity.
+    await expect(page.getByTestId('user-menu')).toContainText('alex');
   });
 
   test('forgot-password — link visible in login mode, reveals CLI instructions', async ({
@@ -310,18 +324,16 @@ test.describe('PersonalAuthGate', () => {
     await expect(page.getByTestId('personal-auth-forgot-toggle')).toBeVisible();
     // Panel is hidden until the link is clicked.
     await expect(page.getByTestId('personal-auth-forgot-panel')).toBeHidden();
-    // Pre-filling email so the rendered command shows the user's address.
-    await page.getByTestId('personal-auth-email').fill('alex@example.com');
+    // Pre-filling username so the rendered command shows the account.
+    await page.getByTestId('personal-auth-username').fill('alex');
     await page.getByTestId('personal-auth-forgot-toggle').click();
     const panel = page.getByTestId('personal-auth-forgot-panel');
     await expect(panel).toBeVisible();
     await expect(panel).toContainText('casual-docs reset-password');
-    await expect(panel).toContainText('alex@example.com');
+    await expect(panel).toContainText('alex');
   });
 
-  test('forgot-password — link hidden in signup mode + collapses on toggle', async ({
-    page,
-  }) => {
+  test('forgot-password — link hidden in signup mode + collapses on toggle', async ({ page }) => {
     await mockAuth(page);
     await page.goto('/?e2e=auth-gate');
     await page.getByTestId('personal-auth-forgot-toggle').click();

--- a/docx-editor/packages/react/src/file-source/PersonalAuthGate.tsx
+++ b/docx-editor/packages/react/src/file-source/PersonalAuthGate.tsx
@@ -9,12 +9,12 @@
  *
  *   - Single dialog, no dismiss (no backdrop click, no Esc) — Mode 3
  *     requires auth before anything else renders.
- *   - Email + password fields, autocomplete hints set so password
- *     managers can fill cleanly.
- *   - Login ↔ Signup toggle below the form. Signup mode adds an
- *     optional displayName.
- *   - Inline error rendering — server's `{code, message}` envelope
- *     becomes a human-readable string above the submit button.
+ *   - Username + password fields, autocomplete hints set so password
+ *     managers can fill cleanly. (collab authenticates by username; the
+ *     display name is set later via the profile dialog.)
+ *   - Login ↔ Signup toggle below the form.
+ *   - Inline error rendering — collab's `{ error }` envelope becomes a
+ *     human-readable string above the submit button.
  *   - Submit on Enter via standard <form> behavior.
  *
  * The gate constructs its own AuthClient by default; tests or
@@ -93,8 +93,8 @@ export interface UsePersonalAuthOptions {
 
 export interface UsePersonalAuthReturn {
   state: AuthState;
-  login: (email: string, password: string) => Promise<void>;
-  signup: (email: string, password: string, displayName?: string) => Promise<void>;
+  login: (username: string, password: string) => Promise<void>;
+  signup: (username: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
 }
 
@@ -153,9 +153,9 @@ export function usePersonalAuth(opts: UsePersonalAuthOptions = {}): UsePersonalA
   }, [client]);
 
   const login = useCallback(
-    async (email: string, password: string) => {
+    async (username: string, password: string) => {
       try {
-        const user = await client.login({ email, password });
+        const user = await client.login({ username, password });
         setState({ status: 'authed', user });
         onAuthRef.current?.(user);
       } catch (err) {
@@ -168,9 +168,9 @@ export function usePersonalAuth(opts: UsePersonalAuthOptions = {}): UsePersonalA
   );
 
   const signup = useCallback(
-    async (email: string, password: string, displayName?: string) => {
+    async (username: string, password: string) => {
       try {
-        const user = await client.signup({ email, password, displayName });
+        const user = await client.signup({ username, password });
         setState({ status: 'authed', user });
         onAuthRef.current?.(user);
       } catch (err) {
@@ -252,9 +252,9 @@ export function PersonalAuthGate({
       initialMode={initialMode}
       onSubmit={async (mode, creds) => {
         if (mode === 'login') {
-          await login(creds.email, creds.password);
+          await login(creds.username, creds.password);
         } else {
-          await signup(creds.email, creds.password, creds.displayName);
+          await signup(creds.username, creds.password);
         }
       }}
       submitError={state.status === 'unauthed' ? state.error : null}
@@ -279,7 +279,7 @@ interface PersonalAuthGateModalProps {
    */
   onSubmit: (
     mode: 'login' | 'signup',
-    creds: { email: string; password: string; displayName?: string }
+    creds: { username: string; password: string }
   ) => Promise<void>;
   submitError: PersonalFileSourceError | null;
   /** True during the initial /auth/me probe — disables Sign in. */
@@ -295,9 +295,8 @@ export function PersonalAuthGateModal({
   loading,
 }: PersonalAuthGateModalProps) {
   const [mode, setMode] = useState<'login' | 'signup'>(initialMode);
-  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [displayName, setDisplayName] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [forgotOpen, setForgotOpen] = useState(false);
 
@@ -307,9 +306,8 @@ export function PersonalAuthGateModal({
     setSubmitting(true);
     try {
       await onSubmit(mode, {
-        email: email.trim(),
+        username: username.trim(),
         password,
-        displayName: displayName.trim() || undefined,
       });
     } catch {
       // Error rendered via submitError prop; no extra handling here.
@@ -334,9 +332,9 @@ export function PersonalAuthGateModal({
         <button
           type="submit"
           form="personal-auth-form"
-          disabled={submitting || loading || !email || !password}
+          disabled={submitting || loading || !username || !password}
           data-testid="personal-auth-submit"
-          style={primaryButtonStyle(submitting || loading || !email || !password)}
+          style={primaryButtonStyle(submitting || loading || !username || !password)}
         >
           {submitting
             ? mode === 'login'
@@ -367,15 +365,18 @@ export function PersonalAuthGateModal({
         style={{ display: 'flex', flexDirection: 'column', gap: 14 }}
       >
         <label style={labelStyle}>
-          <span style={labelTextStyle}>Email</span>
+          <span style={labelTextStyle}>Username</span>
           <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            autoComplete="email"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            autoComplete="username"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
             autoFocus
             required
-            data-testid="personal-auth-email"
+            data-testid="personal-auth-username"
             style={inputStyle}
           />
         </label>
@@ -392,19 +393,6 @@ export function PersonalAuthGateModal({
             style={inputStyle}
           />
         </label>
-        {mode === 'signup' && (
-          <label style={labelStyle}>
-            <span style={labelTextStyle}>Display name (optional)</span>
-            <input
-              type="text"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              autoComplete="name"
-              data-testid="personal-auth-displayname"
-              style={inputStyle}
-            />
-          </label>
-        )}
         {mode === 'login' && (
           <div style={forgotWrapStyle}>
             <button
@@ -421,7 +409,7 @@ export function PersonalAuthGateModal({
                 Mode 3 doesn’t do email recovery — there’s no SMTP server on a single-node deploy.
                 Ask the operator to ssh into the container and run:
                 <pre style={forgotCodeStyle}>
-                  casual-docs reset-password {email || '<your-email>'}
+                  casual-docs reset-password {username || '<your-username>'}
                 </pre>
                 They’ll set a new password for you to sign in with.
               </div>
@@ -430,7 +418,7 @@ export function PersonalAuthGateModal({
         )}
         {submitError && (
           <div data-testid="personal-auth-error" style={errorStyle}>
-            {humanReadable(submitError, mode)}
+            {humanReadable(submitError)}
           </div>
         )}
       </form>
@@ -442,18 +430,25 @@ export function PersonalAuthGateModal({
 // Helpers
 // ---------------------------------------------------------------
 
-function humanReadable(err: PersonalFileSourceError, mode: 'login' | 'signup'): string {
+function humanReadable(err: PersonalFileSourceError): string {
+  // Codes mirror collab's `{ error }` envelope (auth/personal-routes.ts +
+  // the createUser / verifyLogin reasons in auth/personal.ts).
   switch (err.code) {
-    case 'invalid_credentials':
-      return 'That email and password don’t match an account.';
-    case 'email_taken':
-      return 'An account with that email already exists. Try signing in.';
-    case 'invalid_email':
-      return 'That doesn’t look like a valid email address.';
-    case 'weak_password':
+    case 'invalid-credentials':
+      return 'That username and password don’t match an account.';
+    case 'username-taken':
+      return 'That username is already taken. Try signing in.';
+    case 'invalid-username':
+      return 'That username isn’t allowed. Use letters, numbers, dot, dash or underscore.';
+    case 'weak-password':
       return 'Password must be at least 8 characters.';
-    case 'not_authenticated':
-      return mode === 'login' ? 'Please sign in to continue.' : 'Could not create the account.';
+    case 'signup-closed':
+      return 'Sign-ups are closed on this server. Ask the operator for an account.';
+    case 'personal-mode-disabled':
+    case 'mode-disabled':
+      return 'Accounts aren’t enabled on this server.';
+    case 'bad-body':
+      return 'Please enter a username and password.';
     default:
       return err.message || 'Something went wrong. Please try again.';
   }

--- a/docx-editor/packages/react/src/file-source/ProfileSettingsDialog.tsx
+++ b/docx-editor/packages/react/src/file-source/ProfileSettingsDialog.tsx
@@ -2,14 +2,14 @@
  * ProfileSettingsDialog — edit the signed-in user's extended profile.
  *
  * Loads the current profile from GET /auth/profile on open, lets the
- * user edit displayName + timezone + locale, posts the changes via
- * PUT /auth/profile, closes on success. Cancel discards.
+ * user edit displayName + timezone + language, posts the changes via
+ * PATCH /auth/profile, closes on success. Cancel discards.
  *
- * Backend-side identity routing: displayName lands on the SQLite
- * users table (so /auth/me reflects the update on next probe); the
- * other fields land in the .profile.json sidecar. The web client
- * doesn't need to think about that split — a single PUT carries the
- * full patch.
+ * collab stores `displayName` / `email` / `timezone` as first-class
+ * profile columns and everything else (here: `locale`) in the
+ * free-form `preferences` JSON blob. The dialog reads/writes
+ * `preferences.locale` and merges it back so other preference keys
+ * are preserved.
  *
  * Reuses the editor's Dialog shell so visual + motion language match
  * every other modal.
@@ -78,7 +78,7 @@ export function ProfileSettingsDialog({
         setLoad({ status: 'loaded', profile });
         setDisplayName(profile.displayName ?? '');
         setTimezone(profile.timezone ?? '');
-        setLocale(profile.locale ?? '');
+        setLocale(localeOf(profile));
       } catch (err) {
         if (cancelled) return;
         setLoad({
@@ -98,10 +98,13 @@ export function ProfileSettingsDialog({
     setSaving(true);
     setSaveError(null);
     try {
+      // Merge locale into the existing preferences blob so we don't
+      // clobber any other keys collab is round-tripping for us.
+      const basePrefs = load.status === 'loaded' ? load.profile.preferences : {};
       const next = await client.updateProfile({
         displayName: displayName.trim(),
         timezone: timezone.trim(),
-        locale: locale.trim(),
+        preferences: { ...basePrefs, locale: locale.trim() },
       });
       onSaved?.(next);
       onClose();
@@ -216,11 +219,19 @@ export function ProfileSettingsDialog({
 // Helpers + styles
 // ---------------------------------------------------------------
 
+/** Reads the BCP-47 language tag out of collab's free-form preferences. */
+function localeOf(profile: ProfileWire): string {
+  const v = profile.preferences?.locale;
+  return typeof v === 'string' ? v : '';
+}
+
 function humanReadable(err: PersonalFileSourceError): string {
+  // collab PATCH /auth/profile → 409 'conflict-or-invalid', 401
+  // 'unauthenticated'.
   switch (err.code) {
-    case 'display_name':
-      return 'Display name cannot be empty.';
-    case 'not_authenticated':
+    case 'conflict-or-invalid':
+      return 'That display name or email is invalid or already in use.';
+    case 'unauthenticated':
       return 'Your session has expired. Sign in again.';
     default:
       return err.message || 'Could not save. Please try again.';

--- a/docx-editor/packages/react/src/file-source/UserMenu.tsx
+++ b/docx-editor/packages/react/src/file-source/UserMenu.tsx
@@ -52,13 +52,18 @@ export function UserMenu({ className, onLogout, authClient, testId = 'user-menu'
   const [signingOut, setSigningOut] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
   // Locally-overridden displayName so the trigger updates the moment
-  // the profile dialog saves, without waiting for the gate to
-  // re-probe /auth/me. Falls back to the context's user.displayName
-  // when no override exists.
+  // the profile dialog saves. The context user only carries the
+  // username (collab's PublicUser has no displayName); the friendly
+  // name lives in the profile and is only known once the dialog loads
+  // or saves it. Until then we fall back to the username.
   const [displayNameOverride, setDisplayNameOverride] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
 
-  const effectiveDisplayName = displayNameOverride ?? user.displayName;
+  const effectiveDisplayName = displayNameOverride || user.username;
+  // Show the @handle as a secondary line only when a friendly display
+  // name is set — otherwise the primary line already IS the username.
+  const secondaryHandle =
+    displayNameOverride && displayNameOverride !== user.username ? `@${user.username}` : null;
 
   // Close on outside click — mousedown so the dropdown closes before
   // any other click handler fires.
@@ -100,14 +105,14 @@ export function UserMenu({ className, onLogout, authClient, testId = 'user-menu'
     }
   };
 
-  const initials = displayInitials(effectiveDisplayName || user.email);
+  const initials = displayInitials(effectiveDisplayName);
 
   const handleOpenProfile = () => {
     setOpen(false);
     setProfileOpen(true);
   };
   const handleProfileSaved = (profile: ProfileWire) => {
-    setDisplayNameOverride(profile.displayName);
+    setDisplayNameOverride(profile.displayName ?? null);
   };
 
   return (
@@ -124,7 +129,7 @@ export function UserMenu({ className, onLogout, authClient, testId = 'user-menu'
         <span style={initialsStyle} aria-hidden="true">
           {initials}
         </span>
-        <span style={triggerLabelStyle}>{effectiveDisplayName || user.email}</span>
+        <span style={triggerLabelStyle}>{effectiveDisplayName}</span>
         <svg
           width="14"
           height="14"
@@ -140,8 +145,8 @@ export function UserMenu({ className, onLogout, authClient, testId = 'user-menu'
       {open && (
         <div role="menu" style={dropdownStyle} data-testid={`${testId}-dropdown`}>
           <div style={dropdownHeaderStyle}>
-            <div style={dropdownNameStyle}>{effectiveDisplayName || user.email}</div>
-            {effectiveDisplayName && <div style={dropdownEmailStyle}>{user.email}</div>}
+            <div style={dropdownNameStyle}>{effectiveDisplayName}</div>
+            {secondaryHandle && <div style={dropdownEmailStyle}>{secondaryHandle}</div>}
           </div>
           <div style={dropdownDividerStyle} />
           <button

--- a/docx-editor/packages/react/src/file-source/auth-client.test.ts
+++ b/docx-editor/packages/react/src/file-source/auth-client.test.ts
@@ -22,7 +22,7 @@ function makeHarness() {
       respond = fn;
     },
     client: new AuthClient({
-      baseUrl: 'http://gateway.test',
+      baseUrl: 'http://collab.test',
       fetchImpl: fetchImpl as unknown as typeof fetch,
     }),
   };
@@ -36,30 +36,35 @@ function jsonRes(status: number, body: unknown): Response {
 }
 
 const ALEX = {
-  userId: 'user_42',
-  email: 'alex@example.com',
-  displayName: 'Alex',
+  id: 42,
+  username: 'alex',
   isAdmin: false,
-  createdAt: '2026-01-01T00:00:00Z',
+  createdAt: 1_700_000_000_000,
 };
 
 describe('AuthClient', () => {
-  it('me() returns the user on 200', async () => {
+  it('me() unwraps { user } on 200', async () => {
     const h = makeHarness();
-    h.setRespond(() => jsonRes(200, ALEX));
+    h.setRespond(() => jsonRes(200, { user: ALEX }));
     const u = await h.client.me();
     expect(u).toEqual(ALEX);
-    expect(h.calls[0].url).toBe('http://gateway.test/auth/me');
+    expect(h.calls[0].url).toBe('http://collab.test/auth/me');
     expect(h.calls[0].init?.credentials).toBe('include');
   });
 
   it('me() returns null on 401 (no session)', async () => {
     const h = makeHarness();
-    h.setRespond(() => jsonRes(401, { code: 'not_authenticated', message: 'no session' }));
+    h.setRespond(() => jsonRes(401, { error: 'unauthenticated' }));
     expect(await h.client.me()).toBeNull();
   });
 
-  it('me() throws on a 5xx (gateway down)', async () => {
+  it('me() returns null on 503 (personal mode disabled)', async () => {
+    const h = makeHarness();
+    h.setRespond(() => jsonRes(503, { error: 'personal-mode-disabled' }));
+    expect(await h.client.me()).toBeNull();
+  });
+
+  it('me() throws on a 5xx (collab down)', async () => {
     const h = makeHarness();
     h.setRespond(() => new Response('upstream down', { status: 502 }));
     try {
@@ -71,67 +76,63 @@ describe('AuthClient', () => {
     }
   });
 
-  it('login() POSTs the credentials and returns the user', async () => {
+  it('login() POSTs username + password and unwraps the user', async () => {
     const h = makeHarness();
-    h.setRespond(() => jsonRes(200, ALEX));
-    const u = await h.client.login({ email: 'alex@example.com', password: 'passw0rd!' });
+    h.setRespond(() => jsonRes(200, { user: ALEX }));
+    const u = await h.client.login({ username: 'alex', password: 'passw0rd!' });
     expect(u).toEqual(ALEX);
-    expect(h.calls[0].url).toBe('http://gateway.test/auth/login');
+    expect(h.calls[0].url).toBe('http://collab.test/auth/login');
     expect(h.calls[0].init?.method).toBe('POST');
     expect(JSON.parse(h.calls[0].init?.body as string)).toEqual({
-      email: 'alex@example.com',
+      username: 'alex',
       password: 'passw0rd!',
     });
   });
 
-  it('login() throws with code=invalid_credentials on 401', async () => {
+  it('login() throws with code=invalid-credentials on 401', async () => {
     const h = makeHarness();
-    h.setRespond(() => jsonRes(401, { code: 'invalid_credentials', message: 'no match' }));
+    h.setRespond(() => jsonRes(401, { error: 'invalid-credentials' }));
     try {
-      await h.client.login({ email: 'a@b', password: 'wrong' });
+      await h.client.login({ username: 'alex', password: 'wrong' });
       throw new Error('expected throw');
     } catch (err) {
       const e = err as PersonalFileSourceError;
       expect(e).toBeInstanceOf(PersonalFileSourceError);
       expect(e.status).toBe(401);
-      expect(e.code).toBe('invalid_credentials');
+      expect(e.code).toBe('invalid-credentials');
     }
   });
 
-  it('signup() includes displayName in the body when present', async () => {
+  it('signup() POSTs username + password only', async () => {
     const h = makeHarness();
-    h.setRespond(() => jsonRes(201, ALEX));
-    await h.client.signup({
-      email: 'alex@example.com',
-      password: 'passw0rd!',
-      displayName: 'Alex',
-    });
+    h.setRespond(() => jsonRes(201, { user: ALEX }));
+    await h.client.signup({ username: 'alex', password: 'passw0rd!' });
+    expect(h.calls[0].url).toBe('http://collab.test/auth/signup');
     expect(JSON.parse(h.calls[0].init?.body as string)).toEqual({
-      email: 'alex@example.com',
+      username: 'alex',
       password: 'passw0rd!',
-      displayName: 'Alex',
     });
   });
 
-  it('signup() surfaces code=email_taken on 409', async () => {
+  it('signup() surfaces code=username-taken on 409', async () => {
     const h = makeHarness();
-    h.setRespond(() => jsonRes(409, { code: 'email_taken', message: 'already' }));
+    h.setRespond(() => jsonRes(409, { error: 'username-taken' }));
     try {
-      await h.client.signup({ email: 'dup@example.com', password: 'passw0rd!' });
+      await h.client.signup({ username: 'dup', password: 'passw0rd!' });
       throw new Error('expected throw');
     } catch (err) {
-      expect((err as PersonalFileSourceError).code).toBe('email_taken');
+      expect((err as PersonalFileSourceError).code).toBe('username-taken');
     }
   });
 
-  it('signup() surfaces code=weak_password on 400', async () => {
+  it('signup() surfaces code=weak-password on 400', async () => {
     const h = makeHarness();
-    h.setRespond(() => jsonRes(400, { code: 'weak_password', message: 'too short' }));
+    h.setRespond(() => jsonRes(400, { error: 'weak-password' }));
     try {
-      await h.client.signup({ email: 'a@b', password: '123' });
+      await h.client.signup({ username: 'alex', password: '123' });
       throw new Error('expected throw');
     } catch (err) {
-      expect((err as PersonalFileSourceError).code).toBe('weak_password');
+      expect((err as PersonalFileSourceError).code).toBe('weak-password');
     }
   });
 
@@ -139,61 +140,66 @@ describe('AuthClient', () => {
     const h = makeHarness();
     h.setRespond(() => new Response(null, { status: 204 }));
     await h.client.logout();
-    expect(h.calls[0].url).toBe('http://gateway.test/auth/logout');
+    expect(h.calls[0].url).toBe('http://collab.test/auth/logout');
     expect(h.calls[0].init?.method).toBe('POST');
     expect(h.calls[0].init?.credentials).toBe('include');
   });
 
-  it('getProfile() GETs /auth/profile and returns the merged view', async () => {
+  it('getProfile() GETs /auth/profile and unwraps { profile }', async () => {
     const h = makeHarness();
     h.setRespond(() =>
       jsonRes(200, {
-        userId: 'user_42',
-        email: 'alex@example.com',
-        displayName: 'Alex',
-        timezone: 'America/Los_Angeles',
-        locale: 'en-US',
-        prefs: { showRulers: true },
+        user: ALEX,
+        profile: {
+          displayName: 'Alex',
+          email: 'alex@example.com',
+          timezone: 'America/Los_Angeles',
+          hasAvatar: false,
+          preferences: { locale: 'en-US' },
+        },
       })
     );
     const profile = await h.client.getProfile();
-    expect(h.calls[0].url).toBe('http://gateway.test/auth/profile');
+    expect(h.calls[0].url).toBe('http://collab.test/auth/profile');
     expect(h.calls[0].init?.credentials).toBe('include');
     expect(profile.timezone).toBe('America/Los_Angeles');
-    expect(profile.locale).toBe('en-US');
+    expect((profile.preferences as { locale: string }).locale).toBe('en-US');
   });
 
-  it('updateProfile() PUTs the patch and returns the refreshed view', async () => {
+  it('updateProfile() PATCHes the patch and unwraps { profile }', async () => {
     const h = makeHarness();
     h.setRespond(() =>
       jsonRes(200, {
-        userId: 'user_42',
-        email: 'alex@example.com',
-        displayName: 'Alex Tomato',
-        timezone: 'UTC',
+        profile: {
+          displayName: 'Alex Tomato',
+          email: null,
+          timezone: 'UTC',
+          hasAvatar: false,
+          preferences: {},
+        },
       })
     );
     const result = await h.client.updateProfile({
       displayName: 'Alex Tomato',
       timezone: 'UTC',
     });
-    expect(h.calls[0].url).toBe('http://gateway.test/auth/profile');
-    expect(h.calls[0].init?.method).toBe('PUT');
+    expect(h.calls[0].url).toBe('http://collab.test/auth/profile');
+    expect(h.calls[0].init?.method).toBe('PATCH');
     const body = JSON.parse((h.calls[0].init?.body as string) ?? '{}');
     expect(body).toEqual({ displayName: 'Alex Tomato', timezone: 'UTC' });
     expect(result.displayName).toBe('Alex Tomato');
   });
 
-  it('updateProfile() surfaces 400 errors with the code', async () => {
+  it('updateProfile() surfaces 409 errors with the code', async () => {
     const h = makeHarness();
-    h.setRespond(() => jsonRes(400, { code: 'display_name', message: 'empty' }));
+    h.setRespond(() => jsonRes(409, { error: 'conflict-or-invalid' }));
     try {
       await h.client.updateProfile({ displayName: '' });
       throw new Error('expected throw');
     } catch (err) {
       const e = err as PersonalFileSourceError;
-      expect(e.code).toBe('display_name');
-      expect(e.status).toBe(400);
+      expect(e.code).toBe('conflict-or-invalid');
+      expect(e.status).toBe(409);
     }
   });
 
@@ -201,7 +207,7 @@ describe('AuthClient', () => {
     const h = makeHarness();
     h.setRespond(() => new Response('plain html 502', { status: 502 }));
     try {
-      await h.client.login({ email: 'a@b', password: 'x' });
+      await h.client.login({ username: 'alex', password: 'x' });
       throw new Error('expected throw');
     } catch (err) {
       const e = err as PersonalFileSourceError;

--- a/docx-editor/packages/react/src/file-source/auth-client.ts
+++ b/docx-editor/packages/react/src/file-source/auth-client.ts
@@ -5,12 +5,12 @@
  * is constructed: the file source is only valid once `/auth/me`
  * returns 200.
  *
- * Wire shape mirrors backend/internal/auth/personal/routes.go:
+ * Wire shape mirrors CasualOffice/collab `auth/personal-routes.ts`:
  *
- *   POST /auth/signup  → 201 User, sets session cookie
- *   POST /auth/login   → 200 User, sets session cookie
+ *   POST /auth/signup  → 201 { user }, sets cs_session cookie
+ *   POST /auth/login   → 200 { user }, sets cs_session cookie
  *   POST /auth/logout  → 204
- *   GET  /auth/me      → 200 User | 401
+ *   GET  /auth/me      → 200 { user } | 401 | 503 (personal mode off)
  *
  * All requests use `credentials: 'include'` so the cookie set by
  * signup/login rides along on subsequent calls.
@@ -34,15 +34,14 @@ export interface AuthClientOptions {
 }
 
 /**
- * Credentials passed into login / signup. The signup-only
- * `displayName` is optional — the backend falls back to the email
- * prefix when empty.
+ * Credentials passed into login / signup. collab authenticates by
+ * `username` (not email — email is an optional profile field set
+ * later). The display name is edited post-signup via the profile
+ * dialog, so there's no signup-time displayName.
  */
 export interface AuthCredentials {
-  email: string;
+  username: string;
   password: string;
-  /** Signup only — ignored by login. */
-  displayName?: string;
 }
 
 export class AuthClient {
@@ -70,13 +69,17 @@ export class AuthClient {
     const res = await this.fetchImpl(this.baseUrl + '/auth/me', {
       credentials: 'include',
     });
-    if (res.status === 401) {
+    // 401 = no live session; 503 = personal mode isn't enabled on this
+    // deploy at all. Both mean "no signed-in user here" — the gate
+    // shows login on 401, and a 503 deploy never mounts the gate.
+    if (res.status === 401 || res.status === 503) {
       return null;
     }
     if (!res.ok) {
       throw await this.errorFrom(res);
     }
-    return (await res.json()) as UserWire;
+    const body = (await res.json()) as { user: UserWire };
+    return body.user;
   }
 
   /**
@@ -110,18 +113,19 @@ export class AuthClient {
     if (!res.ok) {
       throw await this.errorFrom(res);
     }
-    return (await res.json()) as ProfileWire;
+    const body = (await res.json()) as { profile: ProfileWire };
+    return body.profile;
   }
 
   /**
-   * PUT /auth/profile. Fields omitted from `patch` are left
-   * unchanged; explicit empty strings clear the field server-side.
-   * Returns the freshly-merged view so the caller can render the
-   * post-update state without a follow-up GET.
+   * PATCH /auth/profile. Fields omitted from `patch` are left
+   * unchanged; null clears displayName / email. Returns the freshly
+   * merged profile so the caller can render the post-update state
+   * without a follow-up GET.
    */
   async updateProfile(patch: ProfilePatchWire): Promise<ProfileWire> {
     const res = await this.fetchImpl(this.baseUrl + '/auth/profile', {
-      method: 'PUT',
+      method: 'PATCH',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(patch),
@@ -129,7 +133,8 @@ export class AuthClient {
     if (!res.ok) {
       throw await this.errorFrom(res);
     }
-    return (await res.json()) as ProfileWire;
+    const body = (await res.json()) as { profile: ProfileWire };
+    return body.profile;
   }
 
   /**
@@ -159,22 +164,24 @@ export class AuthClient {
     if (!res.ok) {
       throw await this.errorFrom(res);
     }
-    return (await res.json()) as UserWire;
+    const body = (await res.json()) as { user: UserWire };
+    return body.user;
   }
 
   /**
-   * Parses the backend's `{ code, message }` envelope into a
-   * PersonalFileSourceError. Falls back to a synthesized envelope
-   * when the response body isn't the expected JSON shape (e.g. a
-   * 502 from an upstream proxy).
+   * Parses collab's `{ error }` envelope into a PersonalFileSourceError.
+   * Falls back to a synthesized envelope when the response body isn't
+   * the expected JSON shape (e.g. a 502 from an upstream proxy).
    */
   private async errorFrom(res: Response): Promise<PersonalFileSourceError> {
     let code = 'http_' + res.status;
     let message = res.statusText;
     try {
       const body = (await res.clone().json()) as ErrorWire;
-      if (body?.code) code = body.code;
-      if (body?.message) message = body.message;
+      if (body?.error) {
+        code = body.error;
+        message = body.error;
+      }
     } catch {
       // Non-JSON error — keep synthesized envelope.
     }

--- a/docx-editor/packages/react/src/file-source/personal.test.ts
+++ b/docx-editor/packages/react/src/file-source/personal.test.ts
@@ -28,8 +28,8 @@ function makeHarness() {
       respond = fn;
     },
     source: new PersonalFileSource({
-      baseUrl: 'http://gateway.test',
-      user: { userId: 'user_abc', displayName: 'Alex' },
+      baseUrl: 'http://collab.test',
+      user: { id: 7, username: 'alex' },
       fetchImpl: fetchImpl as unknown as typeof fetch,
     }),
   };
@@ -40,6 +40,18 @@ function jsonRes(status: number, body: unknown, headers?: Record<string, string>
     status,
     headers: { 'Content-Type': 'application/json', ...(headers ?? {}) },
   });
+}
+
+function file(over: Partial<FileSummaryWire>): FileSummaryWire {
+  return {
+    id: 'doc_a',
+    name: 'Report.docx',
+    size: 1024,
+    etag: 'v4',
+    createdAt: 1_700_000_000_000,
+    modifiedAt: 1_700_000_500_000,
+    ...over,
+  };
 }
 
 beforeEach(() => {
@@ -71,35 +83,35 @@ afterEach(() => {
 });
 
 describe('PersonalFileSource', () => {
-  it('exposes a personal kind + the display-name label', () => {
+  it('exposes a personal kind + the username label', () => {
     const { source } = makeHarness();
     expect(source.kind).toBe('personal');
-    expect(source.label).toBe('Alex');
+    expect(source.label).toBe('alex');
   });
 
-  it('list() maps FileSummaryWire[] into FileEntry[]', async () => {
+  it('list() unwraps { files } into FileEntry[]', async () => {
     const h = makeHarness();
-    const summaries: FileSummaryWire[] = [
-      {
-        docId: 'doc_a',
-        fileName: 'Report.docx',
-        version: 4,
-        savedAt: '2026-05-01T12:00:00Z',
+    const files: FileSummaryWire[] = [
+      file({
+        id: 'doc_a',
+        name: 'Report.docx',
+        etag: 'v4',
         size: 1024,
-      },
-      {
-        docId: 'doc_b',
-        fileName: 'Notes.docx',
-        version: 1,
-        savedAt: '2026-05-02T09:00:00Z',
+        modifiedAt: 1_700_000_000_000,
+      }),
+      file({
+        id: 'doc_b',
+        name: 'Notes.docx',
+        etag: 'v1',
         size: 99,
-      },
+        modifiedAt: 1_700_000_900_000,
+      }),
     ];
-    h.setRespond(() => jsonRes(200, summaries));
+    h.setRespond(() => jsonRes(200, { files }));
 
     const entries = await h.source.list();
     expect(h.calls).toHaveLength(1);
-    expect(h.calls[0].url).toBe('http://gateway.test/files');
+    expect(h.calls[0].url).toBe('http://collab.test/files');
     expect(h.calls[0].init?.credentials).toBe('include');
     expect(entries).toHaveLength(2);
     expect(entries[0]).toMatchObject({
@@ -108,12 +120,13 @@ describe('PersonalFileSource', () => {
       size: 1024,
       source: 'personal',
     });
-    expect(entries[0].modifiedAt).toBe(Date.parse('2026-05-01T12:00:00Z'));
-    // Provenance preserved.
-    expect((entries[0].meta as { version: number }).version).toBe(4);
+    // modifiedAt is already ms-since-epoch — passed through, not parsed.
+    expect(entries[0].modifiedAt).toBe(1_700_000_000_000);
+    // Provenance preserved (etag → meta.version).
+    expect((entries[0].meta as { version: string }).version).toBe('v4');
   });
 
-  it('open() streams .docx bytes and the ETag header', async () => {
+  it('open() streams .docx bytes and the etag header', async () => {
     const h = makeHarness();
     const bytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0xab, 0xcd]);
     h.setRespond(() => {
@@ -121,68 +134,60 @@ describe('PersonalFileSource', () => {
         status: 200,
         headers: {
           'Content-Type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-          'Content-Disposition': "attachment; filename*=UTF-8''Report.docx",
-          ETag: '4',
+          'Content-Disposition': 'attachment; filename="Report.docx"',
+          etag: 'v4',
         },
       });
     });
 
     const result = await h.source.open('doc_a');
-    expect(h.calls[0].url).toBe('http://gateway.test/files/doc_a');
+    expect(h.calls[0].url).toBe('http://collab.test/files/doc_a');
     expect(result.name).toBe('Report.docx');
-    expect(result.etag).toBe('4');
+    expect(result.etag).toBe('v4');
     expect(new Uint8Array(result.bytes)).toEqual(bytes);
   });
 
-  it('save() with id=null POSTs to /files and returns the minted id', async () => {
+  it('save() with id=null multipart-POSTs to /files and returns the minted id', async () => {
     const h = makeHarness();
-    const summary: FileSummaryWire = {
-      docId: 'doc_new',
-      fileName: 'Draft.docx',
-      version: 1,
-      savedAt: '2026-05-03T00:00:00Z',
-      size: 6,
-    };
-    h.setRespond(() => jsonRes(201, summary));
+    h.setRespond(() =>
+      jsonRes(201, { file: file({ id: 'doc_new', name: 'Draft.docx', etag: 'v1' }) })
+    );
 
     const result = await h.source.save(null, new Uint8Array([1, 2, 3, 4, 5, 6]).buffer, {
       name: 'Draft.docx',
     });
-    expect(h.calls[0].url).toBe('http://gateway.test/files');
+    expect(h.calls[0].url).toBe('http://collab.test/files');
     expect(h.calls[0].init?.method).toBe('POST');
-    expect((h.calls[0].init?.headers as Record<string, string>)['X-File-Name']).toBe('Draft.docx');
+    const form = h.calls[0].init?.body as FormData;
+    expect(form).toBeInstanceOf(FormData);
+    expect((form.get('file') as File).name).toBe('Draft.docx');
+    expect(form.get('name')).toBe('Draft.docx');
+    // Must NOT set Content-Type — the browser adds the multipart boundary.
+    expect(
+      (h.calls[0].init?.headers as Record<string, string> | undefined)?.['Content-Type']
+    ).toBeUndefined();
     expect(result.id).toBe('doc_new');
-    expect(result.etag).toBe('1');
+    expect(result.etag).toBe('v1');
   });
 
-  it('save() with an existing id PUTs to /files/:id/contents', async () => {
+  it('save() with an existing id POSTs raw bytes to /files/:id with If-Match', async () => {
     const h = makeHarness();
-    const summary: FileSummaryWire = {
-      docId: 'doc_a',
-      fileName: 'Report.docx',
-      version: 5,
-      savedAt: '2026-05-04T00:00:00Z',
-      size: 7,
-    };
-    h.setRespond(() => jsonRes(200, summary));
+    h.setRespond(() => jsonRes(200, { file: file({ id: 'doc_a', etag: 'v5' }) }));
 
-    const result = await h.source.save('doc_a', new Uint8Array([1, 2, 3, 4, 5, 6, 7]).buffer);
-    expect(h.calls[0].url).toBe('http://gateway.test/files/doc_a/contents');
-    expect(h.calls[0].init?.method).toBe('PUT');
-    expect(result.etag).toBe('5');
+    const result = await h.source.save('doc_a', new Uint8Array([1, 2, 3, 4, 5, 6, 7]).buffer, {
+      etag: 'v4',
+    });
+    expect(h.calls[0].url).toBe('http://collab.test/files/doc_a');
+    expect(h.calls[0].init?.method).toBe('POST');
+    const headers = h.calls[0].init?.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/octet-stream');
+    expect(headers['If-Match']).toBe('v4');
+    expect(result.etag).toBe('v5');
   });
 
-  it('rename() PATCHes and updates the recent observer', async () => {
+  it('rename() PATCHes { name } (204) and updates the recent observer', async () => {
     const h = makeHarness();
-    // Seed the recent list first via list().
-    const summary: FileSummaryWire = {
-      docId: 'doc_a',
-      fileName: 'old.docx',
-      version: 1,
-      savedAt: '2026-05-01T00:00:00Z',
-      size: 1,
-    };
-    h.setRespond(() => jsonRes(200, [summary]));
+    h.setRespond(() => jsonRes(200, { files: [file({ id: 'doc_a', name: 'old.docx' })] }));
     await h.source.list();
 
     let observed: { id: string; name: string }[] = [];
@@ -190,20 +195,23 @@ describe('PersonalFileSource', () => {
       observed = entries.map((e) => ({ id: e.id, name: e.name }));
     });
 
-    h.setRespond(() => jsonRes(200, { fileName: 'new.docx' }));
+    h.setRespond(() => new Response(null, { status: 204 }));
     await h.source.rename('doc_a', 'new.docx');
-    expect(h.calls.at(-1)?.url).toBe('http://gateway.test/files/doc_a');
+    expect(h.calls.at(-1)?.url).toBe('http://collab.test/files/doc_a');
     expect(h.calls.at(-1)?.init?.method).toBe('PATCH');
+    expect(JSON.parse((h.calls.at(-1)?.init?.body as string) ?? '{}')).toEqual({
+      name: 'new.docx',
+    });
     expect(observed).toEqual([{ id: 'doc_a', name: 'new.docx' }]);
   });
 
   it('delete() DELETEs and removes the entry from the observer', async () => {
     const h = makeHarness();
-    const summaries: FileSummaryWire[] = [
-      { docId: 'doc_a', fileName: 'a.docx', version: 1, savedAt: '2026-05-01T00:00:00Z', size: 1 },
-      { docId: 'doc_b', fileName: 'b.docx', version: 1, savedAt: '2026-05-01T00:00:00Z', size: 1 },
-    ];
-    h.setRespond(() => jsonRes(200, summaries));
+    h.setRespond(() =>
+      jsonRes(200, {
+        files: [file({ id: 'doc_a', name: 'a.docx' }), file({ id: 'doc_b', name: 'b.docx' })],
+      })
+    );
     await h.source.list();
 
     let observed: string[] = [];
@@ -217,9 +225,9 @@ describe('PersonalFileSource', () => {
     expect(observed).toEqual(['doc_b']);
   });
 
-  it('throws PersonalFileSourceError with the gateway code on 4xx', async () => {
+  it('throws PersonalFileSourceError with the collab error code on 4xx', async () => {
     const h = makeHarness();
-    h.setRespond(() => jsonRes(404, { code: 'not_found', message: 'no such doc' }));
+    h.setRespond(() => jsonRes(404, { error: 'not-found' }));
     try {
       await h.source.open('missing');
       throw new Error('expected open() to throw');
@@ -227,64 +235,68 @@ describe('PersonalFileSource', () => {
       expect(err).toBeInstanceOf(PersonalFileSourceError);
       const e = err as PersonalFileSourceError;
       expect(e.status).toBe(404);
-      expect(e.code).toBe('not_found');
+      expect(e.code).toBe('not-found');
     }
   });
 
-  it('getProfile() GETs /auth/profile and returns the merged view', async () => {
+  it('getProfile() GETs /auth/profile and unwraps { profile }', async () => {
     const h = makeHarness();
     h.setRespond(() =>
       jsonRes(200, {
-        userId: 'user_abc',
-        email: 'a@example.com',
-        displayName: 'Alex',
-        timezone: 'America/Los_Angeles',
-        prefs: { showRulers: true },
+        user: { id: 7, username: 'alex', isAdmin: false, createdAt: 1 },
+        profile: {
+          displayName: 'Alex',
+          email: 'a@example.com',
+          timezone: 'America/Los_Angeles',
+          hasAvatar: false,
+          preferences: { showRulers: true },
+        },
       })
     );
     const profile = await h.source.getProfile();
-    expect(h.calls[0].url).toBe('http://gateway.test/auth/profile');
+    expect(h.calls[0].url).toBe('http://collab.test/auth/profile');
     expect(h.calls[0].init?.method).toBeUndefined(); // default GET
     expect(profile.displayName).toBe('Alex');
     expect(profile.timezone).toBe('America/Los_Angeles');
-    expect((profile.prefs as { showRulers: boolean })?.showRulers).toBe(true);
+    expect((profile.preferences as { showRulers: boolean })?.showRulers).toBe(true);
   });
 
-  it('updateProfile() PUTs the patch and returns the refreshed view', async () => {
+  it('updateProfile() PATCHes the patch and unwraps { profile }', async () => {
     const h = makeHarness();
     h.setRespond(() =>
       jsonRes(200, {
-        userId: 'user_abc',
-        email: 'a@example.com',
-        displayName: 'Alex Updated',
-        locale: 'de-DE',
+        profile: {
+          displayName: 'Alex Updated',
+          email: 'a@example.com',
+          timezone: 'UTC',
+          hasAvatar: false,
+          preferences: { locale: 'de-DE' },
+        },
       })
     );
     const profile = await h.source.updateProfile({
       displayName: 'Alex Updated',
-      locale: 'de-DE',
+      preferences: { locale: 'de-DE' },
     });
-    expect(h.calls[0].url).toBe('http://gateway.test/auth/profile');
-    expect(h.calls[0].init?.method).toBe('PUT');
+    expect(h.calls[0].url).toBe('http://collab.test/auth/profile');
+    expect(h.calls[0].init?.method).toBe('PATCH');
     const body = JSON.parse((h.calls[0].init?.body as string) ?? '{}');
-    expect(body).toEqual({ displayName: 'Alex Updated', locale: 'de-DE' });
+    expect(body).toEqual({ displayName: 'Alex Updated', preferences: { locale: 'de-DE' } });
     expect(profile.displayName).toBe('Alex Updated');
-    expect(profile.locale).toBe('de-DE');
+    expect((profile.preferences as { locale: string }).locale).toBe('de-DE');
   });
 
-  it('updateProfile() surfaces 400 errors with the gateway code', async () => {
+  it('updateProfile() surfaces 409 errors with the collab code', async () => {
     const h = makeHarness();
-    h.setRespond(() =>
-      jsonRes(400, { code: 'display_name', message: 'display name cannot be empty' })
-    );
+    h.setRespond(() => jsonRes(409, { error: 'conflict-or-invalid' }));
     try {
       await h.source.updateProfile({ displayName: '   ' });
       throw new Error('expected updateProfile to throw');
     } catch (err) {
       expect(err).toBeInstanceOf(PersonalFileSourceError);
       const e = err as PersonalFileSourceError;
-      expect(e.status).toBe(400);
-      expect(e.code).toBe('display_name');
+      expect(e.status).toBe(409);
+      expect(e.code).toBe('conflict-or-invalid');
     }
   });
 

--- a/docx-editor/packages/react/src/file-source/personal.ts
+++ b/docx-editor/packages/react/src/file-source/personal.ts
@@ -1,36 +1,36 @@
 /**
  * PersonalFileSource — the FileSource implementation for Mode 3
- * (Standalone). Talks to the Casual gateway over cookie-authenticated
- * REST.
+ * (Standalone). Talks to the collab server over cookie-authenticated
+ * REST (CasualOffice/collab `files/personal-files-routes.ts`).
  *
- * Wire shape — keep these in sync with the route handlers in
- * backend/internal/auth/personal/routes.go:
+ * Wire shape — keep these in sync with the collab route handlers:
  *
- *   GET    /auth/me                  → UserWire | 401
- *   GET    /files                    → FileSummaryWire[]
- *   POST   /files                    → FileSummaryWire (201)
- *   GET    /files/{docId}            → .docx bytes + ETag header
- *   PUT    /files/{docId}/contents   → FileSummaryWire
- *   PATCH  /files/{docId}            → { fileName }
- *   DELETE /files/{docId}            → 204
+ *   GET    /files            → { files: FileSummaryWire[] }
+ *   POST   /files            → { file } (201) — multipart (`file` part)
+ *   GET    /files/{id}        → .docx bytes + `etag` header
+ *   POST   /files/{id}        → { file } — raw bytes + `If-Match` header
+ *   PATCH  /files/{id}        → 204 — body { name }
+ *   DELETE /files/{id}        → 204
+ *   GET    /auth/profile      → { user, profile }
+ *   PATCH  /auth/profile      → { profile }
  *
- * The session cookie is set by /auth/signup or /auth/login and is
- * sent automatically via `credentials: 'include'`. The PersonalAuthGate
- * (Batch 3 — app side) is responsible for showing a login modal when
- * /auth/me returns 401; this class is constructed only after that
- * gate resolves.
+ * The session cookie (`cs_session`) is set by /auth/signup or
+ * /auth/login and rides along via `credentials: 'include'`. The
+ * PersonalAuthGate shows a login modal when /auth/me returns 401; this
+ * class is constructed only after that gate resolves.
  */
 
 import { RecentObserver, readLastOpened, writeLastOpened } from './local-prefs';
 import type { FileEntry, FileSource } from './types';
 import type { ErrorWire, FileSummaryWire, ProfilePatchWire, ProfileWire, UserWire } from './wire';
 
+const OCTET_STREAM = 'application/octet-stream';
+
 export interface PersonalFileSourceOptions {
   /**
-   * Origin of the gateway. Defaults to "" (same-origin) which is the
-   * production deploy shape — editor SPA + gateway served from one
-   * Docker image. Local-dev with Vite on :5173 should set this to
-   * `http://localhost:8080`.
+   * Origin of the collab server. Defaults to "" (same-origin) which is
+   * the production deploy shape — editor SPA + collab served from one
+   * image. Local dev with Vite on :5173 points at the collab origin.
    */
   baseUrl?: string;
   /**
@@ -39,7 +39,7 @@ export interface PersonalFileSourceOptions {
    * state. The personal source does not re-issue /auth/me on every
    * call — that's the gate's job.
    */
-  user: Pick<UserWire, 'userId' | 'displayName'>;
+  user: Pick<UserWire, 'id' | 'username'>;
   /**
    * Override for fetch. Tests inject a mock here; production passes
    * nothing and the global fetch is used.
@@ -78,16 +78,16 @@ export class PersonalFileSource implements FileSource {
     // throw "Illegal invocation" when fetch is called with anything
     // but window / undefined as the receiver.
     this.fetchImpl = opts.fetchImpl ?? (((input, init) => fetch(input, init)) as typeof fetch);
-    this.label = opts.user.displayName || 'My files';
+    this.label = opts.user.username || 'My files';
     // Scoped per (kind, userId) so the recent-files cache survives
     // user-switching on the same browser without leaking.
-    this.scope = `personal.${opts.user.userId}`;
+    this.scope = `personal.${opts.user.id}`;
   }
 
   async list(): Promise<FileEntry[]> {
     const res = await this.req('/files');
-    const summaries = (await res.json()) as FileSummaryWire[];
-    const entries = summaries.map(summaryToEntry);
+    const body = (await res.json()) as { files: FileSummaryWire[] };
+    const entries = (body.files ?? []).map(summaryToEntry);
     this.recent.set(entries);
     return entries;
   }
@@ -110,36 +110,42 @@ export class PersonalFileSource implements FileSource {
     bytes: ArrayBuffer,
     opts?: { etag?: string; name?: string }
   ): Promise<{ id: string; etag: string }> {
-    // First save mints a docId via POST /files; subsequent saves
-    // overwrite via PUT /files/{id}/contents. The HTTP method choice
-    // is the differentiator — the body shape (raw bytes +
-    // X-File-Name) is identical so the multipart code path can be
-    // shared in a future revision.
-    const url = id === null ? '/files' : `/files/${encodeURIComponent(id)}/contents`;
-    const method = id === null ? 'POST' : 'PUT';
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/octet-stream',
-    };
-    if (opts?.name) {
-      headers['X-File-Name'] = encodeRfc2047(opts.name);
+    // First save mints an id via a multipart POST /files (the `file`
+    // part carries the bytes + filename). Subsequent saves overwrite
+    // via POST /files/{id} with the raw bytes and an `If-Match` header
+    // carrying the etag we hold, so a concurrent host-side change
+    // surfaces as a 412 rather than silently clobbering.
+    let res: Response;
+    if (id === null) {
+      const form = new FormData();
+      const blob = new Blob([bytes], { type: OCTET_STREAM });
+      form.append('file', blob, opts?.name || 'document.docx');
+      if (opts?.name) form.append('name', opts.name);
+      res = await this.req('/files', { method: 'POST', body: form });
+    } else {
+      const headers: Record<string, string> = { 'Content-Type': OCTET_STREAM };
+      if (opts?.etag) headers['If-Match'] = opts.etag;
+      res = await this.req(`/files/${encodeURIComponent(id)}`, {
+        method: 'POST',
+        headers,
+        body: bytes,
+      });
     }
-    const res = await this.req(url, { method, headers, body: bytes });
-    const summary = (await res.json()) as FileSummaryWire;
+    const body = (await res.json()) as { file: FileSummaryWire };
+    const summary = body.file;
     // Refresh the recent observer optimistically — callers can rely
     // on watchRecent firing without an explicit list().
     this.bumpRecent(summary);
-    return { id: summary.docId, etag: String(summary.version) };
+    return { id: summary.id, etag: summary.etag };
   }
 
   async rename(id: string, newName: string): Promise<void> {
-    const res = await this.req(`/files/${encodeURIComponent(id)}`, {
+    // collab returns 204 (no body) on a successful rename.
+    await this.req(`/files/${encodeURIComponent(id)}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ fileName: newName }),
+      body: JSON.stringify({ name: newName }),
     });
-    // Drain the body so the connection can be reused (Bun's fetch
-    // doesn't strictly require this, but it's polite).
-    await res.json().catch(() => undefined);
     // Mirror the rename into the recent observer.
     const next = this.recent.snapshot().map((e) => (e.id === id ? { ...e, name: newName } : e));
     this.recent.set(next);
@@ -170,7 +176,8 @@ export class PersonalFileSource implements FileSource {
    */
   async getProfile(): Promise<ProfileWire> {
     const res = await this.req('/auth/profile');
-    return (await res.json()) as ProfileWire;
+    const body = (await res.json()) as { profile: ProfileWire };
+    return body.profile;
   }
 
   /**
@@ -181,11 +188,12 @@ export class PersonalFileSource implements FileSource {
    */
   async updateProfile(patch: ProfilePatchWire): Promise<ProfileWire> {
     const res = await this.req('/auth/profile', {
-      method: 'PUT',
+      method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(patch),
     });
-    return (await res.json()) as ProfileWire;
+    const body = (await res.json()) as { profile: ProfileWire };
+    return body.profile;
   }
 
   // ---------------------------------------------------------------
@@ -198,15 +206,17 @@ export class PersonalFileSource implements FileSource {
       credentials: 'include',
     });
     if (!res.ok) {
-      // Try to parse the gateway's { code, message } envelope. If the
-      // body isn't JSON (e.g. an upstream proxy returned a plain HTML
-      // 502), fall back to a synthesized error.
+      // Try to parse collab's { error } envelope. If the body isn't
+      // JSON (e.g. an upstream proxy returned a plain HTML 502), fall
+      // back to a synthesized error.
       let code = 'http_' + res.status;
       let message = res.statusText;
       try {
         const body = (await res.clone().json()) as ErrorWire;
-        if (body?.code) code = body.code;
-        if (body?.message) message = body.message;
+        if (body?.error) {
+          code = body.error;
+          message = body.error;
+        }
       } catch {
         // Non-JSON error body — keep the synthesized envelope.
       }
@@ -224,30 +234,20 @@ export class PersonalFileSource implements FileSource {
 
 function summaryToEntry(s: FileSummaryWire): FileEntry {
   return {
-    id: s.docId,
-    name: s.fileName,
+    id: s.id,
+    name: s.name,
     size: s.size,
-    modifiedAt: Date.parse(s.savedAt) || 0,
+    // collab returns modifiedAt as ms-since-epoch already.
+    modifiedAt: s.modifiedAt || 0,
     source: 'personal',
-    meta: { version: s.version },
+    meta: { version: s.etag },
   };
 }
 
 /**
- * RFC 2047 encoder for the X-File-Name header. The gateway reads this
- * verbatim into Content-Disposition; non-ASCII names need encoding so
- * a HTTP/1.1 proxy doesn't mangle them.
- */
-function encodeRfc2047(name: string): string {
-  // Fast path: pure ASCII names go through as-is.
-  if (/^[\x20-\x7e]+$/.test(name)) return name;
-  const encoded = btoa(unescape(encodeURIComponent(name)));
-  return `=?UTF-8?B?${encoded}?=`;
-}
-
-/**
- * Pulls the filename out of a Content-Disposition header. Handles the
- * RFC 5987 `filename*=UTF-8''…` form the gateway emits.
+ * Pulls the filename out of a Content-Disposition header. Handles both
+ * the RFC 5987 `filename*=UTF-8''…` form and collab's
+ * `filename="<percent-encoded>"` form.
  */
 function parseFilenameFromContentDisposition(cd: string | null): string | null {
   if (!cd) return null;
@@ -260,5 +260,11 @@ function parseFilenameFromContentDisposition(cd: string | null): string | null {
     }
   }
   const plain = /filename="([^"]+)"/i.exec(cd);
-  return plain ? plain[1] : null;
+  if (!plain) return null;
+  // collab percent-encodes the name into the quoted form; decode it.
+  try {
+    return decodeURIComponent(plain[1]);
+  } catch {
+    return plain[1];
+  }
 }

--- a/docx-editor/packages/react/src/file-source/select.test.ts
+++ b/docx-editor/packages/react/src/file-source/select.test.ts
@@ -5,9 +5,10 @@ import { PersonalFileSource } from './personal';
 import { chooseFileSource, extractWopiContext } from './select';
 import { WopiFileSource } from './wopi';
 
-function userJson(body: { userId: string; displayName: string }) {
+function userJson(body: { id: number; username: string }) {
+  // collab wraps /auth/me as { user }.
   return new Response(
-    JSON.stringify({ ...body, email: 'x@y', createdAt: '2026-01-01T00:00:00Z' }),
+    JSON.stringify({ user: { ...body, isAdmin: false, createdAt: 1_700_000_000_000 } }),
     {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
@@ -26,7 +27,7 @@ describe('chooseFileSource', () => {
     let asked = '';
     const fetchImpl = (async (input: RequestInfo | URL) => {
       asked = typeof input === 'string' ? input : input.toString();
-      return userJson({ userId: 'user_42', displayName: 'Forty-Two' });
+      return userJson({ id: 42, username: 'forty-two' });
     }) as unknown as typeof fetch;
 
     const source = await chooseFileSource({
@@ -36,7 +37,7 @@ describe('chooseFileSource', () => {
     });
     expect(asked).toBe('http://gateway.test/auth/me');
     expect(source).toBeInstanceOf(PersonalFileSource);
-    expect(source.label).toBe('Forty-Two');
+    expect(source.label).toBe('forty-two');
   });
 
   it('falls back to BrowserFileSource when /auth/me returns 401', async () => {

--- a/docx-editor/packages/react/src/file-source/select.ts
+++ b/docx-editor/packages/react/src/file-source/select.ts
@@ -128,10 +128,10 @@ export async function chooseFileSource(opts: ChooseFileSourceOptions = {}): Prom
   try {
     const res = await fetchImpl(baseUrl + '/auth/me', { credentials: 'include' });
     if (res.ok) {
-      const user = (await res.json()) as UserWire;
+      const body = (await res.json()) as { user: UserWire };
       return new PersonalFileSource({
         baseUrl,
-        user: { userId: user.userId, displayName: user.displayName },
+        user: { id: body.user.id, username: body.user.username },
         fetchImpl,
       });
     }

--- a/docx-editor/packages/react/src/file-source/wire.ts
+++ b/docx-editor/packages/react/src/file-source/wire.ts
@@ -1,63 +1,72 @@
 /**
- * Wire types — exact-match counterparts for the JSON shapes the Go
- * gateway emits from backend/internal/auth/personal/routes.go.
+ * Wire types — exact-match counterparts for the JSON shapes the collab
+ * server emits (CasualOffice/collab `src/auth/*` + `src/files/*`).
  *
  * If a field changes on the server, change it here too — there's no
  * runtime validator, only TypeScript's structural check at the call
  * site. Keep this file thin; it shouldn't grow logic.
  */
 
-/** Mirrors `personal.User` from the backend. */
+/**
+ * Mirrors collab `PublicUser` (`auth/personal.ts`). Note: identity is
+ * keyed by a numeric `id` + `username`; there is no email at this
+ * level (email is an optional profile field). Wrapped as `{ user }`
+ * in the /auth/* responses — unwrap at the call site.
+ */
 export interface UserWire {
-  userId: string;
-  email: string;
-  displayName: string;
-  /** RFC3339 string. The personal source converts to ms-since-epoch. */
-  createdAt: string;
-}
-
-/** Mirrors `personal.FileSummary` from the backend. */
-export interface FileSummaryWire {
-  docId: string;
-  fileName: string;
-  version: number;
-  /** RFC3339 string. */
-  savedAt: string;
-  size: number;
-}
-
-/** Mirrors the `errorResp` shape returned on 4xx / 5xx. */
-export interface ErrorWire {
-  code: string;
-  message: string;
+  id: number;
+  username: string;
+  isAdmin: boolean;
+  /** ms since epoch. */
+  createdAt: number;
 }
 
 /**
- * Mirrors `profileView` from the backend — the merged identity +
- * extended-profile shape served by GET / PUT /auth/profile. The
- * extended fields are optional because the JSON sidecar may not
- * exist yet (a never-edited profile yields a zero value).
+ * Mirrors a row from `GET /files` / the `file` field of POST replies
+ * (`files/personal-files-routes.ts`). `GET /files` wraps these as
+ * `{ files: FileSummaryWire[] }`; create/replace as `{ file: … }`.
+ */
+export interface FileSummaryWire {
+  id: string;
+  name: string;
+  size: number;
+  /** Opaque version, bumped on every write — the If-Match value. */
+  etag: string;
+  /** ms since epoch. */
+  createdAt: number;
+  /** ms since epoch. */
+  modifiedAt: number;
+}
+
+/** Mirrors collab's error envelope — a single `{ error: "<code>" }`. */
+export interface ErrorWire {
+  error: string;
+}
+
+/**
+ * Mirrors collab `UserProfile` (`auth/personal.ts`) — the `profile`
+ * field of `GET /auth/profile` (`{ user, profile }`) and the reply of
+ * `PATCH /auth/profile` (`{ profile }`). There is no `locale` or
+ * `avatarUrl`: language lives under `preferences.locale`, and the
+ * avatar is served as bytes from `GET /auth/profile/avatar` when
+ * `hasAvatar` is set.
  */
 export interface ProfileWire {
-  userId: string;
-  email: string;
-  displayName: string;
-  timezone?: string;
-  locale?: string;
-  avatarUrl?: string;
-  prefs?: Record<string, unknown>;
+  displayName: string | null;
+  email: string | null;
+  /** IANA tz string; defaults to "UTC". */
+  timezone: string;
+  hasAvatar: boolean;
+  preferences: Record<string, unknown>;
 }
 
 /**
- * Mirrors `ProfilePatch`. Each field optional → "leave unchanged".
- * Explicit empty string → "clear". The backend interprets via
- * pointer-nil semantics; on the wire that's just omission vs
- * presence.
+ * Mirrors the PATCH /auth/profile body. Each field optional → "leave
+ * unchanged". `displayName` / `email` accept null to clear.
  */
 export interface ProfilePatchWire {
-  displayName?: string;
+  displayName?: string | null;
+  email?: string | null;
   timezone?: string;
-  locale?: string;
-  avatarUrl?: string;
-  prefs?: Record<string, unknown>;
+  preferences?: Record<string, unknown>;
 }


### PR DESCRIPTION
## What

Repoints Mode 3 (Personal / Standalone) from the legacy Go gateway to the **collab server's** auth + files contract (CasualOffice/collab `src/auth/*` + `src/files/*`) — the Sheets-proven shapes. This is the second half of the Go→collab editor cutover (WOPI shipped in #100).

## Contract changes

- **Envelopes:** `{ user }`, `{ files }`, `{ file }`, `{ profile }` (were bare); errors are `{ error }` (were `{ code, message }`).
- **File fields:** `id` / `name` / `etag` / `modifiedAt` (were `docId` / `fileName` / `version` / `savedAt`).
- **Files:** multipart `POST /files` create; `POST /files/:id` replace with `If-Match` (was `PUT /files/:id/contents`); `PATCH { name }` rename → 204.
- **Profile:** `PATCH /auth/profile` (was PUT); `{ user, profile }` read shape; language preference moves into `preferences.locale` (collab has no `locale` column).

## User-visible change

**Authentication is now by username, not email** — collab authenticates by username (email is an optional profile field). The login/signup modal now shows a Username field; `AuthCredentials` is `{ username, password }` and `PersonalFileSourceOptions.user` is `{ id, username }`.

## Verification

typecheck, format, lint (0 errors), build, 58 file-source unit tests, and the `personal-auth-gate` (13) + `autosave-indicator` (3) e2e specs all pass locally. Login modal visually confirmed (Username field). Grounded in collab source, not memory.

Remaining for the cutover: PR2 (prod Dockerfile + compose → collab) and PR3 (delete `backend/` + CI Go job).