### PR TITLE
fix(desktop): Export / Make-a-copy / Email / markdown-save use the na…

### DIFF
--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -1173,6 +1173,29 @@ export function App() {
                 }
               : undefined
           }
+          // Tauri shell: File → Export (ODT/MD/TXT), Make a copy, and
+          // Email-as-attachment hand their bytes here so they open the native
+          // Save dialog (picker) instead of a phantom ~/Downloads blob.
+          // Returns true when the user picked a location (handled), false on
+          // cancel/error so the editor doesn't claim success. Web: unset →
+          // editor keeps its own blob download.
+          onExport={
+            isDesktop
+              ? async (blob: Blob, suggestedName: string) => {
+                  const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
+                  if (!bridge?.isDesktop) return false;
+                  try {
+                    const buf = await blob.arrayBuffer();
+                    const written = await bridge.saveAs(suggestedName, buf);
+                    return written != null;
+                  } catch (err) {
+                    // eslint-disable-next-line no-console
+                    console.error('desktop export failed', err);
+                    return false;
+                  }
+                }
+              : undefined
+          }
         />
       </main>
       <ShareDialog

--- a/docx-editor/examples/vite/src/markdown/MarkdownEditor.tsx
+++ b/docx-editor/examples/vite/src/markdown/MarkdownEditor.tsx
@@ -157,14 +157,30 @@ export function MarkdownEditor({
   // Download the current source as its file. The visible CodeMirror state is
   // the source of truth (it mirrors the shared Y.Text in collab mode), so read
   // straight from the view to avoid a stale React-state snapshot.
-  const handleDownload = useCallback(() => {
+  const handleDownload = useCallback(async () => {
     const text = viewRef.current?.state.doc.toString() ?? docText;
     const mime = kind === 'markdown' ? 'text/markdown' : 'text/plain';
+    const suggested = fileName || (kind === 'markdown' ? 'document.md' : 'document.txt');
+    // Desktop shell: write through the native bridge — overwrite the bound
+    // file path (or open the native Save dialog when untitled) — never a
+    // phantom ~/Downloads blob. The web build keeps the `<a download>` flow.
+    const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
+    if (bridge?.isDesktop) {
+      const buf = new TextEncoder().encode(text).buffer;
+      try {
+        if (bridge.filePath) await bridge.save(buf);
+        else await bridge.saveAs(suggested, buf);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('desktop markdown save failed', err);
+      }
+      return;
+    }
     const blob = new Blob([text], { type: `${mime};charset=utf-8` });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = fileName || (kind === 'markdown' ? 'document.md' : 'document.txt');
+    a.download = suggested;
     document.body.appendChild(a);
     a.click();
     a.remove();

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -476,6 +476,14 @@ export interface DocxEditorProps {
   document?: Document | null;
   /** Callback when document is saved */
   onSave?: (buffer: ArrayBuffer) => void;
+  /** Optional host-provided file deliverer for File → Export (ODT/MD/TXT),
+   *  Make a copy, and Email-as-attachment. When set, the editor hands the
+   *  produced blob + a suggested filename here instead of doing a browser
+   *  blob download, and skips the download if it returns true. The Casual
+   *  Office desktop shell wires this to a native Save dialog so exports open
+   *  a picker (never a phantom ~/Downloads file); the web build leaves it
+   *  unset and falls back to the `<a download>` blob. */
+  onExport?: (blob: Blob, suggestedName: string) => boolean | Promise<boolean>;
   /** Callback invoked when the user picks File → New. Host should
    *  replace the loaded document with a blank one. */
   onNew?: () => void;
@@ -1552,6 +1560,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     documentBuffer,
     document: initialDocument,
     onSave,
+    onExport,
     onNew,
     author = 'User',
     onChange,
@@ -6803,25 +6812,35 @@ body { background: white; }
       const blob = new Blob([buffer], {
         type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       });
-      const url = URL.createObjectURL(blob);
-      const a = window.document.createElement('a');
-      a.href = url;
       const base = (documentName?.trim() || 'document').replace(/\.docx$/i, '');
       const fileName = `${base}.docx`;
-      a.download = fileName;
-      a.click();
-      setTimeout(() => URL.revokeObjectURL(url), 0);
+      // Desktop shell: save via the native dialog (picker) so the user
+      // controls where the attachment lands; web falls back to a download.
+      const savedViaHost = onExport ? await onExport(blob, fileName) : false;
+      if (!savedViaHost) {
+        const url = URL.createObjectURL(blob);
+        const a = window.document.createElement('a');
+        a.href = url;
+        a.download = fileName;
+        a.click();
+        setTimeout(() => URL.revokeObjectURL(url), 0);
+      }
 
       const subject = encodeURIComponent(base);
+      const where = savedViaHost ? 'saved to your chosen location' : 'downloaded to your machine';
       const body = encodeURIComponent(
-        `Attached: ${fileName}\n\n(The file was downloaded to your machine — please attach it to this email.)`
+        `Attached: ${fileName}\n\n(The file was ${where} — please attach it to this email.)`
       );
       window.open(`mailto:?subject=${subject}&body=${body}`, '_blank', 'noopener');
-      toast.success(`Downloaded ${fileName}. Drag it into the email window to attach.`);
+      toast.success(
+        savedViaHost
+          ? `Saved ${fileName}. Attach it to the email window.`
+          : `Downloaded ${fileName}. Drag it into the email window to attach.`
+      );
     } finally {
       setIsSaving(false);
     }
-  }, [handleSave, documentName]);
+  }, [handleSave, documentName, onExport]);
 
   const handleMakeCopy = useCallback(async () => {
     setIsSaving(true);
@@ -6831,11 +6850,16 @@ body { background: white; }
       const blob = new Blob([buffer], {
         type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       });
+      const base = (documentName?.trim() || 'document').replace(/\.docx$/i, '');
+      const fileName = `Copy of ${base}.docx`;
+      // Desktop shell: native Save dialog instead of a phantom download.
+      if (onExport && (await onExport(blob, fileName))) {
+        toast.success(`Saved ${fileName}`);
+        return;
+      }
       const url = URL.createObjectURL(blob);
       const a = window.document.createElement('a');
       a.href = url;
-      const base = (documentName?.trim() || 'document').replace(/\.docx$/i, '');
-      const fileName = `Copy of ${base}.docx`;
       a.download = fileName;
       a.click();
       setTimeout(() => URL.revokeObjectURL(url), 0);
@@ -6843,7 +6867,7 @@ body { background: white; }
     } finally {
       setIsSaving(false);
     }
-  }, [handleSave, documentName]);
+  }, [handleSave, documentName, onExport]);
 
   const handleExportAs = useCallback(
     async (target: 'odt' | 'md' | 'txt') => {
@@ -6871,19 +6895,27 @@ body { background: white; }
           typeof out === 'string'
             ? new Blob([out], { type: mime })
             : new Blob([out as BlobPart], { type: mime });
+        const fileName = `${base}.${target}`;
+        // Desktop shell: hand the bytes to the host's native Save dialog
+        // (picker) instead of a phantom ~/Downloads blob. Falls through to
+        // the browser download on the web (onExport unset / returned false).
+        if (onExport && (await onExport(blob, fileName))) {
+          toast.success(`Saved ${fileName}`, { id: toastId });
+          return;
+        }
         const url = URL.createObjectURL(blob);
         const a = window.document.createElement('a');
         a.href = url;
-        a.download = `${base}.${target}`;
+        a.download = fileName;
         a.click();
         setTimeout(() => URL.revokeObjectURL(url), 0);
-        toast.success(`Downloaded ${base}.${target}`, { id: toastId });
+        toast.success(`Downloaded ${fileName}`, { id: toastId });
       } catch (error) {
         toast.error(`Failed to export as ${label}`, { id: toastId });
         onError?.(error instanceof Error ? error : new Error(`Failed to export as ${target}`));
       }
     },
-    [handleSave, documentName, onError]
+    [handleSave, documentName, onError, onExport]
   );
   const handleExportOdt = useCallback(() => handleExportAs('odt'), [handleExportAs]);
   const handleExportMd = useCallback(() => handleExportAs('md'), [handleExportAs]);


### PR DESCRIPTION
…tive picker

In the Casual Office desktop shell, several File-menu actions did phantom browser blob downloads (`<a download>` → ~/Downloads) instead of routing through the shell's native Save dialog — the same class of bug just fixed in sheets, and a violation of the shell's no-downloads rule. Save (Ctrl+S) and Save As were already correct via the `onSave` prop; these were not.

The editor library (`packages/react`) is cleanly decoupled from the desktop bridge (it only knows the `onSave` prop), so this adds a parallel host hook rather than coupling the library to `window.__deskApp__`:

- New optional `onExport(blob, suggestedName)` prop on `DocxEditor`. When set, File → Export (ODT/MD/TXT), Make a copy, and Email-as-attachment hand their blob + suggested name to the host and skip the blob download when it returns true. Web build leaves it unset → unchanged `<a download>` fallback.
- `examples/vite/App.tsx` wires `onExport` (desktop only) to `bridge.saveAs()` so each opens the native picker and the user chooses the location.
- `MarkdownEditor` (.md/.txt surface): Ctrl+S / download now writes through the bridge (overwrite the bound path, or native Save dialog when untitled) instead of downloading a copy.

Export-as-PDF stays on the system print dialog (Word-style "Save as PDF"), which already works in the shell. The Translate-document export dialog still blob-downloads — niche, tracked as a follow-up.