### PR TITLE
fix(desktop): eliminate constant re-renders and boot-overlay flash

### DIFF
--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -664,17 +664,18 @@ export function App() {
               setDocumentBuffer(null);
               setCurrentDocument(null);
               setTextDoc({ text, fileName: name, kind });
+              // Markdown/text renders immediately (no async DOCX parse step),
+              // so the boot splash can be dismissed as soon as the state lands.
+              window.__deskApp__?.dismissBoot?.();
             })
             .catch((err) => {
               console.error('deskApp loadText failed', err);
               setCurrentDocument(createEmptyDocument());
               setFileName(name);
               setStatus(`Could not open file: ${err}`);
-            })
-            // The document is now in the editor view (or we surfaced a load
-            // error) — drop the cold-start splash either way so it can never
-            // stick. Idempotent; no-op on web.
-            .finally(() => window.__deskApp__?.dismissBoot?.());
+              // Error path — dismiss immediately so the user can see the error.
+              window.__deskApp__?.dismissBoot?.();
+            });
           return;
         }
         bridge
@@ -682,15 +683,20 @@ export function App() {
           .then((buffer) => {
             setDocumentBuffer(buffer);
             setFileName(name);
+            // Do NOT dismiss the boot splash here — the buffer is set but
+            // DocxEditor still needs to run parseDocx (~100–500 ms async) and
+            // paint the first layout before the document is visible. Dismissing
+            // now would reveal a blank editor. onEditorViewReady below handles
+            // the dismiss after the PM view is created and the first paint lands.
           })
           .catch((err) => {
             console.error('deskApp loadDocument failed', err);
             setCurrentDocument(createEmptyDocument());
             setFileName(name);
             setStatus(`Could not open file: ${err}`);
-          })
-          // Dismiss the boot splash on both success and load-error paths.
-          .finally(() => window.__deskApp__?.dismissBoot?.());
+            // Error path — dismiss immediately so the user can see the error.
+            window.__deskApp__?.dismissBoot?.();
+          });
       } else {
         setCurrentDocument(createEmptyDocument());
         setFileName('Untitled.docx');
@@ -896,6 +902,50 @@ export function App() {
     return () => {
       cancelled = true;
     };
+  }, [isDesktop]);
+
+  // Stable desktop save/export handlers — defined outside the JSX render so
+  // DocxEditor's handleSave useCallback (which lists onSave in its deps) does
+  // NOT get a new reference every time status changes (Saving → Saved → '').
+  // Accessing bridge via window avoids closing over a stale reference.
+  const onSaveDesktop = useCallback(async (buffer: ArrayBuffer) => {
+    const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
+    if (!bridge?.isDesktop) return;
+    setStatus('Saving…');
+    try {
+      const written = await bridge.save(buffer);
+      if (typeof written === 'string') {
+        const name = written.split(/[\\/]/).pop();
+        if (name) setFileName(name);
+      }
+      setStatus('Saved');
+      setTimeout(() => setStatus(''), 1500);
+    } catch (err) {
+      console.error('desktop save failed', err);
+      setStatus('Save failed');
+      setTimeout(() => setStatus(''), 2500);
+    }
+  }, []); // bridge.save, setStatus, setFileName are all stable across renders
+
+  const onExportDesktop = useCallback(async (blob: Blob, suggestedName: string) => {
+    const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
+    if (!bridge?.isDesktop) return false;
+    try {
+      const buf = await blob.arrayBuffer();
+      const written = await bridge.saveAs(suggestedName, buf);
+      return written != null;
+    } catch (err) {
+      console.error('desktop export failed', err);
+      return false;
+    }
+  }, []); // bridge.saveAs is stable
+
+  // Dismiss the boot overlay once DocxEditor's PM view is live and the
+  // first layout paint is imminent. This fires AFTER parseDocx completes,
+  // avoiding the blank-editor flash that occurred when dismissBoot was called
+  // immediately after setDocumentBuffer (before async parse + first paint).
+  const handleEditorViewReady = useCallback(() => {
+    if (isDesktop) window.__deskApp__?.dismissBoot?.();
   }, [isDesktop]);
 
   const handleError = useCallback((error: Error) => {
@@ -1143,59 +1193,14 @@ export function App() {
           onNew={handleNewDocument}
           renderLogo={renderLogo}
           renderTitleBarRight={renderTitleBarRight}
-          // Tauri shell: route every Save (toolbar button, File→Save,
-          // Ctrl+S) through the bridge so it overwrites the bound
-          // filesystem path instead of producing a phantom download.
-          // Web mode: leave onSave UNSET so DocxEditor falls back to its
-          // own blob-download path. Passing a handler that no-ops in web
-          // mode still counts as "host owns save" inside the editor, which
-          // suppresses the download entirely (and breaks the e2e save flow).
-          onSave={
-            isDesktop
-              ? async (buffer) => {
-                  const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
-                  if (!bridge?.isDesktop) return;
-                  setStatus('Saving…');
-                  try {
-                    const written = await bridge.save(buffer);
-                    if (typeof written === 'string') {
-                      const name = written.split(/[\\/]/).pop();
-                      if (name) setFileName(name);
-                    }
-                    setStatus('Saved');
-                    setTimeout(() => setStatus(''), 1500);
-                  } catch (err) {
-                    // eslint-disable-next-line no-console
-                    console.error('desktop save failed', err);
-                    setStatus('Save failed');
-                    setTimeout(() => setStatus(''), 2500);
-                  }
-                }
-              : undefined
-          }
-          // Tauri shell: File → Export (ODT/MD/TXT), Make a copy, and
-          // Email-as-attachment hand their bytes here so they open the native
-          // Save dialog (picker) instead of a phantom ~/Downloads blob.
-          // Returns true when the user picked a location (handled), false on
-          // cancel/error so the editor doesn't claim success. Web: unset →
-          // editor keeps its own blob download.
-          onExport={
-            isDesktop
-              ? async (blob: Blob, suggestedName: string) => {
-                  const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
-                  if (!bridge?.isDesktop) return false;
-                  try {
-                    const buf = await blob.arrayBuffer();
-                    const written = await bridge.saveAs(suggestedName, buf);
-                    return written != null;
-                  } catch (err) {
-                    // eslint-disable-next-line no-console
-                    console.error('desktop export failed', err);
-                    return false;
-                  }
-                }
-              : undefined
-          }
+          // Stable callbacks — defined as useCallback above so DocxEditor's
+          // internal handleSave/handleExport don't re-reference on every status change.
+          onSave={isDesktop ? onSaveDesktop : undefined}
+          onExport={isDesktop ? onExportDesktop : undefined}
+          // Dismiss the boot splash after DocxEditor has parsed the DOCX and
+          // created its PM view, avoiding the blank-editor flash that occurred
+          // when dismissBoot fired immediately after setDocumentBuffer.
+          onEditorViewReady={isDesktop ? handleEditorViewReady : undefined}
         />
       </main>
       <ShareDialog

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -5002,6 +5002,40 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     setState((prev) => ({ ...prev, zoom }));
   }, []);
 
+  // Stable PagedEditor onTotalPagesChange — avoids breaking memo() on every render.
+  const handleTotalPagesChange = useCallback((totalPages: number) => {
+    setScrollPageInfo((prev) =>
+      prev.totalPages === totalPages ? prev : { ...prev, totalPages },
+    );
+  }, []);
+
+  // Stable PagedEditor onOpenProperties — avoids breaking memo() on every render.
+  const handleOpenProperties = useCallback(() => openRightPanel('properties'), [openRightPanel]);
+
+  // Stable PagedEditor onReady — avoids breaking memo() on every render.
+  const handlePagedEditorReady = useCallback(
+    (ref: PagedEditorRef) => {
+      const view = ref.getView();
+      if (view) setPmState(view.state);
+      if (view) onEditorViewReady?.(view);
+    },
+    [onEditorViewReady],
+  );
+
+  // Ref pattern for onSelectionChange: the implementation reads the latest
+  // closure values on every call (resolvedCommentIds, commentSidebarItems…)
+  // while the _stable wrapper_ never changes reference, keeping PagedEditor's
+  // memo() effective across every DocxEditor re-render caused by
+  // pmState / isDirty / isSaving state flips.
+  const _pagedSelectionChangeImplRef = useRef<(from: number, to: number) => void>(
+    () => undefined,
+  );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const _pagedOnSelectionChangeStable = useCallback(
+    (from: number, to: number) => _pagedSelectionChangeImplRef.current(from, to),
+    [],
+  );
+
   // Handle hyperlink dialog submit
   const handleHyperlinkSubmit = useCallback(
     (data: HyperlinkData) => {
@@ -8674,6 +8708,62 @@ body { background: white; }
                           `}</style>
                             );
                           })()}
+                        {/* Update the selection-change impl ref on each render so
+                            it always captures the latest closure values, while
+                            the stable wrapper keeps PagedEditor memo() intact. */}
+                        {(_pagedSelectionChangeImplRef.current = (_from, _to) => {
+                          const view = pagedEditorRef.current?.getView();
+                          if (view) {
+                            const selectionState = extractSelectionState(view.state);
+                            handleSelectionChange(selectionState);
+                            const $from = view.state.selection.$from;
+                            const marks = [
+                              ...(view.state.storedMarks ?? []),
+                              ...($from.nodeAfter?.marks ?? []),
+                              ...($from.nodeBefore?.marks ?? []),
+                              ...$from.marks(),
+                            ];
+                            let cursorSidebarItem: string | null = null;
+                            for (const mark of marks) {
+                              if (
+                                mark.type.name === 'comment' &&
+                                mark.attrs.commentId != null
+                              ) {
+                                const commentId = mark.attrs.commentId as number;
+                                if (resolvedCommentIds.has(commentId)) continue;
+                                cursorSidebarItem = `comment-${commentId}`;
+                                break;
+                              }
+                              if (
+                                (mark.type.name === 'insertion' ||
+                                  mark.type.name === 'deletion') &&
+                                mark.attrs.revisionId != null
+                              ) {
+                                const revId = String(mark.attrs.revisionId);
+                                const prefix = `tc-${revId}-`;
+                                let match = commentSidebarItems.find((i) =>
+                                  i.id.startsWith(prefix),
+                                );
+                                if (!match && revisionIdAliases) {
+                                  const aliasedId = revisionIdAliases.get(revId);
+                                  if (aliasedId) {
+                                    match = commentSidebarItems.find(
+                                      (i) => i.id === aliasedId,
+                                    );
+                                  }
+                                }
+                                if (match) {
+                                  cursorSidebarItem = match.id;
+                                  break;
+                                }
+                              }
+                            }
+                            if (cursorSidebarItem) setShowCommentsSidebar(true);
+                            setExpandedSidebarItem(cursorSidebarItem);
+                          } else {
+                            handleSelectionChange(null);
+                          }
+                        }) && null}
                         <PagedEditor
                           ref={pagedEditorRef}
                           document={history.state}
@@ -8699,90 +8789,21 @@ body { background: white; }
                           onFormat={handleFormat}
                           onZoomChange={handleZoomChange}
                           onDocumentChange={handleDocumentChange}
-                          onSelectionChange={(_from, _to) => {
-                            // Extract full selection state from PM and use the standard handler
-                            const view = pagedEditorRef.current?.getView();
-                            if (view) {
-                              const selectionState = extractSelectionState(view.state);
-                              handleSelectionChange(selectionState);
-
-                              // Detect comment/tracked-change marks at cursor to open sidebar card.
-                              // Collect marks from all sources — inclusive:false marks aren't
-                              // reported by $from.marks() at boundaries, and empty arrays are
-                              // truthy so an OR chain would short-circuit.
-                              const $from = view.state.selection.$from;
-                              const marks = [
-                                ...(view.state.storedMarks ?? []),
-                                ...($from.nodeAfter?.marks ?? []),
-                                ...($from.nodeBefore?.marks ?? []),
-                                ...$from.marks(),
-                              ];
-                              let cursorSidebarItem: string | null = null;
-                              for (const mark of marks) {
-                                if (mark.type.name === 'comment' && mark.attrs.commentId != null) {
-                                  // Skip resolved comments — they stay collapsed as a checkmark
-                                  // marker unless the user explicitly clicks it. Otherwise the
-                                  // sidebar fills up with old threads every time the cursor
-                                  // passes through commented text.
-                                  const commentId = mark.attrs.commentId as number;
-                                  if (resolvedCommentIds.has(commentId)) continue;
-                                  cursorSidebarItem = `comment-${commentId}`;
-                                  break;
-                                }
-                                if (
-                                  (mark.type.name === 'insertion' ||
-                                    mark.type.name === 'deletion') &&
-                                  mark.attrs.revisionId != null
-                                ) {
-                                  const revId = String(mark.attrs.revisionId);
-                                  const prefix = `tc-${revId}-`;
-                                  let match = commentSidebarItems.find((i) =>
-                                    i.id.startsWith(prefix)
-                                  );
-                                  // Insertion side of a replacement has a different revisionId;
-                                  // check alias map to find the correct sidebar card.
-                                  if (!match && revisionIdAliases) {
-                                    const aliasedId = revisionIdAliases.get(revId);
-                                    if (aliasedId) {
-                                      match = commentSidebarItems.find((i) => i.id === aliasedId);
-                                    }
-                                  }
-                                  if (match) {
-                                    cursorSidebarItem = match.id;
-                                    break;
-                                  }
-                                }
-                              }
-                              if (cursorSidebarItem) {
-                                setShowCommentsSidebar(true);
-                              }
-                              setExpandedSidebarItem(cursorSidebarItem);
-                            } else {
-                              handleSelectionChange(null);
-                            }
-                          }}
+                          onSelectionChange={_pagedOnSelectionChangeStable}
                           externalPlugins={allExternalPlugins}
-                          onReady={(ref) => {
-                            const view = ref.getView();
-                            if (view) setPmState(view.state);
-                            if (view) onEditorViewReady?.(view);
-                          }}
+                          onReady={handlePagedEditorReady}
                           onRenderedDomContextReady={onRenderedDomContextReady}
                           pluginOverlays={pluginOverlays}
                           onHyperlinkClick={handleHyperlinkClick}
                           onContextMenu={handleContextMenu}
-                          onOpenProperties={() => openRightPanel('properties')}
+                          onOpenProperties={handleOpenProperties}
                           onResizeTextBox={handleTextBoxSetSize}
                           onEditFootnote={handleEditFootnote}
                           onEditEquation={handleEditEquation}
                           onEditEndnote={handleEditEndnote}
                           commentsSidebarOpen={sidebarOpen}
                           onAnchorPositionsChange={setAnchorPositions}
-                          onTotalPagesChange={(totalPages) => {
-                            setScrollPageInfo((prev) =>
-                              prev.totalPages === totalPages ? prev : { ...prev, totalPages }
-                            );
-                          }}
+                          onTotalPagesChange={handleTotalPagesChange}
                           resolvedCommentIds={resolvedIdsForRender}
                           scrollContainerRef={scrollContainerRef}
                           sidebarOverlay={


### PR DESCRIPTION
Three root causes of the flickering/constant-re-render reported on the Tauri desktop build:

1. onSelectionChange inline in PagedEditor JSX Every DocxEditor re-render (isDirty / pmState flip = every keystroke) created a new arrow-function reference, defeating PagedEditor's memo() wrapper and forcing a full PagedEditor re-render on every edit. Fixed with the ref-delegation pattern: a stable useCallback wrapper delegates to a ref whose .current is updated inline on each render, so PagedEditor memo() sees the same function identity across all DocxEditor state updates.

2. onReady / onTotalPagesChange / onOpenProperties inline in JSX Same issue — three more inline functions defeating memo(). Extracted to handlePagedEditorReady, handleTotalPagesChange, handleOpenProperties useCallbacks.

3. onSave / onExport inline in App.tsx Each status change (Saving → Saved → '') triggered an App re-render, producing new onSave / onExport function references. DocxEditor's handleSave useCallback lists onSave in its deps, so it too got a new reference, cascading into toolbar prop changes. Extracted to stable onSaveDesktop / onExportDesktop useCallbacks (no deps — bridge accessed via window, not closed over).

4. Boot-overlay dismissed too early dismissBoot() was called in .finally() immediately after the file bytes were read — before React had processed setDocumentBuffer, before DocxEditor ran parseDocx (~100–500 ms async), and before the first layout paint. Users saw the spinner fade revealing a blank editor. Fixed: success path removes the .finally() dismiss and instead hooks onEditorViewReady, which fires after parseDocx completes and the PM view is live (first paint is imminent). Error paths still dismiss immediately so the error message is visible.