### PR TITLE
fix(a11y): bump dark-mode DS tokens that miss WCAG AA contrast

### DIFF
--- a/docx-editor/packages/react/src/styles/editor.css
+++ b/docx-editor/packages/react/src/styles/editor.css
@@ -176,6 +176,18 @@
 [data-theme='dark'] {
   /* Native form controls (selects, scrollbars) follow this. */
   color-scheme: dark;
+
+  /* WCAG AA overrides for the vendored DS dark tokens. The design-system is a
+     read-only submodule, so the doc editor — which already owns its chrome
+     palette here — bumps the three tokens that miss AA on the dark surfaces:
+       --color-text-muted   4.27 → 4.83:1  (quiet metadata, real text)
+       --color-text-disabled 2.67 → 4.63:1 (drives placeholder text)
+       --color-border-strong 1.94 → 3.33:1 (input outlines + table borders;
+                                            1.4.11 UI-component 3:1 floor)
+     Everything else in the DS dark ramp already clears AA. */
+  --color-text-muted: #969aa3;
+  --color-text-disabled: #8b8e96;
+  --color-border-strong: #646a76;
   /* shadcn vars — used by ui/Button.tsx and any consumer of
      bg-background / bg-card / bg-popover / bg-muted / text-foreground. */
   --background: 220 6% 19%; /* #2d2f31 in HSL */


### PR DESCRIPTION
Three vendored design-system dark tokens fall under AA on the dark chrome surfaces: --color-text-muted (4.27:1), --color-text-disabled (2.67:1, drives placeholder text), and --color-border-strong (1.94:1, used for input outlines + table borders). The DS is a read-only submodule, so override them in the editor's own dark block — which already owns the chrome palette — to 4.83 / 4.63 / 3.33:1.