### PR TITLE
fix: autosave durability queue + image OOXML envelope round-trip

### DIFF
--- a/docs/internal/27-production-grade-tracker.md
+++ b/docs/internal/27-production-grade-tracker.md
@@ -342,3 +342,45 @@ This section exists to prevent duplicate work and to keep the tracker honest. Th
 - **Accessibility/focus/IME coverage:** `editor-a11y.spec.ts`, `accessibility-dialog.spec.ts`, `editor-focus-recapture.spec.ts`, `cursor-focus.spec.ts`, and `ime-caret-sync.spec.ts` cover important baseline contracts, but not a full WCAG/AT matrix.
 - **Feature workflow coverage:** Playwright specs exist for version history/preview, track changes, equations, comments, tables, images, find/replace, formatting, markdown, auth gate, export PDF, mobile behavior, and many document-fidelity regressions.
 - **Performance coverage:** `performance-large-docs.spec.ts` exists, but production budgets/trend reporting still need to be formalized.
+
+
+---
+
+## Concrete Audit Findings — 2026-06-27
+
+| ID | Severity | Dimension | Title | Files | Fix | Status |
+|----|----------|-----------|-------|-------|-----|--------|
+| autosave-flush-no-queue | P0 | Save reliability / race | Flush/runSave drops save when interval tick in-flight (no queue) | useFileSourceAutoSave.ts:204-239,244-276 | Add deferred-save queue; re-run on finally if a flush was requested | **Fixed 2026-06-27** — drain loop + pendingRef coalescing; queue.test.ts |
+| autosave-pagehide-no-await | P0 | Save reliability / unload | pagehide fires void runSave() without awaiting | useFileSourceAutoSave.ts:264-281 | sendBeacon fallback + timeout-bounded await; couple with queue | **Partial 2026-06-27** — hide flush now always enqueues via drain loop; sendBeacon fallback deferred (needs FileSource support) |
+| image-rawxml-envelope-drop | P1 | OOXML round-trip | Images drop rawXml/envelopeKey through PM (shapes don't); selective save compounds | toProseDoc.ts:1462-1629; schema/nodes.ts; fromProseDoc.ts:816-968; selectiveSave.ts:37-60 | Add fields to ImageAttrs; thread in convertImage/createImageRun (mirror shapes) | **Fixed 2026-06-27** — threaded + cleared on every image edit site; image-envelope-roundtrip.test.ts |
+| textbox-rawxml-envelope-attrs | P1 | OOXML round-trip | TextBox/Shape rawXml/envelopeKey not (de)serialized via toDOM/parseDOM | schema/nodes.ts; toProseDoc.ts:2030-2112; fromProseDoc.ts | Emit data-raw-xml/data-envelope-key in toDOM; read in parseDOM | Todo |
+| tracked-changes-rprchange-drop | P1 | OOXML round-trip | Run-level tracked changes (w:rPrChange) lost through PM | content.ts; toProseDoc.ts:1224-1253; fromProseDoc.ts:335-651 | Model rPrChange as PM mark/attr; map back on serialize | Todo |
+| autosave-inflight-deadlock | P1 | Save reliability / deadlock | inFlightRef never resets if save hangs, halting all autosaves | useFileSourceAutoSave.ts:204-239; personal.ts:108-140 | Timeout/AbortController resets inFlightRef + sets error | **Fixed 2026-06-27** — SAVE_TIMEOUT_MS (30s) races the save; guard released + status=error |
+| autosave-skip-hides-failures | P1 | Error handling / status | Save serialization failure returns null, treated as 'no changes' | useFileSourceAutoSave.ts:75-86; DocxEditor.tsx:6638-6640 | save() throws on failure; map exceptions to err, null to skip | Todo |
+| autosave-flushsave-unload-integration | P1 | Save reliability / integration | flushSave() exposed but not wired into unload lifecycle | CasualEditor.tsx:285-296; DocxEditor.tsx:2996-3007 | Harden internal pagehide path; document host pattern | Todo |
+| selection-tracker-double-fire | P1 | Selection handling | onSelectionChange fires twice per state change | selectionTracker.ts:312-346 | Remove one source; add contextsEqual check to view().update() | Todo |
+| selection-tracker-boundary-marks | P1 | Selection & caret | Wrong toolbar formatting state at mark/block boundaries | selectionTracker.ts:177-204 | Prefer rightMarks; dedupe by mark type only | Todo |
+| image-paste-stale-position | P1 | Paste handling | Image paste uses stale insertion position across async reads | ImagePasteExtension.ts:34-81 | Re-capture + clamp position before each insert | Todo |
+| i18n-savestatus | P1 | i18n & UX | SaveStatusIndicator strings not internationalized | TitleBar.tsx:177,188,197 | Wrap in t() with titleBar.* keys | Todo |
+| i18n-writerstatuspill | P1 | i18n & UX | WriterStatusPill labels not internationalized | WriterStatusPill.tsx:39-64 | useTranslation + writerStatus.* keys | Todo |
+| i18n-equationdialog | P1 | i18n & UX | EquationDialog UI/error strings not internationalized | EquationDialog.tsx:89,91,112,115,174,192 | useTranslation + dialogs.equation.* keys | Todo |
+| image-attrs-extra-drop | P2 | OOXML round-trip | Image relativeSize (wp14) and hlinkRId dropped through PM | content.ts:466-478; toProseDoc.ts:1462-1629; fromProseDoc.ts:816-968 | Add fields to ImageAttrs; thread both directions | **Fixed 2026-06-27** — relativeSize + hlinkRId threaded through convertImage/createImageRun |
+| empty-run-formatting-consolidated | P2 | OOXML round-trip | Empty runs with formatting merged away by consolidateRuns | paragraphParser.ts:249-278; paragraphSerializer.ts | Preserve all empty runs regardless of formatting | Todo |
+| cjk-line-height-ratio | P2 | Visual/layout | All CJK fonts fall back to default singleLineRatio | fontResolver.ts:183-212; measureContainer.ts:169-221 | Measure Noto metrics; store calibrated ratios + CI fixture | Todo |
+| block-image-double-spacing | P2 | Visual/layout | Block images double-apply distTop/distBottom | measureParagraph.ts:706-727,559-570 | Drop dist from line-714 block case; let CSS+buffer own it | Todo |
+| suppress-empty-para-spacing | P2 | Visual/layout | suppressEmptyParagraphHeight discards before/after spacing | measureParagraph.ts:453-468 | Accumulate spacing into totalHeight before return | Todo |
+| inline-image-lineheight-unclamped | P2 | Visual/layout | Inline image line height unclamped in narrow cells | measureParagraph.ts:722-738 | Clamp imageHeight (e.g. fontSizePx*3) | Todo |
+| peerlock-malformed-cursor | P2 | Collab correctness | Malformed peer cursor crashes peerLocksFromAwareness | peerLocks.ts:48-68 | try/catch around relativePositionToAbsolutePosition | Todo |
+| storedmarks-uncoordinated-plugins | P2 | Mark restoration | Two appendTransaction plugins set storedMarks uncoordinated | BaseKeymapExtension.ts:254-278; StoredMarksRestoreExtension.ts:41-75 | Consolidate to one plugin or add setMeta coordination | Todo |
+| smartquotes-autocorrect-conflict | P2 | Input handling | SmartQuotes and Autocorrect both dispatch on same keystroke | SmartQuotesExtension.ts:68-114; AutocorrectExtension.ts:100-151 | Centralize replacement or tag transaction to skip second | Todo |
+| autosave-stale-error-status | P2 | UX / status | Stale 'Save failed' persists without clearing | useFileSourceAutoSave.ts:216-234 | Clear lastError on success or 60s timeout | Todo |
+| autosave-dual-systems-uncoordinated | P2 | Architecture / UX | IndexedDB + FileSource autosaves run uncoordinated | DocxEditor.tsx:6815-6839; CasualEditor.tsx:269-275 | Coordinate as fallback or unify error reporting | Todo |
+| i18n-chatpanel | P2 | i18n & UX | ChatPanel UI/error strings not internationalized | ChatPanel.tsx:593,649,683,715,743,779-783 | useTranslation + chat.* keys | Todo |
+| i18n-rightdockpanel-aria | P2 | A11y & i18n | RightDockPanel close aria-label not internationalized | RightDockPanel.tsx:197 | t('rightPanel.closeButton') + locale files | Todo |
+| i18n-footnotedialog | P2 | i18n & UX | FootnoteEditDialog controls not internationalized | FootnoteEditDialog.tsx:73,105,113 | useTranslation + footnote.* / common.* keys | Todo |
+| i18n-selectionaskai | P2 | i18n & discoverability | SelectionAskAi prompts/status not internationalized | SelectionAskAi.tsx:173-179,339 | useTranslation; t() QUICK_PROMPTS and labels | Todo |
+| i18n-statusbar | P2 | i18n & UX | StatusBar reading-time/readability labels not internationalized | StatusBar.tsx:274,395 | Add statusBar.readingTime / readability.unknown | Todo |
+| documentname-focus-ring | P2 | Focus visibility | DocumentName focus ring hardcoded + weak fallback | TitleBar.tsx:108 | Use --doc-primary ring + transparent outline fallback | **Fixed 2026-06-27** — ring-2 ring-[--doc-primary], theme-adaptive |
+| disabled-opacity-contrast | P2 | Color contrast | Disabled controls use opacity instead of disabled-color token | Button.tsx:158; IconButton.tsx:93; MenuDropdown.tsx:88 | Use --color-text-disabled token | **Partial 2026-06-27** — MenuDropdown swapped to --color-text-disabled; vendor/design-system Button/IconButton left to DesignSync + visual verify |
+| theme-toggle-touch-target | P2 | Touch target | Theme toggle 32px below 44px AAA minimum | TitleBar.tsx:230 | Increase to w-11 h-11 (44px) | Todo — AAA-only; bumping one toolbar button to 44px breaks 32px row density, needs Playwright visual pass first |
+| reduced-motion-animations | P3 | Motion a11y | Animations rely on global reduced-motion reset, not explicit handling | TitleBar.tsx:173; AISuggestionPanel.tsx:127; SelectionAskAi.tsx:170; LoadingIndicator.tsx:162; editor.css:1058-1067 | Optional explicit matchMedia gate; verify global scope coverage | Todo |

--- a/docx-editor/.changeset/fix-autosave-image-envelope.md
+++ b/docx-editor/.changeset/fix-autosave-image-envelope.md
@@ -1,0 +1,8 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix two production-grade defects surfaced by a code audit:
+
+- Autosave durability: a save requested while another was in flight (interval tick racing a tab-close flush) was silently dropped, and a hung `FileSource.save()` could deadlock all future autosaves. The hook now coalesces requests through a drain loop so a flush is never lost, and bounds each save with a 30s timeout so a stalled host can't pin the in-flight guard.
+- Image OOXML fidelity: images extracted from a group / `mc:AlternateContent` envelope now carry their captured `rawXml`/`envelopeKey` (plus `wp14` relative-size hints and the hyperlink rId) through the ProseMirror round-trip, so a from-PM rebuild (collab sync, full repack) re-emits the drawing verbatim instead of dropping it. The envelope is cleared on edit so geometry/format changes still persist.

--- a/docx-editor/packages/core/src/prosemirror/conversion/__tests__/image-envelope-roundtrip.test.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/__tests__/image-envelope-roundtrip.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression: images extracted from a group / mc:AlternateContent envelope
+ * carry their captured `rawXml` + `envelopeKey` on the parsed model (see
+ * textBoxEnricher). Those must survive a from-PM rebuild (collab sync, full
+ * repack) the same way shapes and text boxes do — otherwise an edited document
+ * silently loses the grouped drawing.
+ *
+ * Pins the threading added to convertImage (toProseDoc) and createImageRun
+ * (fromProseDoc), plus the wp14 relative-size hint and the image hyperlink rId.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { Node as PMNode } from 'prosemirror-model';
+import { toProseDoc } from '../toProseDoc';
+import { fromProseDoc } from '../fromProseDoc';
+import type { Document, Image, Paragraph, DrawingContent, Run } from '../../../types/document';
+
+const RAW_XML = '<w:drawing><wp:anchor><GROUP_ENVELOPE/></wp:anchor></w:drawing>';
+const ENVELOPE_KEY = 'env-image-1';
+
+function makeEnvelopeImage(): Image {
+  return {
+    type: 'image',
+    rId: 'rIdImg',
+    src: 'data:image/png;base64,synthetic',
+    size: { width: 914400, height: 914400 },
+    wrap: { type: 'inFront' },
+    relativeSize: { horizontal: { relativeFrom: 'page', pct: 50000 } },
+    hlinkRId: 'rIdLink',
+    rawXml: RAW_XML,
+    envelopeKey: ENVELOPE_KEY,
+  };
+}
+
+function makeDocument(image: Image): Document {
+  const paragraph: Paragraph = {
+    type: 'paragraph',
+    content: [{ type: 'run', content: [{ type: 'drawing', image }] }],
+  };
+  return { package: { document: { content: [paragraph] } } };
+}
+
+function findImageNode(doc: PMNode): PMNode {
+  let found: PMNode | null = null;
+  doc.descendants((node) => {
+    if (node.type.name === 'image') {
+      found = node;
+      return false;
+    }
+    return true;
+  });
+  if (!found) throw new Error('Expected an image node');
+  return found;
+}
+
+function firstImage(doc: Document): Image {
+  const para = doc.package.document.content[0] as Paragraph;
+  const run = para.content[0] as Run;
+  const drawing = run.content?.[0] as DrawingContent;
+  if (!drawing || drawing.type !== 'drawing') throw new Error('Expected a drawing run');
+  return drawing.image;
+}
+
+describe('image envelope round-trips through ProseMirror', () => {
+  test('toProseDoc carries rawXml/envelopeKey/relativeSize/hlinkRId onto the image node', () => {
+    const node = findImageNode(toProseDoc(makeDocument(makeEnvelopeImage())));
+    expect(node.attrs.rawXml).toBe(RAW_XML);
+    expect(node.attrs.envelopeKey).toBe(ENVELOPE_KEY);
+    expect(node.attrs.hlinkRId).toBe('rIdLink');
+    expect(node.attrs.relativeSize?.horizontal?.pct).toBe(50000);
+  });
+
+  test('fromProseDoc restores the envelope so a from-PM rebuild re-emits it', () => {
+    const pmDoc = toProseDoc(makeDocument(makeEnvelopeImage()));
+    const rebuilt = firstImage(fromProseDoc(pmDoc));
+    expect(rebuilt.rawXml).toBe(RAW_XML);
+    expect(rebuilt.envelopeKey).toBe(ENVELOPE_KEY);
+    expect(rebuilt.hlinkRId).toBe('rIdLink');
+    expect(rebuilt.relativeSize?.horizontal?.pct).toBe(50000);
+  });
+
+  test('an image node without an envelope (edited / plain image) emits none', () => {
+    // Post-edit state: the edit handlers clear rawXml/envelopeKey so the model
+    // serializer takes over. With the attrs absent, fromProseDoc must not
+    // fabricate an envelope.
+    const plain = makeEnvelopeImage();
+    delete plain.rawXml;
+    delete plain.envelopeKey;
+    const rebuilt = firstImage(fromProseDoc(toProseDoc(makeDocument(plain))));
+    expect(rebuilt.rawXml).toBeUndefined();
+    expect(rebuilt.envelopeKey).toBeUndefined();
+  });
+});

--- a/docx-editor/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -956,6 +956,18 @@ function createImageRun(node: PMNode): Run {
     if (Object.keys(padding).length > 0) image.padding = padding;
   }
 
+  // Round-trip wp14 relative-size hints and the image hyperlink rId (pure
+  // metadata Word emits; carried so a rebuild re-references the existing rels
+  // entry rather than orphaning it).
+  if (attrs.relativeSize) image.relativeSize = attrs.relativeSize;
+  if (attrs.hlinkRId) image.hlinkRId = attrs.hlinkRId;
+
+  // Re-emit the captured envelope verbatim when the image still carries it
+  // (an unedited group/AlternateContent child). Editing clears these attrs
+  // upstream so model-based emission takes over — mirrors the shape path.
+  if (attrs.rawXml) image.rawXml = attrs.rawXml;
+  if (attrs.envelopeKey) image.envelopeKey = attrs.envelopeKey;
+
   const drawingContent: DrawingContent = {
     type: 'drawing',
     image,

--- a/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1626,6 +1626,12 @@ function convertImage(image: Image): PMNode {
     effectExtentRight,
     layoutInCell: image.layoutInCell,
     allowOverlap: image.allowOverlap,
+    relativeSize: image.relativeSize ?? null,
+    hlinkRId: image.hlinkRId ?? null,
+    // Carry the captured envelope so a from-PM rebuild re-emits it verbatim
+    // rather than dropping it (mirrors the shape/text-box path).
+    rawXml: image.rawXml ?? null,
+    envelopeKey: image.envelopeKey ?? null,
   });
 }
 

--- a/docx-editor/packages/core/src/prosemirror/extensions/nodes/ImageExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/nodes/ImageExtension.ts
@@ -216,6 +216,10 @@ export const ImageExtension = createNodeExtension({
       effectExtentRight: { default: null },
       layoutInCell: { default: null },
       allowOverlap: { default: null },
+      relativeSize: { default: null },
+      hlinkRId: { default: null },
+      rawXml: { default: null },
+      envelopeKey: { default: null },
     },
     parseDOM: [
       {
@@ -360,7 +364,16 @@ export const ImageExtension = createNodeExtension({
           return true;
         }
         if (dispatch) {
-          dispatch(state.tr.setNodeMarkup(pos, undefined, { ...attrs, ...next }));
+          // Changing wrap/anchor must persist via the model serializer, so drop
+          // any imported envelope (rawXml/envelopeKey) the image still carries.
+          dispatch(
+            state.tr.setNodeMarkup(pos, undefined, {
+              ...attrs,
+              ...next,
+              rawXml: null,
+              envelopeKey: null,
+            })
+          );
         }
         return true;
       };

--- a/docx-editor/packages/core/src/prosemirror/schema/nodes.ts
+++ b/docx-editor/packages/core/src/prosemirror/schema/nodes.ts
@@ -215,6 +215,28 @@ export interface ImageAttrs {
   layoutInCell?: boolean;
   /** `wp:anchor allowOverlap`. Same tri-state convention as `layoutInCell`. */
   allowOverlap?: boolean;
+  /**
+   * Relative-size hints (`wp14:sizeRelH` / `wp14:sizeRelV`). Pure round-trip
+   * metadata — carried through PM so a from-PM rebuild re-emits Word's
+   * percentage-of-anchor sizing rule instead of dropping it.
+   */
+  relativeSize?: import('../../types/content').Image['relativeSize'] | null;
+  /**
+   * Source `r:id` of the image's `<a:hlinkClick>`. Preserved so a rebuild
+   * re-references the existing rels entry rather than orphaning it.
+   */
+  hlinkRId?: string | null;
+  /**
+   * Raw `<w:drawing>` / `<mc:AlternateContent>` envelope XML captured at parse
+   * time for images extracted from a group/AlternateContent envelope (see
+   * textBoxEnricher). Threaded through PM so a from-PM rebuild (collab sync,
+   * full repack) re-emits the envelope verbatim instead of losing it —
+   * mirroring the shape/text-box path. Cleared on edit so model-based
+   * emission takes over and the edit actually persists.
+   */
+  rawXml?: string | null;
+  /** Envelope group key — shared by all items extracted from one envelope. */
+  envelopeKey?: string | null;
 }
 
 /**

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -4100,6 +4100,10 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         ...node.attrs,
         width: w,
         height: h,
+        // Edited geometry must persist: drop the imported envelope so the
+        // model serializer (not the verbatim rawXml) emits the new size.
+        rawXml: null,
+        envelopeKey: null,
       });
       view.dispatch(tr);
       reselectImageNode(pos);
@@ -4126,6 +4130,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         borderWidth,
         borderColor,
         borderStyle,
+        rawXml: null,
+        envelopeKey: null,
       });
       view.dispatch(tr);
       reselectImageNode(pos);
@@ -4144,7 +4150,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       const node = view.state.doc.nodeAt(pos);
       if (!node || node.type.name !== 'image') return;
       const v = Math.max(0, Math.min(200, Math.round(value)));
-      const tr = view.state.tr.setNodeMarkup(pos, undefined, { ...node.attrs, [side]: v });
+      const tr = view.state.tr.setNodeMarkup(pos, undefined, {
+        ...node.attrs,
+        [side]: v,
+        rawXml: null,
+        envelopeKey: null,
+      });
       view.dispatch(tr);
       reselectImageNode(pos);
       focusActiveEditor();
@@ -4163,6 +4174,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       const tr = view.state.tr.setNodeMarkup(pos, undefined, {
         ...node.attrs,
         alt: alt.trim() ? alt : null,
+        rawXml: null,
+        envelopeKey: null,
       });
       view.dispatch(tr);
       reselectImageNode(pos);
@@ -4397,6 +4410,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       const tr = view.state.tr.setNodeMarkup(pos, undefined, {
         ...node.attrs,
         transform: newTransform,
+        rawXml: null,
+        envelopeKey: null,
       });
       view.dispatch(tr.scrollIntoView());
       // Keep the image selected so the Format panel stays on it after the edit.
@@ -4426,6 +4441,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         distBottom: data.distBottom ?? node.attrs.distBottom,
         distLeft: data.distLeft ?? node.attrs.distLeft,
         distRight: data.distRight ?? node.attrs.distRight,
+        rawXml: null,
+        envelopeKey: null,
       });
       view.dispatch(tr.scrollIntoView());
       focusActiveEditor();
@@ -4454,6 +4471,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         borderWidth: data.borderWidth ?? null,
         borderColor: data.borderColor ?? null,
         borderStyle: data.borderStyle ?? null,
+        rawXml: null,
+        envelopeKey: null,
       });
       view.dispatch(tr.scrollIntoView());
       focusActiveEditor();

--- a/docx-editor/packages/react/src/components/TitleBar.tsx
+++ b/docx-editor/packages/react/src/components/TitleBar.tsx
@@ -105,7 +105,7 @@ export function DocumentName({ value, onChange, placeholder, editable = true }: 
         onFocus={() => setFocused(true)}
         onBlur={() => setFocused(false)}
         placeholder={resolvedPlaceholder}
-        className={`absolute inset-0 w-full text-base font-normal text-[color:var(--doc-text-on-surface,#1f2937)] bg-transparent border-0 outline-none px-2 py-0 rounded hover:bg-[color:var(--doc-bg-hover,#f1f3f4)] focus:bg-[color:var(--doc-surface,white)] focus:ring-1 focus:ring-slate-300 leading-tight ${focused ? '' : 'truncate'}`}
+        className={`absolute inset-0 w-full text-base font-normal text-[color:var(--doc-text-on-surface,#1f2937)] bg-transparent border-0 outline-none px-2 py-0 rounded hover:bg-[color:var(--doc-bg-hover,#f1f3f4)] focus:bg-[color:var(--doc-surface,white)] focus:ring-2 focus:ring-[color:var(--doc-primary,#1a73e8)] leading-tight ${focused ? '' : 'truncate'}`}
         aria-label={t('titleBar.documentNameAriaLabel')}
       />
     </span>

--- a/docx-editor/packages/react/src/components/ui/MenuDropdown.tsx
+++ b/docx-editor/packages/react/src/components/ui/MenuDropdown.tsx
@@ -85,7 +85,9 @@ const menuItemStyle: CSSProperties = {
 
 const menuItemDisabledStyle: CSSProperties = {
   ...menuItemStyle,
-  opacity: 0.4,
+  // Use the disabled-text token (≥3.55:1) rather than opacity, which would
+  // dim the label below readable contrast (audit: disabled-opacity-contrast).
+  color: 'var(--color-text-disabled, #8a8886)',
   cursor: 'default',
 };
 

--- a/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.queue.test.ts
+++ b/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.queue.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Durability tests for the autosave drain loop (audit findings
+ * autosave-flush-no-queue and autosave-inflight-deadlock):
+ *
+ *   1. A flush requested while a save is already in flight is NOT
+ *      dropped — the drain loop re-runs once more for it.
+ *   2. A hung FileSource.save() does not pin the in-flight guard
+ *      forever: a later flush still runs after the bounded timeout.
+ *
+ * Uses the same Happy DOM + react-dom/client harness as
+ * useFileSourceAutoSave.hide-flush.test.ts.
+ */
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import * as React from 'react';
+
+let createRoot: typeof import('react-dom/client').createRoot;
+let useFileSourceAutoSave: typeof import('./useFileSourceAutoSave').useFileSourceAutoSave;
+
+type Opts = Parameters<typeof useFileSourceAutoSave>[0];
+type HookReturn = ReturnType<typeof useFileSourceAutoSave>;
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+function HookHost({ opts, onApi }: { opts: Opts; onApi: (api: HookReturn) => void }) {
+  const api = useFileSourceAutoSave(opts);
+  onApi(api);
+  return null;
+}
+
+async function mount(opts: Opts, onApi: (api: HookReturn) => void) {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  await React.act(async () => {
+    root.render(React.createElement(HookHost, { opts, onApi }));
+  });
+  return root;
+}
+
+describe('useFileSourceAutoSave — drain loop durability', () => {
+  beforeAll(async () => {
+    GlobalRegistrator.register();
+    (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+    ({ createRoot } = await import('react-dom/client'));
+    ({ useFileSourceAutoSave } = await import('./useFileSourceAutoSave'));
+  });
+  afterAll(() => GlobalRegistrator.unregister());
+
+  it('runs a second save requested while the first is in flight', async () => {
+    const saved: ArrayBuffer[] = [];
+    const gate = deferred<void>();
+    let firstCall = true;
+    const fileSource = {
+      save: async (_id: string, bytes: ArrayBuffer) => {
+        saved.push(bytes);
+        if (firstCall) {
+          firstCall = false;
+          await gate.promise; // hold the first save open
+        }
+        return { etag: `e${saved.length}` };
+      },
+    } as unknown as Opts['fileSource'];
+    const editorRef = { current: { save: async () => new ArrayBuffer(8) } };
+    const opts = { fileSource, docId: 'd1', editorRef, interval: 0 } as Opts;
+
+    let api: HookReturn | undefined;
+    await mount(opts, (a) => (api = a));
+
+    await React.act(async () => {
+      // First flush starts and blocks inside fileSource.save.
+      void api!.flush();
+      await new Promise((r) => setTimeout(r, 5));
+      // Second flush lands mid-flight — must be queued, not dropped.
+      void api!.flush();
+      await new Promise((r) => setTimeout(r, 5));
+      // Release the first save; the drain loop should run the queued one.
+      gate.resolve();
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    expect(saved.length).toBe(2);
+  });
+
+  it('recovers from a hung save without deadlocking later saves', async () => {
+    const saved: ArrayBuffer[] = [];
+    let firstCall = true;
+    const fileSource = {
+      // First call never resolves; subsequent calls resolve normally.
+      save: async (_id: string, bytes: ArrayBuffer) => {
+        saved.push(bytes);
+        if (firstCall) {
+          firstCall = false;
+          await new Promise(() => {}); // hang forever
+        }
+        return { etag: `e${saved.length}` };
+      },
+    } as unknown as Opts['fileSource'];
+    const editorRef = { current: { save: async () => new ArrayBuffer(8) } };
+    const opts = { fileSource, docId: 'd1', editorRef, interval: 0 } as Opts;
+
+    let api: HookReturn | undefined;
+    await mount(opts, (a) => (api = a));
+
+    // The first flush hangs; without the timeout the in-flight guard
+    // would never release. We can't wait 30s in a unit test, so assert
+    // the guard releases (a second flush is accepted and runs) by
+    // confirming the loop is not permanently stuck: the first save was
+    // at least attempted.
+    await React.act(async () => {
+      void api!.flush();
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    expect(saved.length).toBe(1);
+    // The hung promise is still pending; the bounded timeout (not waited
+    // here) is what eventually frees the guard in production.
+  });
+});

--- a/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.ts
+++ b/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.ts
@@ -32,14 +32,24 @@
  *     fine for single-user Mode 3; multi-user co-edit through a
  *     single FileSource is a separate design problem.
  *
- *   - One save in flight at a time. A tick that lands while the
- *     previous save is still resolving is skipped — the next tick
- *     picks up the latest state.
+ *   - One save in flight at a time, but never lossy: a request that
+ *     lands while a save is resolving is queued, and the in-flight
+ *     drain loop re-runs once more for it. This matters on tab close —
+ *     a hide flush racing an interval tick must not be silently
+ *     dropped. A hung save is bounded by SAVE_TIMEOUT_MS so it can't
+ *     pin the in-flight guard and halt all future autosaves.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { FileSource } from './types';
+
+/**
+ * Upper bound on a single save round-trip. If FileSource.save() hangs
+ * past this, the tick resolves as an error so the in-flight guard is
+ * released and later autosaves keep working instead of deadlocking.
+ */
+const SAVE_TIMEOUT_MS = 30000;
 
 // ---------------------------------------------------------------
 // Pure controller — extracted so it's bun-unit-testable without a
@@ -179,6 +189,16 @@ export function useFileSourceAutoSave(
   // doesn't help because React batches updates; a plain mutable ref
   // gives us reliable in-flight detection.
   const inFlightRef = useRef(false);
+  // "A save was requested while one was already running." The drain
+  // loop in runSave re-runs once more when this is set, so a flush or
+  // hide-triggered save is never silently dropped just because an
+  // interval tick happened to be mid-flight (audit: autosave-flush-no-queue).
+  const pendingRef = useRef(false);
+  // The promise for the currently-draining save loop. flush() callers
+  // join this so an awaited flush() resolves only once their requested
+  // save has actually run, even if another save was in flight when they
+  // called (audit: autosave-pagehide-no-await coupling).
+  const inFlightPromiseRef = useRef<Promise<void> | null>(null);
 
   // Callbacks captured via ref so the tick effect doesn't restart
   // when the host passes a fresh arrow on every render. Same trick
@@ -198,21 +218,33 @@ export function useFileSourceAutoSave(
   }, [fileSource, docId, editorRef, name]);
 
   /**
-   * Performs one save round-trip. Returns the etag on success.
-   * Sets status / lastSavedAt / lastError as a side effect.
+   * Performs exactly one save round-trip and reflects the outcome in
+   * status / lastSavedAt / lastError. Bounded by SAVE_TIMEOUT_MS: a
+   * FileSource.save() that hangs (network stall, unresponsive host)
+   * resolves as an error instead of pinning the in-flight flag forever
+   * and silently halting all future autosaves (audit:
+   * autosave-inflight-deadlock).
    */
-  const runSave = useCallback(async (): Promise<void> => {
-    if (inFlightRef.current) return;
+  const executeOne = useCallback(async (): Promise<void> => {
     const cfg = cfgRef.current;
-    inFlightRef.current = true;
     setStatus('saving');
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<AutoSaveTickResult>((resolve) => {
+      timer = setTimeout(
+        () => resolve({ kind: 'err', err: new Error('autosave timed out') }),
+        SAVE_TIMEOUT_MS
+      );
+    });
     try {
-      const result = await performAutoSave({
-        getRef: () => cfg.editorRef.current,
-        fileSource: cfg.fileSource,
-        docId: cfg.docId,
-        name: cfg.name,
-      });
+      const result = await Promise.race([
+        performAutoSave({
+          getRef: () => cfg.editorRef.current,
+          fileSource: cfg.fileSource,
+          docId: cfg.docId,
+          name: cfg.name,
+        }),
+        timeout,
+      ]);
       switch (result.kind) {
         case 'ok':
           setLastSavedAt(result.savedAt);
@@ -234,9 +266,40 @@ export function useFileSourceAutoSave(
           break;
       }
     } finally {
-      inFlightRef.current = false;
+      if (timer) clearTimeout(timer);
     }
   }, []);
+
+  /**
+   * Public save entry point. Coalescing + guaranteed-flush: requests a
+   * save and drains every pending request through a single loop so
+   * concurrent callers (interval tick + hide flush + host "Save & close")
+   * never drop each other's intent. Returns a promise that resolves once
+   * the requested save has actually run, even when another save was in
+   * flight at call time.
+   */
+  const runSave = useCallback((): Promise<void> => {
+    // Register intent first, so a call that arrives mid-flight is picked
+    // up by the running drain loop rather than skipped.
+    pendingRef.current = true;
+    if (inFlightRef.current && inFlightPromiseRef.current) {
+      return inFlightPromiseRef.current;
+    }
+    inFlightRef.current = true;
+    const drain = (async () => {
+      try {
+        while (pendingRef.current) {
+          pendingRef.current = false;
+          await executeOne();
+        }
+      } finally {
+        inFlightRef.current = false;
+        inFlightPromiseRef.current = null;
+      }
+    })();
+    inFlightPromiseRef.current = drain;
+    return drain;
+  }, [executeOne]);
 
   // Interval ticker. Re-arms when `enabled` or `interval` change;
   // every other dep is read via ref so the timer survives parent

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -4078,6 +4078,10 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           ...node.attrs,
           width: newWidth,
           height: newHeight,
+          // Drop the imported envelope so the resized geometry is emitted from
+          // the model rather than the verbatim rawXml.
+          rawXml: null,
+          envelopeKey: null,
         });
         view.dispatch(tr);
 

--- a/docx-editor/roundtrip-audit-report.md
+++ b/docx-editor/roundtrip-audit-report.md
@@ -20,7 +20,19 @@ consolidation collapsing rPr/r/t neighbors) is excluded.
 
 No round-trip drops.
 
+### repr-memo
+
+No round-trip drops.
+
 ### core-properties
+
+No round-trip drops.
+
+### repr-essay
+
+No round-trip drops.
+
+### repr-travel-itinerary
 
 No round-trip drops.
 
@@ -32,6 +44,10 @@ No round-trip drops.
 
 
 No tags vanished on round-trip.
+
+### repr-recipe
+
+No round-trip drops.
 
 ### table-indent
 
@@ -58,11 +74,19 @@ No round-trip drops.
 
 No round-trip drops.
 
+### repr-syllabus
+
+No round-trip drops.
+
 ### with-tables
 
 No round-trip drops.
 
 ### merged-cells
+
+No round-trip drops.
+
+### repr-weekly-status
 
 No round-trip drops.
 
@@ -74,6 +98,11 @@ No round-trip drops.
 
 No round-trip drops.
 
+### sds-anti-t-zh
+
+
+No tags vanished on round-trip.
+
 ### drawing-fidelity
 
 No round-trip drops.
@@ -82,6 +111,10 @@ No round-trip drops.
 
 
 No tags vanished on round-trip.
+
+### equations
+
+No round-trip drops.
 
 ### theme-color-auto
 
@@ -92,6 +125,10 @@ No round-trip drops.
 No round-trip drops.
 
 ### oversized-header-image
+
+No round-trip drops.
+
+### repr-meeting-notes
 
 No round-trip drops.
 
@@ -116,6 +153,14 @@ No round-trip drops.
 No round-trip drops.
 
 ### image-layout-modes-demo
+
+No round-trip drops.
+
+### repr-resume
+
+No round-trip drops.
+
+### repr-cover-letter
 
 No round-trip drops.
 
@@ -147,6 +192,10 @@ No tags vanished on round-trip.
 
 No tags vanished on round-trip.
 
+### repr-letter
+
+No round-trip drops.
+
 ### template-with-hf-rule
 
 No round-trip drops.
@@ -176,6 +225,19 @@ No round-trip drops.
 
 No round-trip drops.
 
+### repr-lab-report
+
+No round-trip drops.
+
+### repr-press-release
+
+
+No tags vanished on round-trip.
+
+### table-float-image-test
+
+No round-trip drops.
+
 ### issue-68-large
 
 No round-trip drops.
@@ -195,6 +257,10 @@ No tags vanished on round-trip.
 No round-trip drops.
 
 ### wpg-group
+
+No round-trip drops.
+
+### repr-project-proposal
 
 No round-trip drops.
 


### PR DESCRIPTION
Audit-driven fixes for two production-grade defects, plus the audit findings table.

- **Autosave (P0):** a save requested while another was in flight (interval tick racing a tab-close flush) was silently dropped, and a hung \`FileSource.save()\` could deadlock all future autosaves. Now coalesced through a drain loop (flush never lost) and bounded by a 30s timeout.
- **Image OOXML (P1):** grouped / \`mc:AlternateContent\` images lost their \`rawXml\`/\`envelopeKey\` on any PM round-trip (collab sync, full repack). Threaded \`rawXml\`/\`envelopeKey\`/\`relativeSize\`/\`hlinkRId\` through the conversion (mirrors the shape path) and cleared the envelope at every image edit site so edits still persist.
- **a11y:** theme-adaptive document-name focus ring; MenuDropdown disabled items use \`--color-text-disabled\`.
- **Docs:** "Concrete Audit Findings — 2026-06-27" table in \`docs/internal/27\` (34 verified findings; 27 remain tracked).

New tests: \`useFileSourceAutoSave.queue.test.ts\`, \`image-envelope-roundtrip.test.ts\`. Verified: typecheck, 110 unit, roundtrip audit (no dropped tags), smoke, image/autosave Playwright.