### PR TITLE
fix(desktop): clear bound file path on File→New so it can't overwrite the old file

### DIFF
--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -724,6 +724,15 @@ export function App() {
     setDocumentBuffer(null);
     setFileName('Untitled.docx');
     setStatus('');
+    // Desktop: a brand-new blank document must NOT stay bound to the path of
+    // the file this window previously had open — otherwise the next Save would
+    // overwrite that file on disk with the blank content. Clear the bound path
+    // so save() falls through to saveAs() (prompts for a location), matching
+    // the untitled-document save semantics.
+    const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
+    if (bridge?.isDesktop) {
+      bridge.filePath = null;
+    }
     // Navigate to the canonical draft URL so back / refresh / bookmark
     // converge. The route effect picks this up and flips view='editor'.
     // The legacy-flag check inside that effect ensures `?e2e=1` specs


### PR DESCRIPTION
In desktop mode, File→New replaced the document in-window but left `window.__deskApp__.filePath` bound to the previously-open file — so the next Save wrote the new blank content over that file on disk (silent cross-file data loss). `handleNewDocument` now clears `bridge.filePath`, so `save()` falls through to `saveAs()` (prompts for a location), matching the untitled-document save semantics.

Scoped to the example app's New action. A related vector — File→**Open** inside `DocxEditor` (hidden file input) also replaces the doc in-window without rebinding `filePath` — lives in the published `packages/react` and is tracked as a separate follow-up.