### PR TITLE
fix(desktop): drive dirty flag from doc-change, not a DOM keystroke heuristic

### DIFF
--- a/docx-editor/e2e/tests/desktop-dirty-tracking.spec.ts
+++ b/docx-editor/e2e/tests/desktop-dirty-tracking.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Desktop dirty-tracking regression.
+ *
+ * The Tauri shell's unsaved-changes close-guard only prompts when the window
+ * is flagged dirty. That flag used to be driven by a DOM keystroke heuristic,
+ * which missed every mouse/toolbar/menu edit (bold, tables, format painter,
+ * accept/reject) — so closing after a toolbar-only edit silently discarded the
+ * work. The bridge now takes the dirty signal from DocxEditor's `onChange`
+ * (forwarded by App.tsx → `window.__deskApp__.setDirty`).
+ *
+ * This stubs a desktop bridge that records setDirty calls and asserts a
+ * toolbar-only Bold edit (no typing) marks the window dirty.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test('toolbar-only edit marks the desktop window dirty', async ({ page }) => {
+  await page.addInitScript(() => {
+    const w = window as unknown as { __deskDirtyCalls: boolean[]; __deskApp__: unknown };
+    w.__deskDirtyCalls = [];
+    w.__deskApp__ = {
+      isDesktop: true,
+      filePath: null,
+      fileKind: 'docx',
+      loadDocument: async () => {
+        throw new Error('not used');
+      },
+      save: async () => null,
+      saveAs: async () => null,
+      setDirty: (dirty: boolean) => {
+        w.__deskDirtyCalls.push(dirty);
+      },
+      dismissBoot: () => undefined,
+    };
+  });
+
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.focus();
+
+  // Type some text (this also marks dirty), then clear the record so the
+  // assertion isolates the TOOLBAR edit — the case the old heuristic missed.
+  await editor.typeText('Hello world');
+  await page.evaluate(() => {
+    (window as unknown as { __deskDirtyCalls: boolean[] }).__deskDirtyCalls.length = 0;
+  });
+
+  // Toolbar-only edit: select via the API + click the Bold toolbar button.
+  // No keypress that the old input/keydown heuristic would have caught.
+  await editor.selectText('Hello');
+  await editor.applyBold();
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as unknown as { __deskDirtyCalls: boolean[] }).__deskDirtyCalls,
+      ),
+    )
+    .toContain(true);
+});

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -944,6 +944,16 @@ export function App() {
     }
   }, []); // bridge.saveAs is stable
 
+  // Forward DocxEditor's authoritative document-change signal to the desktop
+  // bridge so the Rust close-guard sees a dirty window for EVERY real edit —
+  // including mouse/toolbar/menu edits (bold, tables, format painter, accept/
+  // reject) that the bridge's old DOM keystroke heuristic missed. save()/saveAs()
+  // clear the flag. No-op on web (no bridge).
+  const onDocChangeDesktop = useCallback(() => {
+    const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
+    bridge?.setDirty?.(true);
+  }, []);
+
   // Dismiss the boot overlay once DocxEditor's PM view is live and the
   // first layout paint is imminent. This fires AFTER parseDocx completes,
   // avoiding the blank-editor flash that occurred when dismissBoot was called
@@ -1220,6 +1230,9 @@ export function App() {
           // internal handleSave/handleExport don't re-reference on every status change.
           onSave={isDesktop ? onSaveDesktop : undefined}
           onExport={isDesktop ? onExportDesktop : undefined}
+          // Desktop only: mark the window dirty on every real document change
+          // so the unsaved-changes close-guard fires for mouse/toolbar edits.
+          onChange={isDesktop ? onDocChangeDesktop : undefined}
           // Dismiss the boot splash after DocxEditor has parsed the DOCX and
           // created its PM view, avoiding the blank-editor flash that occurred
           // when dismissBoot fired immediately after setDocumentBuffer.

--- a/docx-editor/examples/vite/src/desk-bridge-bootstrap.ts
+++ b/docx-editor/examples/vite/src/desk-bridge-bootstrap.ts
@@ -324,6 +324,7 @@ if (isDesktop) {
         loadText?(p?: string): Promise<string>;
         save(bytes: ArrayBuffer): Promise<string | null>;
         saveAs(name: string, bytes: ArrayBuffer): Promise<string | null>;
+        setDirty?(dirty: boolean): void;
       }
     | undefined;
 
@@ -411,27 +412,14 @@ if (isDesktop) {
         /* best-effort */
       }
     }
-    // Mark dirty on any user edit. Capture phase so we see the event even
-    // if the editor stops propagation. Heuristic: any input = dirty.
-    const markDirty = () => {
-      editSeq++;
-      setWindowDirty(true);
-    };
-    document.addEventListener('input', markDirty, true);
-    document.addEventListener('beforeinput', markDirty, true);
-    document.addEventListener(
-      'keydown',
-      (e) => {
-        // Only printable / editing keys imply a content change; ignore
-        // pure navigation / modifier chords so we don't flag dirty on
-        // Ctrl+S, arrow keys, etc.
-        if (e.ctrlKey || e.metaKey || e.altKey) return;
-        if (e.key.length === 1 || e.key === 'Enter' || e.key === 'Backspace' || e.key === 'Delete') {
-          markDirty();
-        }
-      },
-      true,
-    );
+    // The dirty signal is driven by the editor's authoritative document-change
+    // callback, not a DOM keystroke heuristic: App.tsx forwards DocxEditor's
+    // `onChange` to `bridge.setDirty(true)`. The old heuristic (input/beforeinput
+    // /printable-keydown listeners) missed every mouse/toolbar/menu edit — bold,
+    // table ops, format painter, accept/reject changes, paste via the menu —
+    // because ProseMirror dispatches those as transactions with no keyboard or
+    // input event, so the close-guard saw a "clean" window and discarded the
+    // work with no prompt. `setDirty` (below) is the single entry point now.
 
     // Chunked read in 1 MB slices to avoid IPC payload truncation for big
     // files (the default JSON number-array path silently drops the file's
@@ -460,6 +448,15 @@ if (isDesktop) {
       // @ts-expect-error setter on getter via Object.defineProperty pattern
       set filePath(v: string | null) { filePath = v; },
       get fileKind() { return fileKindFor(filePath); },
+      // Editor → bridge dirty signal. App.tsx forwards DocxEditor's `onChange`
+      // here, so every real document change (mouse/toolbar/menu edits included)
+      // marks the window dirty for the Rust close-guard. save()/saveAs() clear it.
+      setDirty(dirty: boolean) {
+        // Bump editSeq on every edit signal (even while already dirty) so an
+        // in-flight save can detect a change that landed during the write.
+        if (dirty) editSeq++;
+        setWindowDirty(dirty);
+      },
       async loadText(p?: string): Promise<string> {
         const path = p ?? filePath;
         if (!path) throw new Error('no file path bound to this window');

--- a/docx-editor/examples/vite/src/deskapp-bridge.d.ts
+++ b/docx-editor/examples/vite/src/deskapp-bridge.d.ts
@@ -57,6 +57,13 @@ declare global {
        */
       saveAs(suggestedName: string, bytes: ArrayBuffer): Promise<string | null>;
       /**
+       * Editor → bridge dirty signal for the Rust unsaved-changes close-guard.
+       * App.tsx forwards DocxEditor's `onChange` here so every real document
+       * change (mouse/toolbar/menu edits included) marks the window dirty;
+       * save()/saveAs() clear it.
+       */
+      setDirty?(dirty: boolean): void;
+      /**
        * Dismiss the cold-start boot overlay the bootstrap paints before React
        * mounts (top-level desktop windows only). Fades it out then removes it.
        * Idempotent and safe to call from both the document-load success and


### PR DESCRIPTION
The desktop bridge flagged the window dirty from `input`/`beforeinput`/printable-`keydown` events. ProseMirror dispatches mouse/toolbar/menu edits (bold, tables, format painter, accept/reject, menu paste) as transactions with **no** such event, so the dirty flag stayed false and the Rust unsaved-changes close-guard let the window close with no prompt — silently discarding the work.

Now the dirty signal comes from `DocxEditor`'s authoritative `onChange`: App.tsx forwards it to a new `bridge.setDirty(true)` (which also bumps the in-flight-save edit counter from #114); the DOM listeners are removed. This mirrors the sheets bridge, which already drives `setDirty` from the Univer mutation hook.

All in the (unpublished) example app + bridge. Verified by running: new e2e (`desktop-dirty-tracking.spec.ts`) asserts a toolbar-only Bold edit marks the window dirty; `formatting`/typing specs still green (the 4 known-flaky `text-editing` clipboard/nav cases fail identically on clean main — environmental).