### PR TITLE
fix(find-replace): clear stale highlight after replacing the last match

### DIFF
--- a/docx-editor/.changeset/fix-find-replace-stale-highlight.md
+++ b/docx-editor/.changeset/fix-find-replace-stale-highlight.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix Find & Replace leaving a stale highlight after the last match is replaced. Replacing the final occurrence cleared the result but left the previous match still highlighted on the page; the highlight is now cleared when no matches remain, matching the search path's behaviour.

--- a/docx-editor/packages/react/src/components/dialogs/FindReplaceDialog.tsx
+++ b/docx-editor/packages/react/src/components/dialogs/FindReplaceDialog.tsx
@@ -510,8 +510,12 @@ export function FindReplaceDialog({
     if (success) {
       const newResult = onFind(searchText, { matchCase, matchWholeWord, useRegex });
       setResult(newResult);
-      if (newResult?.matches && onHighlightMatches) {
-        onHighlightMatches(newResult.matches);
+      if (newResult?.matches && newResult.matches.length > 0) {
+        onHighlightMatches?.(newResult.matches);
+      } else {
+        // Replacing the last match leaves no matches — clear the stale
+        // highlight instead of leaving it painted on the now-replaced text.
+        onClearHighlights?.();
       }
     }
   }, [
@@ -524,6 +528,7 @@ export function FindReplaceDialog({
     onReplace,
     onFind,
     onHighlightMatches,
+    onClearHighlights,
   ]);
 
   const handleReplaceAll = useCallback(() => {


### PR DESCRIPTION
Found while auditing existing features for behavioral bugs.

Replacing the last remaining match left its highlight painted on the page: `handleReplace` re-searched and only called `onHighlightMatches` when matches remained, with no `onClearHighlights` for the empty case — even though the search path already clears in exactly that situation. Now mirrors that behaviour.

Verified: react typecheck, find-replace e2e (shortcuts + scroll).