### PR TITLE
feat(editor): add onFileOpened hook; desktop unbinds path on in-window open

### DIFF
--- a/docx-editor/.changeset/docx-on-file-opened.md
+++ b/docx-editor/.changeset/docx-on-file-opened.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': minor
+---
+
+Add an `onFileOpened` callback to `DocxEditor`, fired after the user opens a file in-window via File → Open. Hosts can react to the document being replaced — the Casual Office desktop shell uses it to unbind the previous file path so a later Save can't overwrite the old file with the newly-opened content.

--- a/docx-editor/e2e/tests/desktop-open-unbinds-path.spec.ts
+++ b/docx-editor/e2e/tests/desktop-open-unbinds-path.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Desktop in-window open safety.
+ *
+ * File → Open inside the editor loads a browser-picked file in place. A browser
+ * File has no real filesystem path, so the window must NOT stay bound to the
+ * previously-open file — otherwise the next Save would overwrite that file with
+ * the newly-opened content. The editor now fires `onFileOpened`, which the
+ * desktop host uses to unbind the path (Save then prompts for a location).
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test('opening a file in-window unbinds the previous desktop file path', async ({ page }) => {
+  await page.addInitScript(() => {
+    (window as unknown as { __deskApp__: unknown }).__deskApp__ = {
+      isDesktop: true,
+      filePath: null,
+      fileKind: 'docx',
+      loadDocument: async () => {
+        throw new Error('not used');
+      },
+      save: async () => null,
+      saveAs: async () => null,
+      setDirty: () => undefined,
+      dismissBoot: () => undefined,
+    };
+  });
+
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+
+  // Simulate a window already bound to a file on disk.
+  await page.evaluate(() => {
+    (window as unknown as { __deskApp__: { filePath: string | null } }).__deskApp__.filePath =
+      '/tmp/original.docx';
+  });
+  expect(
+    await page.evaluate(
+      () =>
+        (window as unknown as { __deskApp__: { filePath: string | null } }).__deskApp__.filePath,
+    ),
+  ).toBe('/tmp/original.docx');
+
+  // Open a different file in-window via File → Open (sets the hidden input).
+  await editor.loadDocxFile('fixtures/demo/demo.docx');
+
+  // The bound path must be cleared so a later Save can't overwrite original.docx.
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as unknown as { __deskApp__: { filePath: string | null } }).__deskApp__.filePath,
+      ),
+    )
+    .toBeNull();
+});

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -960,6 +960,17 @@ export function App() {
     bridge?.setDirty?.(true);
   }, []);
 
+  // Desktop only: the user opened a file in-window via File → Open. A browser-
+  // picked file has no real filesystem path, so the window must NOT stay bound
+  // to the previously-open file — otherwise the next Save would overwrite that
+  // file with the newly-opened content. Unbind the path so Save behaves like
+  // Save As (prompts for a location).
+  const onFileOpenedDesktop = useCallback(() => {
+    if (typeof window !== 'undefined' && window.__deskApp__) {
+      window.__deskApp__.filePath = null;
+    }
+  }, []);
+
   // Dismiss the boot overlay once DocxEditor's PM view is live and the
   // first layout paint is imminent. This fires AFTER parseDocx completes,
   // avoiding the blank-editor flash that occurred when dismissBoot was called
@@ -1297,6 +1308,9 @@ export function App() {
           // Desktop only: mark the window dirty on every real document change
           // so the unsaved-changes close-guard fires for mouse/toolbar edits.
           onChange={isDesktop ? onDocChangeDesktop : undefined}
+          // Desktop only: unbind the old file path when a file is opened
+          // in-window, so a later Save can't overwrite the previous file.
+          onFileOpened={isDesktop ? onFileOpenedDesktop : undefined}
           // Dismiss the boot splash after DocxEditor has parsed the DOCX and
           // created its PM view, avoiding the blank-editor flash that occurred
           // when dismissBoot fired immediately after setDocumentBuffer.

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -487,6 +487,11 @@ export interface DocxEditorProps {
   /** Callback invoked when the user picks File → New. Host should
    *  replace the loaded document with a blank one. */
   onNew?: () => void;
+  /** Callback invoked after the user opens a file in-window via File → Open
+   *  (the editor has already loaded it). Lets a host react to the document
+   *  being replaced — e.g. the desktop shell unbinds the previous file path so
+   *  a later Save can't overwrite the old file with the newly-opened content. */
+  onFileOpened?: () => void;
   /** Author name used for comments and track changes */
   author?: string;
   /** Callback when document changes */
@@ -1562,6 +1567,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     onSave,
     onExport,
     onNew,
+    onFileOpened,
     author = 'User',
     onChange,
     onSelectionChange,
@@ -7035,6 +7041,10 @@ body { background: white; }
         await loadBuffer(docxBuffer);
         const cleanName = file.name.replace(/\.(docx|odt|md|markdown|txt)$/i, '');
         onDocumentNameChange?.(cleanName);
+        // The in-window document was replaced by a newly-opened file. Notify the
+        // host so it can react (the desktop shell unbinds the old file path so a
+        // later Save can't overwrite the previous file with this content).
+        onFileOpened?.();
         // Record in the recent-files list so the Home screen can show
         // a one-click reopen tile. Best-effort — failures are logged
         // inside the helper and don't surface to the user.
@@ -7048,7 +7058,7 @@ body { background: white; }
         onError?.(error instanceof Error ? error : new Error('Failed to open document'));
       }
     },
-    [loadBuffer, onDocumentNameChange, onError]
+    [loadBuffer, onDocumentNameChange, onError, onFileOpened]
   );
 
   // ============================================================================


### PR DESCRIPTION
File → Open inside the editor loads a browser-picked file in place, but a browser `File` has no real filesystem path. The desktop window stayed bound to the previously-open file, so the next Save overwrote that file with the newly-opened content — silent cross-file data loss (the in-editor counterpart to File→New, #117).

`DocxEditor` now fires a new optional `onFileOpened` callback after an in-window open; App.tsx (desktop) uses it to unbind `bridge.filePath`, so Save falls through to `saveAs` (prompts for a location). The web open path is unchanged when no callback is provided.

Verified by running: new e2e (`desktop-open-unbinds-path.spec.ts`) opens a fixture in-window with a bound path and asserts the path is unbound. typecheck + prettier clean.