### PR TITLE
fix(print): pin @page size to the document's page size, not the dialog paper

### DIFF
--- a/docx-editor/.changeset/fix-print-page-size.md
+++ b/docx-editor/.changeset/fix-print-page-size.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix Export as PDF / Print using the print dialog's default paper size instead of the document's page size. The print stylesheet pinned `@page { size: auto }`, so an A4 (or landscape) document could export at Letter size with clipped or mis-margined pages. The page box is now pinned to the document's actual page dimensions (read from the rendered page), matching WYSIWYG.

--- a/docx-editor/e2e/tests/export-pdf.spec.ts
+++ b/docx-editor/e2e/tests/export-pdf.spec.ts
@@ -70,5 +70,12 @@ test.describe('Export as PDF', () => {
     // strips a trailing `.docx` and uses the remainder as the title.
     expect(captured!).toContain('<title>core-properties</title>');
     expect(captured!).toContain('class="layout-page"');
+
+    // The printed page box must be pinned to the document's actual page
+    // size (read from the .layout-page px dimensions), NOT `size: auto`
+    // which would let the print dialog's default paper drive the PDF.
+    const pageRule = captured!.match(/@page\s*\{[^}]*\}/)?.[0] ?? '';
+    expect(pageRule).not.toContain('size: auto');
+    expect(pageRule).toMatch(/size:\s*\d+(?:\.\d+)?px\s+\d+(?:\.\d+)?px/);
   });
 });

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -6724,6 +6724,19 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         el.style.margin = '0';
       }
 
+      // Pin the printed page box to the document's actual page size. Each
+      // `.layout-page` carries the WYSIWYG page dimensions as inline px
+      // width/height; without this, `@page { size: auto }` lets the print
+      // dialog's default paper (often Letter) drive the PDF, so an A4 (or
+      // landscape) document exports at the wrong size. Uniform page size is
+      // the overwhelmingly common case; mixed-size docs fall back no worse
+      // than `auto` did.
+      const firstPrintPage = pagesClone.querySelector('.layout-page') as HTMLElement | null;
+      const pageSizeRule =
+        firstPrintPage?.style.width && firstPrintPage?.style.height
+          ? `${firstPrintPage.style.width} ${firstPrintPage.style.height}`
+          : 'auto';
+
       // Restore memory-efficient virtualization after the clone is done.
       requestAnimationFrame(() => {
         restoreVirtualization(pagesEl as HTMLElement);
@@ -6741,7 +6754,7 @@ ${fontFaceRules.join('\n')}
 body { background: white; }
 .layout-page { break-after: page; }
 .layout-page:last-child { break-after: auto; }
-@page { margin: 0; size: auto; }
+@page { margin: 0; size: ${pageSizeRule}; }
 </style>
 </head><body>${pagesClone.outerHTML}</body></html>`);
       printWindow.document.close();


### PR DESCRIPTION
Found in the behavioral analysis (logged as a candidate in #125, now verified and fixed).

Export as PDF / Print used `@page { size: auto }`, so the exported PDF followed the print dialog's default paper (usually Letter) rather than the document's own page size. An A4 or landscape document would print at the wrong size — clipped content or mis-placed margins. The fix reads the document's page dimensions from the rendered `.layout-page` (which already carries them as inline px width/height) and pins `@page size` to them. Uniform page size is the common case; mixed-size docs fall back no worse than `auto` did.

Verified by extending `export-pdf.spec.ts` (which stubs `window.open` to capture the print HTML) to assert a concrete `NNNpx NNNpx` `@page` size instead of `auto`. Also: react typecheck.