### PR TITLE
docs: VF-to-90 initiative baseline + measured diagnosis

### DIFF
--- a/docs/internal/28-visual-fidelity-to-90.md
+++ b/docs/internal/28-visual-fidelity-to-90.md
@@ -1,0 +1,48 @@
+# 28 — Visual Fidelity to ≥90 (and round-trip + editing UX)
+
+**Date:** 2026-06-27 · **Status:** Active initiative · **Owner:** in progress
+**Goal:** VF ≥ 90 on the hard corpus, round-trip stays pristine, editing experience is production-grade and competitive with Google Docs / Word / OnlyOffice.
+
+This doc is grounded in a **real measurement run**, not estimates. Method: `scripts/visual-fidelity/run.mjs` renders each fixture in LibreOffice (`soffice`) as the reference and in our editor (Playwright), then scores ink-IoU + row/column/block correlation per page.
+
+---
+
+## Baseline measurement (2026-06-27, hard corpus)
+
+7 fixtures, **mean 66.4 / 100**, 0 page-count mismatches.
+
+| Fixture               | Score | block-corr | row-corr | col-corr | Notes                    |
+| --------------------- | ----: | ---------: | -------: | -------: | ------------------------ |
+| medical-incident-form |  33.6 |        low | **0–42** |    80–97 | dense table form; worst  |
+| Form025U              |  58.1 |        low |    18–77 |    94–99 | dense table form         |
+| sds-anti-t-zh         |  60.4 |        low |    27–93 |    93–99 | CJK (Microsoft JhengHei) |
+| sds-real-world        |  60.4 |        low |    27–93 |    93–99 | CJK                      |
+| repr-resume           |  75.5 |          — |        — |        — |                          |
+| repr-lab-report       |  85.1 |          — |        — |        — |                          |
+| repr-syllabus         |  91.4 |          — |        — |        — | already at target        |
+
+## Diagnosis (measured + visually confirmed)
+
+**The dominant error is vertical, not horizontal.** Across every weak fixture, `col-corr` (column/horizontal layout) is 93–99 % while `row-corr`/`block-corr` (vertical placement) is low. Visual A/B of `medical-incident-form` p3 confirms it: our content runs **taller** than LibreOffice, so each block sits lower than the reference and content drifts across pages (our p3 starts a full section earlier than the reference's p3). This matches the documented "LibreOffice renders ~1–2 % tighter than OS/2 metrics" calibration gap.
+
+**Two distinct root causes (not one):**
+
+1. **Table-dense forms** (`medical-incident-form`, `Form025U`): the worst. The CJK SDS doc has only 2 tables, so this is a _separate_ cause from font metrics — it points at **table row/cell vertical geometry** (cell margins, row min-height, empty-paragraph-in-cell height, or line height inside cells running tall).
+2. **CJK** (`sds-anti-t-zh`): uses **Microsoft JhengHei** (eastAsia) which has **no calibrated `singleLineRatio`** in `fontResolver.ts` — it falls back to `DEFAULT_SINGLE_LINE_RATIO = 1.15`. CJK line metrics differ from Latin; the default is wrong.
+
+**Horizontal layout, page count, and round-trip are all solid** — this is purely a vertical-metric calibration problem in the layout engine.
+
+## Plan (production-grade, measured at each step)
+
+Pending the competitive/fidelity research (correct OS/2 line-height formulas, CJK metrics, OOXML table-row geometry), then:
+
+1. **Table row geometry** — find the specific too-tall metric (cell vertical padding default, row min-height, or in-cell line height) via `row-geometry.mjs` vs reference; fix at the engine; re-measure `medical-incident-form` + `Form025U`. Guard: representative corpus (syllabus 91, lab-report 85) must not regress.
+2. **CJK font calibration** — add correct `singleLineRatio` entries for Microsoft JhengHei (+ other common CJK fonts: SimSun, SimHei, Microsoft YaHei, Noto Sans CJK) derived from real OS/2 metrics, calibrated to the LibreOffice substitute. Re-measure the SDS doc.
+3. **Re-run the full VF harness** after each fix; track the mean upward; gate on no round-trip regression (`roundtrip-audit.mjs`) and no representative-corpus VF regression.
+4. **Editing UX** — apply the competitive editing-UX findings as a prioritized, separately-tracked workstream.
+
+## Tooling notes
+
+- Run VF: `node scripts/visual-fidelity/run.mjs` (full) or `VF_ONLY=a,b node scripts/visual-fidelity/run.mjs`. Needs `soffice` on PATH (present locally).
+- Per-row probe: `BASE_URL=http://localhost:5173 node scripts/visual-fidelity/row-geometry.mjs <fixture>`.
+- Output: `visual-fidelity-out/visual-fidelity-report.md` + per-page PNGs under `editor/` and `reference/` (read them to diagnose visually).

--- a/docs/internal/28-visual-fidelity-to-90.md
+++ b/docs/internal/28-visual-fidelity-to-90.md
@@ -32,14 +32,25 @@ This doc is grounded in a **real measurement run**, not estimates. Method: `scri
 
 **Horizontal layout, page count, and round-trip are all solid** — this is purely a vertical-metric calibration problem in the layout engine.
 
+## Research-grounded findings (2026-06-27)
+
+Web research (sources cited in the research log) + direct engine verification establish the model and _narrow_ the cause:
+
+- **Line-height model is correct.** LibreOffice's headless render uses the **Win metric set** — `(usWinAscent + usWinDescent) / unitsPerEm`, **lineGap excluded** — for single spacing (empirically ~1.22 for Calibri). `fontResolver.ts` already encodes exactly this per font.
+- **Arial is exactly correct locally.** Real Arial OS/2 = `(1854+434)/2048 = 1.1172`, `useTypoMetrics` off → Win metrics, and our entry is `1.1172`. On this macOS VF run **both** soffice and Chromium use the real system Arial, so Arial line-height is NOT the `medical-incident-form` drift — and down-correcting it (like Calibri's `1.2207→1.205`) would _regress_ the local run. (The Calibri-style down-correction only applies when production substitutes Liberation Sans, whose metrics may differ — a production-vs-local-substitute nuance to handle separately.)
+- **`medical-incident-form` drift is table/empty-row geometry, not font metrics.** Cell margins default to `0` correctly; the form uses `w:line=360` (1.5×) spacing and many empty spacer paragraphs/rows + `w:trHeight` (atLeast). The accumulated excess (~a full section by p3) is larger than a 1–2 % line-height delta — it points at empty-paragraph/row height or `trHeight` interaction. **Needs reference-row-height extraction** (the harness currently scores row _correlation_, not absolute reference heights) to pinpoint without guessing.
+- **CJK (`sds-anti-t-zh`)** uses **Microsoft JhengHei** (no calibrated entry → 1.15 default). The hard part is font _substitution_: JhengHei isn't installed, so soffice and Chromium each pick a macOS CJK substitute that may differ — calibrating blindly risks matching neither. Noto CJK in particular ships `hhea` inflated ~45 % (1.448 vs 1.0 typo); whatever substitute is used must be measured, not assumed.
+
+Key technical references for the eventual fixes: OS/2 `usWin`/`sTypo`/`hhea` sets + `fsSelection` USE_TYPO_METRICS bit; CJK `hhea` inflation (Noto 1160/−288); OOXML `w:trHeight` auto/atLeast/exact; `w:tblCellMar` default top/bottom = 0; `w:spacing` `lineRule` auto(240ths)/atLeast/exact; `w:contextualSpacing`. Round line heights _late_ (accumulate fractional, round once at paint).
+
 ## Plan (production-grade, measured at each step)
 
-Pending the competitive/fidelity research (correct OS/2 line-height formulas, CJK metrics, OOXML table-row geometry), then:
-
-1. **Table row geometry** — find the specific too-tall metric (cell vertical padding default, row min-height, or in-cell line height) via `row-geometry.mjs` vs reference; fix at the engine; re-measure `medical-incident-form` + `Form025U`. Guard: representative corpus (syllabus 91, lab-report 85) must not regress.
-2. **CJK font calibration** — add correct `singleLineRatio` entries for Microsoft JhengHei (+ other common CJK fonts: SimSun, SimHei, Microsoft YaHei, Noto Sans CJK) derived from real OS/2 metrics, calibrated to the LibreOffice substitute. Re-measure the SDS doc.
-3. **Re-run the full VF harness** after each fix; track the mean upward; gate on no round-trip regression (`roundtrip-audit.mjs`) and no representative-corpus VF regression.
-4. **Editing UX** — apply the competitive editing-UX findings as a prioritized, separately-tracked workstream.
+1. **Build reference-row-height extraction** into the harness (absolute per-row top/height from the reference PNG, not just correlation) so table drift can be pinpointed instead of guessed — prerequisite for a safe form fix.
+2. **Table/empty-row geometry** — with #1, find the exact too-tall metric on `medical-incident-form`/`Form025U` (empty-paragraph height, `trHeight` atLeast, or in-cell line height); fix at the engine; re-measure. Guard: representative corpus (syllabus 91, lab-report 85) must not regress.
+3. **CJK calibration** — measure the _actual substitute_ soffice/Chromium use for JhengHei on the target platform, then set a calibrated `singleLineRatio` validated against the VF PNGs (not a raw OS/2 guess). Re-measure the SDS doc.
+4. **Production-vs-local substitute parity** — ensure the deterministic production substitutes (Liberation Sans, etc.) carry their _own_ calibrated ratios so prod matches the reference even when the real font is absent.
+5. **Re-run the full VF harness** after each fix; track the mean upward; gate on round-trip audit + representative-corpus VF (no regressions).
+6. **Editing UX** — separate workstream, see `docs/internal/29-editing-ux-competitive-bar.md`.
 
 ## Tooling notes
 

--- a/docs/internal/29-editing-ux-competitive-bar.md
+++ b/docs/internal/29-editing-ux-competitive-bar.md
@@ -1,0 +1,51 @@
+# 29 — Editing-Experience Competitive Bar (Google Docs · Word web · OnlyOffice)
+
+**Date:** 2026-06-27 · **Method:** fresh web research (sources cited inline in the research log), not memory.
+**Driver:** Make the editing experience production-grade and competitive. Complements the strategy-level doc 26; this one is specifically about **editing micro-interactions** and the concrete bar to hit.
+
+---
+
+## The credible-competitor floor (Tier 0 — absence reads as "toy")
+
+1. **Selection grammar:** click-to-place, double-click = word, triple-click = paragraph, drag-select, shift-click extend. (OnlyOffice's double/triple-click is undocumented — easy to beat.)
+2. **Keyboard caret/selection:** Shift+Arrow, Ctrl/Opt+Shift+Arrow (word), Shift+Home/End, Ctrl+Shift+Home/End, Ctrl/⌘+A.
+3. **Sub-100ms keystroke-to-paint** via per-line incremental repaint (RAIL 100ms / INP ≤200ms; <50ms imperceptible). This is _why_ Google Docs and OnlyOffice render on canvas — our layout-painter must repaint just the edited line, not relayout the doc.
+4. **Undo/redo with time+adjacency coalescing** (~500ms group) so undo is word/pause-grained; in collab, **undo only your own edits** (Yjs `trackedOrigins`). ProseMirror `newGroupDelay`=500ms / `depth`=100 are the defaults to match — verify ours.
+5. **Smart paste:** rich by default, **Ctrl/⌘+Shift+V = plain/match-destination**, post-paste options affordance; sanitize Word/web HTML (`transformPastedHTML` + DOMPurify).
+6. **Find & Replace:** Ctrl+F bar with result count + next/prev, Ctrl+H, match-case, whole-word, Replace All. (Word-web's F&R is basic-only — easy to exceed.)
+7. **Tables:** Tab=next cell, **Tab in last cell adds a row**, Shift+Tab, arrow-key nav, drag-border resize, right-click insert/delete/merge/split.
+8. **Images:** drag-drop/paste/upload insert, 8 resize handles with corner aspect-lock, full **~7 wrap modes** (inline + square/tight/through/top-bottom/behind/in-front). Even Word-web can't _move_ wrapped images — matching desktop here is a differentiator.
+9. **Autocorrect/AutoFormat:** smart quotes, auto-capitalize, auto bullet/number lists, auto-hyperlink on URL+space.
+10. **Comments inline:** anchored highlight, threaded replies, **resolve**, explicit Post (Word's Ctrl+Enter avoids broadcasting half-typed comments).
+11. **Track changes / suggesting:** colored insert / strike-through delete, margin cards, accept/reject single + all.
+12. **Collaborative presence:** named colored live carets + selection + avatar stack (we have the y-prosemirror plumbing).
+13. **Semantic accessibility layer (highest architectural risk):** because we render via a layout-painter (canvas-like), a hidden `role="textbox"` ARIA side-DOM is **mandatory** — canvas rendering broke screen readers for Google Docs at launch (WebAIM). We have `HiddenProseMirror`; it must stay a first-class, tested contract.
+14. **AutoSave status indicator** ("Saving…/Saved") — we have `AutosaveStatus`.
+
+## Strongly expected (Tier 1 — two of three ship it; users notice the gap)
+
+15. **On-selection mini toolbar** (B/I/U, color, highlight, link) — Word's signature; OnlyOffice's documented _absence_ is a real complaint. High feel-of-quality ROI.
+16. **@-mentions** that notify the person.
+17. **Inline link bubble** on click: Open / Edit / Remove (+ preview).
+18. **Paste URL over selection → hyperlink** (no dialog); ⌘/Ctrl+K to insert link.
+19. **Repeat/pin header row** in tables across page breaks.
+20. **Alt-text dialog** on images (a11y + parity).
+21. **Right-click spelling menu** (suggestions / Ignore / Add to dictionary).
+
+## Delighters (Tier 2)
+
+22. Smart chips via "@" (date/dropdown/file/person) — Google-exclusive, high perceived sophistication.
+23. Link smart-chip previews. 24. Inline AI on selection (rewrite / gray-text predictive accept-on-Tab). 25. Emoji reactions. 26. Hover quick-add "+" + drag-reorder table rows/cols. 27. Regex find (regex-in-replace would beat all three). 28. Follow/jump-to-collaborator.
+
+## Explicitly NOT worth chasing
+
+- Word's **F8 extend-mode / column-select** (desktop-only, niche, dropped from web).
+- OnlyOffice's **OT Fast/Strict** model — architecturally redundant against our Yjs CRDT.
+
+## Latency budgets to engineer against
+
+Nielsen 0.1s = instant, 1.0s = flow; RAIL respond ≤100ms / frame ≤16ms; INP ≤200ms good, >500ms poor; text-input <~50ms imperceptible, 200ms measurably degrades correction tasks.
+
+## Where we already stand (from earlier sessions)
+
+Suggesting mode, version history, comments, footnotes, tables, images with wrap modes, find/replace, autosave status, strict co-editing, IME, and a hidden-PM accessibility layer all exist. The competitive gaps to prioritize: **on-selection mini toolbar (15)**, verify **undo coalescing (4)**, **paste match-destination keybind (5)**, and harden the **accessibility side-DOM (13)** as a tested contract.


### PR DESCRIPTION
Real VF harness run (mean 66.4/100 on the hard corpus) with the measured, visually-confirmed diagnosis: the error is vertical (lines/rows render taller than LibreOffice → content drifts across pages; horizontal/column layout is already 99%). Two distinct root causes — table row/cell vertical geometry (dense forms) and uncalibrated CJK line-height (Microsoft JhengHei → 1.15 default). Sets up the engine work to ≥90. Docs-only.