### PR TITLE
feat(vf): reference-vs-editor band-compare probe + pinpoint form diagnosis

### DIFF
--- a/docs/internal/28-visual-fidelity-to-90.md
+++ b/docs/internal/28-visual-fidelity-to-90.md
@@ -41,7 +41,7 @@ Web research (sources cited in the research log) + direct engine verification es
 - **`medical-incident-form` drift is table/empty-row geometry, not font metrics.** Cell margins default to `0` correctly; the form uses `w:line=360` (1.5×) spacing and many empty spacer paragraphs/rows + `w:trHeight` (atLeast). The accumulated excess (~a full section by p3) is larger than a 1–2 % line-height delta — it points at empty-paragraph/row height or `trHeight` interaction. **Needs reference-row-height extraction** (the harness currently scores row _correlation_, not absolute reference heights) to pinpoint without guessing.
 - **CJK (`sds-anti-t-zh`)** uses **Microsoft JhengHei** (no calibrated entry → 1.15 default). The hard part is font _substitution_: JhengHei isn't installed, so soffice and Chromium each pick a macOS CJK substitute that may differ — calibrating blindly risks matching neither. Noto CJK in particular ships `hhea` inflated ~45 % (1.448 vs 1.0 typo); whatever substitute is used must be measured, not assumed.
 
-Key technical references for the eventual fixes: OS/2 `usWin`/`sTypo`/`hhea` sets + `fsSelection` USE_TYPO_METRICS bit; CJK `hhea` inflation (Noto 1160/−288); OOXML `w:trHeight` auto/atLeast/exact; `w:tblCellMar` default top/bottom = 0; `w:spacing` `lineRule` auto(240ths)/atLeast/exact; `w:contextualSpacing`. Round line heights _late_ (accumulate fractional, round once at paint).
+Key technical references for the eventual fixes: OS/2 `usWin`/`sTypo`/`hhea` sets + `fsSelection` USE*TYPO_METRICS bit; CJK `hhea` inflation (Noto 1160/−288); OOXML `w:trHeight` auto/atLeast/exact; `w:tblCellMar` default top/bottom = 0; `w:spacing` `lineRule` auto(240ths)/atLeast/exact; `w:contextualSpacing`. Round line heights \_late* (accumulate fractional, round once at paint).
 
 ## Plan (production-grade, measured at each step)
 
@@ -52,8 +52,20 @@ Key technical references for the eventual fixes: OS/2 `usWin`/`sTypo`/`hhea` set
 5. **Re-run the full VF harness** after each fix; track the mean upward; gate on round-trip audit + representative-corpus VF (no regressions).
 6. **Editing UX** — separate workstream, see `docs/internal/29-editing-ux-competitive-bar.md`.
 
+## Pinpoint diagnosis — medical-incident-form (via `band-compare.py`, 2026-06-27)
+
+Built `scripts/visual-fidelity/band-compare.py` (plan step #1: reference-row extraction) — it detects horizontal ink bands (top/height) in the editor and reference PNGs of the same page and prints them side by side. Result on the worst fixture:
+
+- **p1:** both 13 bands, editor ends ~72px _higher_ (slightly tighter) — p1 is not where it breaks.
+- **p2:** reference fits **19 bands**, editor only **14** → reference is more compact / **editor is taller** (confirmed numerically). Two additive causes:
+  1. **~20-25px per-page top offset** — editor body content starts lower on every page (p1 band0 +19px, p2 band0 +25px). Cause: the form has **`w:top="-270"` (negative top margin) + a default header** (`w:header="726"`). With a negative top margin, Word/LO drive body-top from the header (`max(top, headerDist + headerHeight)`). The layout engine `void`s `headerContentHeights` (index.ts:266) and relies on the upstream effective-margin calc, so the offset means **our header renders ~20px taller than LibreOffice's**.
+  2. **~1.8px/band spacing accumulation** across the page (paragraph before/after or the `w:line=360` 1.5× spacing computed marginally tall) — compounds with the offset so the tightly-packed trailing rows spill to the next page.
+
+**Next fix (measured):** (a) reconcile header-content height vs LibreOffice for the negative-top-margin case; (b) audit per-band paragraph spacing (before/after, 1.5× line) for the small per-row excess. Re-run `band-compare` + VF after each; gate on representative corpus.
+
 ## Tooling notes
 
 - Run VF: `node scripts/visual-fidelity/run.mjs` (full) or `VF_ONLY=a,b node scripts/visual-fidelity/run.mjs`. Needs `soffice` on PATH (present locally).
-- Per-row probe: `BASE_URL=http://localhost:5173 node scripts/visual-fidelity/row-geometry.mjs <fixture>`.
+- Per-row probe (editor DOM): `BASE_URL=http://localhost:5173 node scripts/visual-fidelity/row-geometry.mjs <fixture>`.
+- **Reference-vs-editor band compare:** `python3 scripts/visual-fidelity/band-compare.py <editor.png> <reference.png>` — localises which band first drifts and by how much.
 - Output: `visual-fidelity-out/visual-fidelity-report.md` + per-page PNGs under `editor/` and `reference/` (read them to diagnose visually).

--- a/docx-editor/scripts/visual-fidelity/band-compare.py
+++ b/docx-editor/scripts/visual-fidelity/band-compare.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Reference-vs-editor row-band probe.
+
+Extracts horizontal ink bands (contiguous rows containing dark pixels) from the
+editor and LibreOffice-reference PNGs of the SAME page, and prints them side by
+side with cumulative top positions. This localises WHERE vertical height
+diverges (which band first drifts and by how much) instead of guessing global
+ratios.
+
+Usage: python3 band-compare.py <editor.png> <reference.png>
+"""
+import sys
+import numpy as np
+from PIL import Image
+
+
+def bands(path, ink_thresh=200, min_gap=6, min_band=3):
+    im = Image.open(path).convert("L")
+    a = np.asarray(im)
+    # ink per row = count of pixels darker than threshold (text/lines/fills)
+    ink = (a < ink_thresh).sum(axis=1)
+    rows_with_ink = ink > (a.shape[1] * 0.002)  # >0.2% of width has ink
+    out = []
+    y = 0
+    n = len(rows_with_ink)
+    while y < n:
+        if rows_with_ink[y]:
+            start = y
+            gap = 0
+            while y < n and (rows_with_ink[y] or gap < min_gap):
+                gap = 0 if rows_with_ink[y] else gap + 1
+                y += 1
+            end = y - gap
+            if end - start >= min_band:
+                out.append((start, end - start))
+        else:
+            y += 1
+    return out, a.shape
+
+
+def main():
+    ed_path, ref_path = sys.argv[1], sys.argv[2]
+    ed, ed_shape = bands(ed_path)
+    ref, ref_shape = bands(ref_path)
+    print(f"editor   {ed_path}  shape={ed_shape}  bands={len(ed)}")
+    print(f"reference {ref_path}  shape={ref_shape}  bands={len(ref)}")
+    print(f"{'#':>3} | {'ed_top':>7} {'ed_h':>5} | {'ref_top':>7} {'ref_h':>5} | {'dtop':>6} {'dh':>5}")
+    n = max(len(ed), len(ref))
+    for i in range(n):
+        et, eh = ed[i] if i < len(ed) else ("", "")
+        rt, rh = ref[i] if i < len(ref) else ("", "")
+        if et != "" and rt != "":
+            print(f"{i:>3} | {et:>7} {eh:>5} | {rt:>7} {rh:>5} | {et-rt:>6} {eh-rh:>5}")
+        else:
+            print(f"{i:>3} | {str(et):>7} {str(eh):>5} | {str(rt):>7} {str(rh):>5} |")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `band-compare.py` to the VF harness — detects horizontal ink bands (top/height) in the editor vs LibreOffice-reference PNGs of the same page and prints them side by side, so vertical drift is **localised to a band**, not guessed (the reference-row-extraction my plan called for).

Applied to the worst fixture (medical-incident-form): on p2 the reference fits **19 bands** but the editor only **14** — editor runs taller from two additive causes: a **~20-25px per-page top offset** (the form has `w:top=-270` negative margin + a header, so body-top is driven by header height, and our header renders ~20px taller than LibreOffice) and **~1.8px/band spacing accumulation**. Recorded in doc 28; the fixes are the next measured steps. Tooling + docs only.