### PR TITLE
feat(desktop): New document shows the template gallery instead of a blank page

### DIFF
--- a/docx-editor/e2e/tests/desktop-new-templates.spec.ts
+++ b/docx-editor/e2e/tests/desktop-new-templates.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Desktop "New document" should show the editor's template gallery, not a blank
+ * page. A file-bound desktop window still boots straight into the document.
+ */
+import { test, expect } from '@playwright/test';
+
+const deskBridge = (filePath: string | null) => ({
+  isDesktop: true,
+  filePath,
+  fileKind: 'docx',
+  loadDocument: async () => {
+    throw new Error('not a real file in this test');
+  },
+  save: async () => null,
+  saveAs: async () => null,
+  setDirty: () => undefined,
+  dismissBoot: () => undefined,
+});
+
+test('desktop New (no file) shows the template gallery, not a blank editor', async ({ page }) => {
+  await page.addInitScript((b) => {
+    (window as unknown as { __deskApp__: unknown }).__deskApp__ = b;
+  }, deskBridge(null));
+
+  await page.goto('/?desk=1');
+
+  await expect(page.locator('[data-testid="home-page"]')).toBeVisible();
+  await expect(page.locator('[data-testid="docx-editor"]')).toHaveCount(0);
+});
+
+test('desktop with a file boots into the document, not the gallery', async ({ page }) => {
+  await page.addInitScript((b) => {
+    (window as unknown as { __deskApp__: unknown }).__deskApp__ = b;
+  }, deskBridge('/tmp/a.docx'));
+
+  await page.goto('/?desk=1&file=/tmp/a.docx');
+
+  // A file-bound desktop window is a document window — it must NOT show the
+  // template gallery (it boots into the document instead).
+  await page.waitForTimeout(300);
+  await expect(page.locator('[data-testid="home-page"]')).toHaveCount(0);
+});

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -53,8 +53,16 @@ function isLegacyForcedEditor(): boolean {
 }
 
 function getInitialView(): 'home' | 'editor' {
-  if (isLegacyForcedEditor()) return 'editor';
   if (typeof window === 'undefined') return 'home';
+  const params = new URLSearchParams(window.location.search);
+  // Desktop (Tauri shell): a file-bound window boots straight into the
+  // document, but a blank "New document" window (no `file`) shows the editor's
+  // template gallery instead of an empty page. isLegacyForcedEditor() still
+  // reports true for desk mode so the web route-sync effect stays suppressed.
+  if (params.get('desk') === '1') {
+    return params.get('file') ? 'editor' : 'home';
+  }
+  if (isLegacyForcedEditor()) return 'editor';
   // Route-driven. `/` and `/home` → home; `/document/*` → editor.
   if (window.location.pathname === '/' || window.location.pathname === '/home') {
     return 'home';


### PR DESCRIPTION
A desktop "New document" window opens the editor at `?desk=1` with no file and previously seeded a blank document — so the 14-template gallery (which lives in the editor's home) was never reachable in the desktop app.

It now shows that existing gallery for the no-file case; a file-bound window (`?desk=1&file=...`) still boots straight into the document. Reuses the existing gallery UI, so **no launcher change is needed**. Picking a template (or "blank document") loads it as an untitled doc, so Save prompts for a location (no overwrite risk).

Verified by running: new e2e (`desktop-new-templates.spec.ts`) asserts `?desk=1` (no file) shows `home-page` and not the editor, while `?desk=1&file=...` does not show the gallery. `formatting.spec.ts` regression green.