### PR TITLE
feat(editor): on-selection mini formatting toolbar (B/I/U/S)

### DIFF
--- a/docx-editor/.changeset/selection-format-toolbar.md
+++ b/docx-editor/.changeset/selection-format-toolbar.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Add a Google-Docs / Word-style on-selection mini formatting toolbar. Selecting body text now surfaces a small floating toolbar above the selection with Bold / Italic / Underline / Strikethrough, each reflecting the selection's current state and applying the same formatting as the main toolbar. Clicking a button never collapses the selection. This is the Tier-1 editing-UX affordance the leaders ship and OnlyOffice notably lacks.

--- a/docx-editor/e2e/tests/selection-format-toolbar.spec.ts
+++ b/docx-editor/e2e/tests/selection-format-toolbar.spec.ts
@@ -27,6 +27,9 @@ test.describe('Selection format toolbar', () => {
 
     const bar = page.getByTestId('selection-format-toolbar');
     await expect(bar).toBeVisible();
+    // B / I / U / S + Link = 5 buttons.
+    await expect(bar.locator('button')).toHaveCount(5);
+    await expect(page.getByTestId('selection-format-insertLink')).toBeVisible();
 
     // Apply bold via the mini toolbar button.
     await page.getByTestId('selection-format-bold').click();
@@ -37,6 +40,17 @@ test.describe('Selection format toolbar', () => {
     await expect(page.getByTestId('selection-format-bold')).toHaveAttribute('aria-pressed', 'true');
 
     await page.screenshot({ path: 'screenshots/selection-format-toolbar.png' });
+  });
+
+  test('link button opens the hyperlink dialog for the selection', async ({ page }) => {
+    await editor.typeText('Link this word');
+    await editor.selectText('word');
+
+    await expect(page.getByTestId('selection-format-toolbar')).toBeVisible();
+    await page.getByTestId('selection-format-insertLink').click();
+
+    await expect(page.getByTestId('hyperlink-dialog')).toBeVisible();
+    await page.screenshot({ path: 'screenshots/selection-format-toolbar-link.png' });
   });
 
   test('hides when the selection collapses', async ({ page }) => {

--- a/docx-editor/e2e/tests/selection-format-toolbar.spec.ts
+++ b/docx-editor/e2e/tests/selection-format-toolbar.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * On-selection mini formatting toolbar (Google Docs / Word style).
+ *
+ * Selecting body text should surface a small floating toolbar above the
+ * selection; its buttons apply the same formatting as the main toolbar and
+ * reflect the selection's active marks. Clicking a button must NOT collapse
+ * the selection (the documented PM focus-stealing pitfall).
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+import * as assertions from '../helpers/assertions';
+
+test.describe('Selection format toolbar', () => {
+  let editor: EditorPage;
+
+  test.beforeEach(async ({ page }) => {
+    editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+  });
+
+  test('appears on selection and applies bold without losing the selection', async ({ page }) => {
+    await editor.typeText('Mini toolbar text');
+    await editor.selectText('toolbar');
+
+    const bar = page.getByTestId('selection-format-toolbar');
+    await expect(bar).toBeVisible();
+
+    // Apply bold via the mini toolbar button.
+    await page.getByTestId('selection-format-bold').click();
+    await assertions.assertTextIsBold(page, 'toolbar');
+
+    // Selection survived the click, so the toolbar is still up and bold reads active.
+    await expect(bar).toBeVisible();
+    await expect(page.getByTestId('selection-format-bold')).toHaveAttribute('aria-pressed', 'true');
+
+    await page.screenshot({ path: 'screenshots/selection-format-toolbar.png' });
+  });
+
+  test('hides when the selection collapses', async ({ page }) => {
+    await editor.typeText('Collapse me');
+    await editor.selectText('Collapse');
+    await expect(page.getByTestId('selection-format-toolbar')).toBeVisible();
+
+    // Click to collapse the selection (place caret) → toolbar goes away.
+    await page.keyboard.press('ArrowRight');
+    await expect(page.getByTestId('selection-format-toolbar')).toBeHidden();
+  });
+});

--- a/docx-editor/packages/react/i18n/de.json
+++ b/docx-editor/packages/react/i18n/de.json
@@ -997,5 +997,8 @@
     "readyToLoad": null,
     "running": null,
     "unloading": null
+  },
+  "selectionToolbar": {
+    "ariaLabel": null
   }
 }

--- a/docx-editor/packages/react/i18n/en.json
+++ b/docx-editor/packages/react/i18n/en.json
@@ -96,6 +96,9 @@
     "body": "Edits are recorded as tracked suggestions. Reviewers can accept or reject them.",
     "switchToEditing": "Switch to editing"
   },
+  "selectionToolbar": {
+    "ariaLabel": "Text formatting"
+  },
   "formattingBar": {
     "groups": {
       "history": "History",

--- a/docx-editor/packages/react/i18n/he.json
+++ b/docx-editor/packages/react/i18n/he.json
@@ -997,5 +997,8 @@
     "readyToLoad": null,
     "running": null,
     "unloading": null
+  },
+  "selectionToolbar": {
+    "ariaLabel": null
   }
 }

--- a/docx-editor/packages/react/i18n/pl.json
+++ b/docx-editor/packages/react/i18n/pl.json
@@ -997,5 +997,8 @@
     "readyToLoad": null,
     "running": null,
     "unloading": null
+  },
+  "selectionToolbar": {
+    "ariaLabel": null
   }
 }

--- a/docx-editor/packages/react/i18n/pt-BR.json
+++ b/docx-editor/packages/react/i18n/pt-BR.json
@@ -997,5 +997,8 @@
     "readyToLoad": null,
     "running": null,
     "unloading": null
+  },
+  "selectionToolbar": {
+    "ariaLabel": null
   }
 }

--- a/docx-editor/packages/react/i18n/tr.json
+++ b/docx-editor/packages/react/i18n/tr.json
@@ -997,5 +997,8 @@
     "readyToLoad": null,
     "running": null,
     "unloading": null
+  },
+  "selectionToolbar": {
+    "ariaLabel": null
   }
 }

--- a/docx-editor/packages/react/i18n/zh-CN.json
+++ b/docx-editor/packages/react/i18n/zh-CN.json
@@ -997,5 +997,8 @@
     "readyToLoad": null,
     "running": null,
     "unloading": null
+  },
+  "selectionToolbar": {
+    "ariaLabel": null
   }
 }

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -244,6 +244,7 @@ import { AISuggestionPanel } from './AISuggestionPanel';
 import { ChatPanel } from './ChatPanel';
 import { InlinePreviewPopover } from './InlinePreviewPopover';
 import { SelectionAskAi } from './SelectionAskAi';
+import { SelectionFormatToolbar } from './SelectionFormatToolbar';
 import { runPipeline } from '../lib/writer/pipeline';
 // WriterStatusPill is built and exported; rendering it inside
 // `TitleBarRight` is queued for P2 along with the active-feature
@@ -9579,6 +9580,15 @@ body { background: white; }
                 with the user's free-form prompt; the resulting
                 proposal goes into the inline preview popover (same
                 surface as chat-driven proposals). */}
+            {/* On-selection mini formatting toolbar (Google Docs / Word style).
+                Anchored above the body selection; reuses the toolbar's own
+                format handler + the live selection's active marks. */}
+            <SelectionFormatToolbar
+              isOpen={hasTextSelection}
+              getView={() => getActiveEditorView() ?? null}
+              formatting={state.selectionFormatting}
+              onFormat={handleFormat}
+            />
             {/* SelectionAskAi forced off — LLM gating. */}
             <SelectionAskAi
               isOpen={false}

--- a/docx-editor/packages/react/src/components/SelectionFormatToolbar.tsx
+++ b/docx-editor/packages/react/src/components/SelectionFormatToolbar.tsx
@@ -8,12 +8,25 @@
  * competitive analysis (docs/internal/29) flagged as expected — Google Docs and
  * Word ship it; OnlyOffice's absence is a documented complaint.
  *
- * It anchors with the same `coordsAtPos` approach as SelectionAskAi, but prefers
- * ABOVE the selection (Word's mini-toolbar placement) and falls back below when
- * there isn't room. Every button uses `onMouseDown` preventDefault so clicking
- * never collapses the PM selection (the documented focus-stealing pitfall).
+ * Buttons use `onMouseDown` preventDefault so clicking never collapses the PM
+ * selection (the documented focus-stealing pitfall). Functional behaviour is
+ * verified (applies formatting, opens the link dialog, hides on collapse).
+ *
+ * KNOWN LIMITATION (blocks merge — PR is draft): positioning is WRONG. This
+ * anchors via `view.coordsAtPos`, but in this editor the EditorView is the
+ * HIDDEN ProseMirror painted off-screen at `left:-9999px` (the dual-render
+ * architecture — see docx-editor/CLAUDE.md). So coordsAtPos returns the
+ * off-screen coordinates and the bar lands in the top-left corner instead of
+ * above the visible selection. (SelectionAskAi shares this approach but is
+ * force-disabled, so its placement was never validated either.)
+ *
+ * FIX PATH: expose a `getSelectionScreenRect()` on PagedEditorRef that maps the
+ * selection's `from` to VISIBLE coordinates using the layout-painter's
+ * `getCaretPosition` (the same function comment-anchoring uses), converting
+ * page-relative y → viewport via the page offset + scroll + zoom, then anchor
+ * to that rect instead of coordsAtPos.
  */
-import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { Fragment, useEffect, useRef, useState, type CSSProperties } from 'react';
 import type { EditorView } from 'prosemirror-view';
 import { MaterialSymbol } from './ui/Icons';
 import { useTranslation } from '../i18n';
@@ -52,10 +65,12 @@ const barStyle: CSSProperties = {
 
 interface BtnDef {
   /** String-literal subset of FormattingAction (all assignable to it). */
-  action: 'bold' | 'italic' | 'underline' | 'strikethrough';
+  action: 'bold' | 'italic' | 'underline' | 'strikethrough' | 'insertLink';
   icon: string;
   active: boolean;
   labelKey: string;
+  /** Render a thin separator before this button (groups marks vs actions). */
+  divider?: boolean;
 }
 
 export function SelectionFormatToolbar({
@@ -144,6 +159,13 @@ export function SelectionFormatToolbar({
       active: !!formatting.strike,
       labelKey: 'formattingBar.strikethrough',
     },
+    {
+      action: 'insertLink',
+      icon: 'link',
+      active: false,
+      labelKey: 'formattingBar.insertLink',
+      divider: true,
+    },
   ];
 
   return (
@@ -157,30 +179,44 @@ export function SelectionFormatToolbar({
       onMouseDown={(e) => e.preventDefault()}
     >
       {buttons.map((b) => (
-        <button
-          key={b.action}
-          type="button"
-          aria-label={t(b.labelKey as never)}
-          aria-pressed={b.active}
-          title={t(b.labelKey as never)}
-          data-testid={`selection-format-${b.action}`}
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={() => onFormat(b.action)}
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: 30,
-            height: 30,
-            borderRadius: 6,
-            border: 'none',
-            cursor: 'pointer',
-            color: b.active ? 'var(--doc-primary, #1a73e8)' : 'var(--doc-text-on-surface, #1f2937)',
-            background: b.active ? 'var(--doc-primary-light, #e8f0fe)' : 'transparent',
-          }}
-        >
-          <MaterialSymbol name={b.icon} size={18} />
-        </button>
+        <Fragment key={b.action}>
+          {b.divider && (
+            <span
+              aria-hidden
+              style={{
+                width: 1,
+                height: 18,
+                margin: '0 2px',
+                background: 'var(--doc-border, #e0e0e0)',
+              }}
+            />
+          )}
+          <button
+            type="button"
+            aria-label={t(b.labelKey as never)}
+            aria-pressed={b.active}
+            title={t(b.labelKey as never)}
+            data-testid={`selection-format-${b.action}`}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => onFormat(b.action)}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 30,
+              height: 30,
+              borderRadius: 6,
+              border: 'none',
+              cursor: 'pointer',
+              color: b.active
+                ? 'var(--doc-primary, #1a73e8)'
+                : 'var(--doc-text-on-surface, #1f2937)',
+              background: b.active ? 'var(--doc-primary-light, #e8f0fe)' : 'transparent',
+            }}
+          >
+            <MaterialSymbol name={b.icon} size={18} />
+          </button>
+        </Fragment>
       ))}
     </div>
   );

--- a/docx-editor/packages/react/src/components/SelectionFormatToolbar.tsx
+++ b/docx-editor/packages/react/src/components/SelectionFormatToolbar.tsx
@@ -1,0 +1,189 @@
+/**
+ * SelectionFormatToolbar — Google-Docs / Word-style on-selection mini toolbar.
+ *
+ * When the user selects text in the body editor, a small floating toolbar
+ * appears just above the selection with the highest-frequency character
+ * formatting (bold / italic / underline / strikethrough), each reflecting the
+ * selection's current state. This is the Tier-1 editing-UX affordance the
+ * competitive analysis (docs/internal/29) flagged as expected — Google Docs and
+ * Word ship it; OnlyOffice's absence is a documented complaint.
+ *
+ * It anchors with the same `coordsAtPos` approach as SelectionAskAi, but prefers
+ * ABOVE the selection (Word's mini-toolbar placement) and falls back below when
+ * there isn't room. Every button uses `onMouseDown` preventDefault so clicking
+ * never collapses the PM selection (the documented focus-stealing pitfall).
+ */
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import type { EditorView } from 'prosemirror-view';
+import { MaterialSymbol } from './ui/Icons';
+import { useTranslation } from '../i18n';
+import type { SelectionFormatting } from './Toolbar';
+import type { FormattingAction } from './Toolbar';
+
+export interface SelectionFormatToolbarProps {
+  /** Shown only when there is a non-empty body selection. */
+  isOpen: boolean;
+  /** Returns the active editor view for coordinate mapping. */
+  getView: () => EditorView | null;
+  /** Current selection's active marks (drives the pressed state). */
+  formatting: SelectionFormatting;
+  /** Same handler the main toolbar uses, so behaviour stays identical. */
+  onFormat: (action: FormattingAction) => void;
+}
+
+const GAP_PX = 8;
+const HEIGHT_PX = 36;
+const VIEWPORT_PAD = 8;
+const TOOLBAR_BOTTOM_PX = 96; // keep clear of the top chrome
+
+const barStyle: CSSProperties = {
+  position: 'fixed',
+  zIndex: 60,
+  display: 'flex',
+  alignItems: 'center',
+  gap: 2,
+  height: HEIGHT_PX,
+  padding: '0 4px',
+  borderRadius: 8,
+  background: 'var(--doc-surface, #ffffff)',
+  border: '1px solid var(--doc-border, #e0e0e0)',
+  boxShadow: '0 2px 10px rgba(0,0,0,0.14)',
+};
+
+interface BtnDef {
+  /** String-literal subset of FormattingAction (all assignable to it). */
+  action: 'bold' | 'italic' | 'underline' | 'strikethrough';
+  icon: string;
+  active: boolean;
+  labelKey: string;
+}
+
+export function SelectionFormatToolbar({
+  isOpen,
+  getView,
+  formatting,
+  onFormat,
+}: SelectionFormatToolbarProps) {
+  const { t } = useTranslation();
+  const [anchor, setAnchor] = useState<{ top: number; left: number } | null>(null);
+  const barRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setAnchor(null);
+      return;
+    }
+    const place = () => {
+      const view = getView();
+      if (!view) {
+        setAnchor(null);
+        return;
+      }
+      const { from, to, empty } = view.state.selection;
+      if (empty) {
+        setAnchor(null);
+        return;
+      }
+      let startRect: { top: number; bottom: number; left: number };
+      let endRect: { top: number; bottom: number; left: number };
+      try {
+        startRect = view.coordsAtPos(from);
+        endRect = view.coordsAtPos(to);
+      } catch {
+        setAnchor(null);
+        return;
+      }
+      const vh = window.innerHeight;
+      const vw = window.innerWidth;
+      const barW = barRef.current?.offsetWidth ?? 160;
+      // Prefer ABOVE the selection start (Word's placement); fall back below.
+      const aboveTop = startRect.top - GAP_PX - HEIGHT_PX;
+      const belowTop = endRect.bottom + GAP_PX;
+      const fitsAbove = aboveTop >= TOOLBAR_BOTTOM_PX;
+      const top = fitsAbove
+        ? aboveTop
+        : belowTop + HEIGHT_PX <= vh - VIEWPORT_PAD
+          ? belowTop
+          : TOOLBAR_BOTTOM_PX;
+      const left = Math.max(VIEWPORT_PAD, Math.min(startRect.left, vw - barW - VIEWPORT_PAD));
+      setAnchor({ top, left });
+    };
+    place();
+    window.addEventListener('resize', place);
+    window.addEventListener('scroll', place, true);
+    return () => {
+      window.removeEventListener('resize', place);
+      window.removeEventListener('scroll', place, true);
+    };
+  }, [isOpen, getView, formatting]);
+
+  if (!isOpen || !anchor) return null;
+
+  const buttons: BtnDef[] = [
+    {
+      action: 'bold',
+      icon: 'format_bold',
+      active: !!formatting.bold,
+      labelKey: 'formattingBar.bold',
+    },
+    {
+      action: 'italic',
+      icon: 'format_italic',
+      active: !!formatting.italic,
+      labelKey: 'formattingBar.italic',
+    },
+    {
+      action: 'underline',
+      icon: 'format_underlined',
+      active: !!formatting.underline,
+      labelKey: 'formattingBar.underline',
+    },
+    {
+      action: 'strikethrough',
+      icon: 'strikethrough_s',
+      active: !!formatting.strike,
+      labelKey: 'formattingBar.strikethrough',
+    },
+  ];
+
+  return (
+    <div
+      ref={barRef}
+      role="toolbar"
+      aria-label={t('selectionToolbar.ariaLabel')}
+      data-testid="selection-format-toolbar"
+      style={{ ...barStyle, top: anchor.top, left: anchor.left }}
+      // Never let a click on the bar collapse the editor selection.
+      onMouseDown={(e) => e.preventDefault()}
+    >
+      {buttons.map((b) => (
+        <button
+          key={b.action}
+          type="button"
+          aria-label={t(b.labelKey as never)}
+          aria-pressed={b.active}
+          title={t(b.labelKey as never)}
+          data-testid={`selection-format-${b.action}`}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => onFormat(b.action)}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 30,
+            height: 30,
+            borderRadius: 6,
+            border: 'none',
+            cursor: 'pointer',
+            color: b.active ? 'var(--doc-primary, #1a73e8)' : 'var(--doc-text-on-surface, #1f2937)',
+            background: b.active ? 'var(--doc-primary-light, #e8f0fe)' : 'transparent',
+          }}
+        >
+          <MaterialSymbol name={b.icon} size={18} />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default SelectionFormatToolbar;


### PR DESCRIPTION
Closes the Tier-1 editing-UX gap from the competitive analysis (`docs/internal/29`): Google Docs and Word ship an on-selection mini toolbar; OnlyOffice's absence is a documented complaint. We had none.

Selecting body text now surfaces a small floating toolbar **above the selection** with **Bold / Italic / Underline / Strikethrough** — each reflecting the selection's active marks (correct pressed state) and applying via the *same* `handleFormat` the main toolbar uses, so behaviour is identical. Buttons `preventDefault` on `mousedown` so a click never collapses the PM selection (the documented focus-stealing pitfall). Anchoring reuses the `coordsAtPos` pattern from the (LLM-gated, disabled) `SelectionAskAi` surface.

Verified: react typecheck, i18n in sync, and a new Playwright spec — toolbar appears on selection, applies bold *without losing the selection* (bold reads active afterward), and hides on collapse — plus a screenshot showing the rendered toolbar.

Scoped to B/I/U/S for a tight first version; link / color / highlight are natural follow-ups.