### PR TITLE
feat(editor): add Link button to the selection format bar

### DIFF
--- a/docx-editor/.changeset/format-bar-link.md
+++ b/docx-editor/.changeset/format-bar-link.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Add a Link button to the on-selection format bar (MobileFormatBar, mobile + desktop variants). After Bold/Italic/Underline/Strikethrough, a divider then a link button opens the hyperlink dialog for the current selection — matching Google Docs' selection toolbar. Uses the existing format handler and the bar's correct selection-anchored positioning.

--- a/docx-editor/e2e/tests/mobile-format-bar.spec.ts
+++ b/docx-editor/e2e/tests/mobile-format-bar.spec.ts
@@ -50,6 +50,20 @@ test.describe('Mobile floating format bar', () => {
         'true'
       );
     });
+
+    test('link button on the desktop bar opens the hyperlink dialog', async ({ page }) => {
+      await page.goto('/?e2e=1');
+      await page.waitForSelector('[data-testid="docx-editor"]');
+      await page.waitForTimeout(500);
+      await page.locator('.ProseMirror').focus();
+      await page.keyboard.type('Link this');
+      await page.keyboard.press(`${await modifierKey(page)}+a`);
+      await expect(page.locator('[data-testid="desktop-format-bar"]')).toBeVisible({
+        timeout: 2000,
+      });
+      await page.locator('[data-testid="desktop-format-insertLink"]').click();
+      await expect(page.locator('[data-testid="hyperlink-dialog"]')).toBeVisible();
+    });
   });
 
   test.describe('phone viewport — chip appears + tap formats', () => {

--- a/docx-editor/packages/react/src/components/ui/MobileFormatBar.tsx
+++ b/docx-editor/packages/react/src/components/ui/MobileFormatBar.tsx
@@ -22,9 +22,18 @@
  * parent's scale transform).
  */
 
-import React, { useEffect, useState, useMemo, type CSSProperties } from 'react';
+import React, { Fragment, useEffect, useState, useMemo, type CSSProperties } from 'react';
 import type { SelectionRect } from '@eigenpal/docx-core/layout-bridge';
 import type { SelectionFormatting, FormattingAction } from '../Toolbar';
+import { MaterialSymbol } from './MaterialSymbol';
+
+const dividerStyle: CSSProperties = {
+  width: 1,
+  height: 16,
+  margin: '0 2px',
+  background: 'var(--doc-border, #e0e0e0)',
+  flexShrink: 0,
+};
 
 export interface MobileFormatBarProps {
   /** Selection rectangles in *overlay-local* coordinates (unscaled).
@@ -119,10 +128,15 @@ const btnActive: CSSProperties = {
 };
 
 interface FormatButton {
-  cmd: FormattingAction;
+  cmd: 'bold' | 'italic' | 'underline' | 'strikethrough' | 'insertLink';
   label: string;
-  glyph: string;
+  /** Text glyph (B/I/U/S). Mutually exclusive with `icon`. */
+  glyph?: string;
+  /** MaterialSymbol name — used for actions with no good text glyph (link). */
+  icon?: string;
   active: (f: SelectionFormatting) => boolean;
+  /** Render a thin separator before this button (groups marks vs actions). */
+  divider?: boolean;
 }
 
 const BUTTONS: FormatButton[] = [
@@ -136,6 +150,13 @@ const BUTTONS: FormatButton[] = [
     // SelectionFormatting calls it `strike` (matches PM mark name);
     // the FormattingAction uses `strikethrough` for the command.
     active: (f) => !!f.strike,
+  },
+  {
+    cmd: 'insertLink',
+    label: 'Insert link',
+    icon: 'link',
+    active: () => false,
+    divider: true,
   },
 ];
 
@@ -205,10 +226,7 @@ function MobileFormatBarInner({
     >
       {BUTTONS.map((b) => {
         const on = b.active(formatting);
-        // We know cmd is one of the four string literals in this
-        // file's BUTTONS table; the FormattingAction union also
-        // carries object variants we never construct here.
-        const cmd = b.cmd as 'bold' | 'italic' | 'underline' | 'strikethrough';
+        const cmd = b.cmd;
         const glyphStyle: CSSProperties = {
           fontWeight: cmd === 'bold' ? 700 : 600,
           fontStyle: cmd === 'italic' ? 'italic' : 'normal',
@@ -216,19 +234,25 @@ function MobileFormatBarInner({
             cmd === 'underline' ? 'underline' : cmd === 'strikethrough' ? 'line-through' : 'none',
         };
         return (
-          <button
-            key={b.label}
-            type="button"
-            style={{ ...btnBase, ...(on ? btnActive : null) }}
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={() => onFormat(b.cmd)}
-            aria-pressed={on}
-            aria-label={b.label}
-            title={b.label}
-            data-testid={`${variant}-format-${cmd}`}
-          >
-            <span style={glyphStyle}>{b.glyph}</span>
-          </button>
+          <Fragment key={b.label}>
+            {b.divider && <span aria-hidden style={dividerStyle} />}
+            <button
+              type="button"
+              style={{ ...btnBase, ...(on ? btnActive : null) }}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => onFormat(b.cmd)}
+              aria-pressed={on}
+              aria-label={b.label}
+              title={b.label}
+              data-testid={`${variant}-format-${cmd}`}
+            >
+              {b.icon ? (
+                <MaterialSymbol name={b.icon} size={variant === 'mobile' ? 18 : 16} />
+              ) : (
+                <span style={glyphStyle}>{b.glyph}</span>
+              )}
+            </button>
+          </Fragment>
         );
       })}
     </div>


### PR DESCRIPTION
Adds the genuinely-missing **Link** action to the existing on-selection format bar (`MobileFormatBar`, which despite its name has both mobile and desktop variants and already ships B/I/U/S anchored above the visible selection).

After B/I/U/S, a divider then a link icon button opens the hyperlink dialog for the current selection — matching Google Docs' selection toolbar. It routes through the same `onFormat → handleFormat` the other buttons use (which handles `insertLink`), and the bar's existing selection-rect positioning places it correctly. Buttons now support a MaterialSymbol icon in addition to text glyphs; link uses the `link` icon (no emoji, per house style).

Verified: react typecheck, lint, the `mobile-format-bar` e2e (new test: desktop link button opens the hyperlink dialog; existing B/I/U/S + phone tests still pass) + a screenshot showing `B I U S | link` anchored above the selection.

Context: this replaces the closed #130, which reimplemented this bar from scratch (a duplicate of MobileFormatBar) — here I extend the real component instead.