### PR TITLE
feat(editor): add text-color + highlight pickers to the selection format bar

### DIFF
--- a/docx-editor/.changeset/format-bar-color.md
+++ b/docx-editor/.changeset/format-bar-color.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Add text-color and highlight pickers to the on-selection format bar (MobileFormatBar, mobile + desktop). After B/I/U/S and Link, a divider then compact (non-split) color and highlight pickers that open the standard palette and apply to the selection via the same handler as the main toolbar — completing the Word-style mini toolbar.

--- a/docx-editor/e2e/tests/mobile-format-bar.spec.ts
+++ b/docx-editor/e2e/tests/mobile-format-bar.spec.ts
@@ -64,6 +64,28 @@ test.describe('Mobile floating format bar', () => {
       await page.locator('[data-testid="desktop-format-insertLink"]').click();
       await expect(page.locator('[data-testid="hyperlink-dialog"]')).toBeVisible();
     });
+
+    test('text color picker on the desktop bar applies a color to the selection', async ({
+      page,
+    }) => {
+      await page.goto('/?e2e=1');
+      await page.waitForSelector('[data-testid="docx-editor"]');
+      await page.waitForTimeout(500);
+      await page.locator('.ProseMirror').focus();
+      await page.keyboard.type('Color me');
+      await page.keyboard.press(`${await modifierKey(page)}+a`);
+      const bar = page.locator('[data-testid="desktop-format-bar"]');
+      await bar.waitFor({ timeout: 2000 });
+
+      // Open the text-color picker (it lives inside the bar) and pick Red.
+      await bar.getByRole('button', { name: 'Font Color' }).click();
+      await page.getByRole('button', { name: 'Red', exact: true }).first().click();
+
+      // The selected text now carries a colour mark.
+      await expect(page.locator('.ProseMirror span[style*="color"]')).toHaveCount(1, {
+        timeout: 2000,
+      });
+    });
   });
 
   test.describe('phone viewport — chip appears + tap formats', () => {

--- a/docx-editor/packages/react/src/components/ui/MobileFormatBar.tsx
+++ b/docx-editor/packages/react/src/components/ui/MobileFormatBar.tsx
@@ -26,6 +26,7 @@ import React, { Fragment, useEffect, useState, useMemo, type CSSProperties } fro
 import type { SelectionRect } from '@eigenpal/docx-core/layout-bridge';
 import type { SelectionFormatting, FormattingAction } from '../Toolbar';
 import { MaterialSymbol } from './MaterialSymbol';
+import { ColorPicker } from './ColorPicker';
 
 const dividerStyle: CSSProperties = {
   width: 1,
@@ -255,6 +256,24 @@ function MobileFormatBarInner({
           </Fragment>
         );
       })}
+      <span aria-hidden style={dividerStyle} />
+      {/* Text color + highlight — compact (non-split) pickers; the dropdown
+          opens on click and applies via the same onFormat the main toolbar
+          uses. onMouseDown preventDefault on the bar keeps the selection. */}
+      <ColorPicker
+        mode="text"
+        splitButton={false}
+        value={formatting.color?.replace(/^#/, '')}
+        onChange={(color) => onFormat({ type: 'textColor', value: color })}
+      />
+      <ColorPicker
+        mode="highlight"
+        splitButton={false}
+        value={formatting.highlight}
+        onChange={(color) =>
+          onFormat({ type: 'highlightColor', value: typeof color === 'string' ? color : '' })
+        }
+      />
     </div>
   );
 }


### PR DESCRIPTION
Completes the Word-style on-selection format bar (`MobileFormatBar`, mobile + desktop): after **B / I / U / S / Link**, a divider then compact **text-color** and **highlight** pickers.

They reuse the established `ColorPicker` (non-split for compactness) and wire to `onFormat({ type: 'textColor' | 'highlightColor', value })` — the exact path the main toolbar uses. `onMouseDown` preventDefault on the bar keeps the editor selection through the multi-step picker interaction.

Verified: react typecheck, the `mobile-format-bar` e2e suite (existing B/I/U/S + link + phone tests still pass, plus a new test that opens Font Color → picks Red → asserts a colour mark on the selection), and screenshots confirming (1) the bar is compact/not cluttered, (2) the palette dropdown opens correctly positioned (not clipped) from the floating bar, and (3) the colour applies with the selection preserved.