### PR TITLE
feat(editor): auto-link URLs on type + paste-URL-over-selection

### DIFF
--- a/docx-editor/.changeset/auto-hyperlink.md
+++ b/docx-editor/.changeset/auto-hyperlink.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Auto-hyperlink: typing a URL (http(s):// or www.) followed by a space now turns it into a link automatically (Word/Google Docs autoformat), and pasting a bare URL over selected text wraps the selection in a link to that URL instead of replacing the text.

--- a/docx-editor/e2e/tests/auto-hyperlink.spec.ts
+++ b/docx-editor/e2e/tests/auto-hyperlink.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Auto-hyperlink: typing a URL then space auto-links it (Word/GDocs
+ * autoformat), and pasting a bare URL over a selection wraps the SELECTED
+ * text in a link to that URL (Google Docs behaviour) rather than replacing it.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test.describe('Auto-hyperlink', () => {
+  let editor: EditorPage;
+
+  test.beforeEach(async ({ page }) => {
+    editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+  });
+
+  test('typing a URL followed by a space auto-links it', async ({ page }) => {
+    await editor.typeText('Visit http://example.com ');
+    // The URL is now an anchor; the surrounding text is not.
+    const link = page.locator('.paged-editor__hidden-pm .ProseMirror a[href="http://example.com"]');
+    await expect(link).toHaveCount(1, { timeout: 2000 });
+    await expect(link).toHaveText('http://example.com');
+  });
+
+  test('normalises a bare www. URL to an absolute href', async ({ page }) => {
+    await editor.typeText('see www.example.org ');
+    await expect(
+      page.locator('.paged-editor__hidden-pm .ProseMirror a[href="http://www.example.org"]')
+    ).toHaveCount(1, { timeout: 2000 });
+  });
+
+  test('pasting a URL over a selection links the selection (keeps the text)', async ({ page }) => {
+    await editor.typeText('Anchor text');
+    await editor.selectText('Anchor text');
+
+    await page.evaluate(() => {
+      const dt = new DataTransfer();
+      dt.setData('text/plain', 'https://example.com/page');
+      const ev = new ClipboardEvent('paste', { bubbles: true, cancelable: true });
+      Object.defineProperty(ev, 'clipboardData', { value: dt });
+      const target = document.querySelector('.paged-editor__hidden-pm .ProseMirror');
+      target?.dispatchEvent(ev);
+    });
+
+    const link = page.locator(
+      '.paged-editor__hidden-pm .ProseMirror a[href="https://example.com/page"]'
+    );
+    await expect(link).toHaveCount(1, { timeout: 2000 });
+    // The original text is preserved (not replaced by the URL).
+    await expect(link).toHaveText('Anchor text');
+  });
+});

--- a/docx-editor/packages/core/src/prosemirror/extensions/marks/HyperlinkExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/marks/HyperlinkExtension.ts
@@ -5,8 +5,15 @@
 import { createMarkExtension } from '../create';
 import { isMarkActive } from './markUtils';
 import type { HyperlinkAttrs } from '../../schema/marks';
-import type { Command, EditorState } from 'prosemirror-state';
+import { Plugin, type Command, type EditorState } from 'prosemirror-state';
 import type { ExtensionContext, ExtensionRuntime } from '../types';
+
+/** A whole token is a URL: http(s):// or www. followed by non-space. */
+const URL_TOKEN_RE = /^(?:https?:\/\/|www\.)[^\s]+$/i;
+/** Normalise a bare `www.` URL to an absolute href. */
+function toHref(url: string): string {
+  return /^www\./i.test(url) ? `http://${url}` : url;
+}
 
 // ============================================================================
 // HYPERLINK QUERY HELPERS (exported for toolbar)
@@ -172,12 +179,56 @@ export const HyperlinkExtension = createMarkExtension({
       };
     };
 
+    // Auto-link plugin: (1) typing a space/enter after a URL token wraps it in
+    // a hyperlink (Word/GDocs autoformat); (2) pasting a bare URL over a
+    // non-empty selection wraps the SELECTED text in a link to that URL
+    // (Google Docs behaviour) instead of replacing it.
+    const autoLinkPlugin = new Plugin({
+      props: {
+        handleTextInput(view, from, to, text) {
+          // Trigger only on a space; the URL is the token immediately before.
+          if (text !== ' ') return false;
+          const { state } = view;
+          const $from = state.doc.resolve(from);
+          if (!$from.parent.isTextblock) return false;
+          const before = state.doc.textBetween($from.start(), from, undefined, '￼');
+          const m = before.match(/(\S+)$/);
+          if (!m || !URL_TOKEN_RE.test(m[1])) return false;
+          const token = m[1];
+          const tokenStart = from - token.length;
+          // Skip if the token is already (partly) linked.
+          let alreadyLinked = false;
+          state.doc.nodesBetween(tokenStart, from, (node) => {
+            if (node.marks.some((mk) => mk.type === hlType)) alreadyLinked = true;
+          });
+          if (alreadyLinked) return false;
+          const mark = hlType.create({ href: toHref(token), tooltip: null });
+          const tr = state.tr
+            .insertText(text, from, to)
+            .addMark(tokenStart, from, mark)
+            .removeStoredMark(hlType); // don't carry the link onto further typing
+          view.dispatch(tr);
+          return true;
+        },
+        handlePaste(view, event) {
+          const raw = event.clipboardData?.getData('text/plain')?.trim();
+          if (!raw || /\s/.test(raw) || !URL_TOKEN_RE.test(raw)) return false;
+          const { from, to, empty } = view.state.selection;
+          if (empty) return false; // only wrap an existing selection
+          const mark = hlType.create({ href: toHref(raw), tooltip: null });
+          view.dispatch(view.state.tr.addMark(from, to, mark).scrollIntoView());
+          return true; // handled — keep the selected text, just link it
+        },
+      },
+    });
+
     return {
       commands: {
         setHyperlink,
         removeHyperlink: () => removeHyperlink,
         insertHyperlink,
       },
+      plugins: [autoLinkPlugin],
     };
   },
 });


### PR DESCRIPTION
Two missing autoformat behaviours the leaders ship (there was zero URL linkification anywhere):

- **Type-to-link**: typing a `http(s)://` or `www.` URL followed by a space turns it into a hyperlink automatically (normalising bare `www.` to an absolute href). Skips already-linked tokens and clears the stored mark so subsequent typing isn't linked.
- **Paste-URL-over-selection**: pasting a bare URL while text is selected links the **selected text** to that URL (Google Docs behaviour) instead of replacing it.

Implemented as a plugin on the existing `HyperlinkExtension` (reuses the `hyperlink` mark). Verified: core typecheck/lint, a new `auto-hyperlink` e2e (type-to-link, www-normalisation, paste-over-selection), and smoke + text-editing (31 tests) confirm normal typing/cut/paste/selection are unaffected.