### PR TITLE
feat(editor): auto-list on typing a marker + space

### DIFF
--- a/docx-editor/.changeset/auto-list.md
+++ b/docx-editor/.changeset/auto-list.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Auto-list: typing a list marker at the start of a paragraph followed by a space now converts it to a list (Word/Google Docs autoformat) — `-`, `*`, or `+` start a bullet list; `1.` or `1)` start a numbered list. A marker mid-paragraph is left alone.

--- a/docx-editor/e2e/tests/auto-list.spec.ts
+++ b/docx-editor/e2e/tests/auto-list.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Auto-list: typing a list marker at the start of a paragraph followed by a
+ * space converts it to a list (Word / Google Docs autoformat).
+ *   "-" / "*" / "+"  → bullet list
+ *   "1." / "1)"      → numbered list
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test.describe('Auto-list', () => {
+  let editor: EditorPage;
+
+  test.beforeEach(async ({ page }) => {
+    editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+  });
+
+  test('"- " at line start creates a bullet list and consumes the marker', async ({ page }) => {
+    await editor.typeText('- Buy milk');
+    // A list marker is painted, and the typed "-" is gone from the content.
+    await expect(page.locator('.layout-list-marker')).toHaveCount(1, { timeout: 2000 });
+    const text = await page.locator('.paged-editor__hidden-pm .ProseMirror').innerText();
+    expect(text).toContain('Buy milk');
+    expect(text).not.toContain('- Buy milk');
+  });
+
+  test('"1. " at line start creates a numbered list', async ({ page }) => {
+    await editor.typeText('1. First');
+    const marker = page.locator('.layout-list-marker');
+    await expect(marker).toHaveCount(1, { timeout: 2000 });
+    await expect(marker).toContainText('1');
+  });
+
+  test('a marker mid-paragraph does NOT trigger auto-list', async ({ page }) => {
+    await editor.typeText('a - b');
+    await expect(page.locator('.layout-list-marker')).toHaveCount(0);
+  });
+});

--- a/docx-editor/packages/core/src/prosemirror/extensions/features/ListExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/features/ListExtension.ts
@@ -5,7 +5,7 @@
  * Provides: toggle bullet/number, indent/outdent, enter/backspace handling.
  */
 
-import type { Command, EditorState } from 'prosemirror-state';
+import { Plugin, type Command, type EditorState } from 'prosemirror-state';
 import { createExtension } from '../create';
 import { Priority } from '../types';
 import type { ExtensionRuntime } from '../types';
@@ -409,11 +409,39 @@ import { goToNextCell, goToPrevCell } from '../nodes/TableExtension';
 // EXTENSION
 // ============================================================================
 
+// Auto-list: typing a list marker at the very start of a non-list paragraph
+// followed by a space converts it to a list (Word/Google Docs autoformat).
+//   "-", "*", "+"  → bullet list
+//   "1.", "1)"     → numbered list
+const autoListPlugin = new Plugin({
+  props: {
+    handleTextInput(view, from, _to, text) {
+      if (text !== ' ') return false;
+      const { state } = view;
+      const $from = state.doc.resolve(from);
+      if (!$from.parent.isTextblock) return false;
+      // Already a list paragraph → don't toggle it off.
+      if (($from.parent.attrs as { numPr?: { numId?: number } }).numPr?.numId != null) return false;
+      // The marker must be the ENTIRE content before the cursor (line start).
+      const before = state.doc.textBetween($from.start(), from);
+      let cmd: Command | null = null;
+      if (/^[-*+]$/.test(before)) cmd = toggleBulletList;
+      else if (/^\d{1,3}[.)]$/.test(before)) cmd = toggleNumberedList;
+      if (!cmd) return false;
+      // Remove the typed marker, then apply the list to the now-empty paragraph.
+      view.dispatch(state.tr.delete($from.start(), from));
+      cmd(view.state, view.dispatch);
+      return true; // consume the space
+    },
+  },
+});
+
 export const ListExtension = createExtension({
   name: 'list',
   priority: Priority.High, // Must be before base keymap
   onSchemaReady(): ExtensionRuntime {
     return {
+      plugins: [autoListPlugin],
       commands: {
         toggleBulletList: () => toggleBulletList,
         toggleNumberedList: () => toggleNumberedList,


### PR DESCRIPTION
Autoformat the leaders ship and we lacked (the editor had no input-rule/autoformat system at all): typing a list marker as the whole line then a space starts a list.

- `-`, `*`, `+` → bullet list
- `1.`, `1)` → numbered list

Implemented as a `handleTextInput` plugin on `ListExtension` that removes the typed marker and applies the existing `toggleBulletList`/`toggleNumberedList` commands. Guards: only at the start of a **non-list** paragraph where the marker is the entire content; a marker mid-paragraph is left alone.

Verified: core typecheck/lint, a new `auto-list` e2e (bullet, numbered, mid-paragraph negative case) and `lists` + `smoke` (33 tests) confirm no regression to normal typing or existing list behaviour.