### PR TITLE
feat(desktop): route Export as PDF through native print-to-PDF

### DIFF
--- a/docx-editor/.changeset/feat-on-export-pdf.md
+++ b/docx-editor/.changeset/feat-on-export-pdf.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': minor
+---
+
+Add an `onExportPdf` hook to `DocxEditor`. When set and it resolves true, the host handled "Export as PDF" (the Casual Office desktop shell uses its native webview print-to-PDF for selectable-text output reliable on WebKitGTK) and the browser print-dialog fallback is skipped. Unset / false falls back to the existing print pipeline.

--- a/docx-editor/e2e/tests/desktop-export-pdf.spec.ts
+++ b/docx-editor/e2e/tests/desktop-export-pdf.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+/**
+ * In the desktop shell, "Export as PDF" must route through the host's native
+ * webview print-to-PDF (selectable text, reliable on WebKitGTK) instead of the
+ * browser print-dialog fallback. We stub a desktop bridge whose exportPdf
+ * records calls, and assert the native path is taken and window.open (the
+ * print pipeline) is NOT used.
+ */
+test('desktop Export as PDF routes through the native host, not the print dialog', async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    const w = window as unknown as {
+      __pdfCalls: string[];
+      __printOpened: boolean;
+      __deskApp__: unknown;
+    };
+    w.__pdfCalls = [];
+    w.__printOpened = false;
+    w.__deskApp__ = {
+      isDesktop: true,
+      filePath: null,
+      fileKind: 'docx',
+      loadDocument: async () => {
+        throw new Error('not used');
+      },
+      save: async () => null,
+      saveAs: async () => null,
+      setDirty: () => undefined,
+      dismissBoot: () => undefined,
+      exportPdf: async (name: string) => {
+        w.__pdfCalls.push(name);
+        return '/tmp/out.pdf';
+      },
+    };
+    // Harmless stub so a fallback to the print pipeline can't pop an OS dialog,
+    // and is detectable.
+    window.open = function () {
+      w.__printOpened = true;
+      return {
+        document: { write() {}, close() {} },
+        onload: null,
+        print() {},
+        close() {},
+        closed: true,
+      } as unknown as Window;
+    };
+  });
+
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.loadDocxFile('fixtures/core-properties.docx');
+  await page.waitForTimeout(300);
+
+  await page.getByRole('button', { name: /^File$/ }).click();
+  await page.getByText('Export as PDF', { exact: true }).click();
+  await page.waitForTimeout(150);
+
+  // Routed through the native host with `<doc>.pdf`, and the browser print
+  // fallback was NOT used.
+  expect(await page.evaluate(() => (window as unknown as { __pdfCalls: string[] }).__pdfCalls)).toEqual(
+    ['core-properties.pdf'],
+  );
+  expect(
+    await page.evaluate(() => (window as unknown as { __printOpened: boolean }).__printOpened),
+  ).toBe(false);
+});

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -958,6 +958,22 @@ export function App() {
     }
   }, []); // bridge.saveAs is stable
 
+  // Export as PDF via the shell's native webview print-to-PDF (selectable text,
+  // reliable on WebKitGTK). Returns true when handled so the editor skips the
+  // browser print-dialog fallback; false on web, missing host support, or a
+  // cancelled save dialog (export_pdf returns null) so the fallback still runs.
+  const onExportPdfDesktop = useCallback(async (suggestedName: string) => {
+    const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
+    if (!bridge?.isDesktop || !bridge.exportPdf) return false;
+    try {
+      const written = await bridge.exportPdf(suggestedName);
+      return written != null;
+    } catch (err) {
+      console.error('desktop PDF export failed', err);
+      return false;
+    }
+  }, []);
+
   // Forward DocxEditor's authoritative document-change signal to the desktop
   // bridge so the Rust close-guard sees a dirty window for EVERY real edit —
   // including mouse/toolbar/menu edits (bold, tables, format painter, accept/
@@ -1313,6 +1329,7 @@ export function App() {
           // internal handleSave/handleExport don't re-reference on every status change.
           onSave={isDesktop ? onSaveDesktop : undefined}
           onExport={isDesktop ? onExportDesktop : undefined}
+          onExportPdf={isDesktop ? onExportPdfDesktop : undefined}
           // Desktop only: mark the window dirty on every real document change
           // so the unsaved-changes close-guard fires for mouse/toolbar edits.
           onChange={isDesktop ? onDocChangeDesktop : undefined}

--- a/docx-editor/examples/vite/src/desk-bridge-bootstrap.ts
+++ b/docx-editor/examples/vite/src/desk-bridge-bootstrap.ts
@@ -325,6 +325,7 @@ if (isDesktop) {
         save(bytes: ArrayBuffer): Promise<string | null>;
         saveAs(name: string, bytes: ArrayBuffer): Promise<string | null>;
         setDirty?(dirty: boolean): void;
+        exportPdf?(suggestedName: string): Promise<string | null>;
       }
     | undefined;
 
@@ -545,6 +546,12 @@ if (isDesktop) {
           email: string | null;
           avatar_path: string | null;
         } | null;
+      },
+      // Native webview print-to-PDF (selectable text). Opens the OS save dialog
+      // and renders this window to PDF via the shell's export_pdf command.
+      // Returns the written path, or null if the user cancelled.
+      async exportPdf(suggestedName: string): Promise<string | null> {
+        return (await inv('export_pdf', { suggestedName })) as string | null;
       },
     };
   } else {

--- a/docx-editor/examples/vite/src/deskapp-bridge.d.ts
+++ b/docx-editor/examples/vite/src/deskapp-bridge.d.ts
@@ -63,6 +63,10 @@ declare global {
        * save()/saveAs() clear it.
        */
       setDirty?(dirty: boolean): void;
+      /** Native webview print-to-PDF: opens the OS save dialog and renders this
+       *  window to a selectable-text PDF via the shell's export_pdf command.
+       *  Returns the written path, or null if cancelled. */
+      exportPdf?(suggestedName: string): Promise<string | null>;
       /**
        * Dismiss the cold-start boot overlay the bootstrap paints before React
        * mounts (top-level desktop windows only). Fades it out then removes it.

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -484,6 +484,12 @@ export interface DocxEditorProps {
    *  a picker (never a phantom ~/Downloads file); the web build leaves it
    *  unset and falls back to the `<a download>` blob. */
   onExport?: (blob: Blob, suggestedName: string) => boolean | Promise<boolean>;
+  /** Export as PDF hook. When set and it resolves true, the host handled the
+   *  PDF export (e.g. the desktop shell's native webview print-to-PDF, which
+   *  yields selectable text and is reliable on WebKitGTK) and the browser
+   *  print-dialog fallback is skipped. Returns false / unset → fall back to the
+   *  print pipeline's "Save as PDF". */
+  onExportPdf?: (suggestedName: string) => boolean | Promise<boolean>;
   /** Callback invoked when the user picks File → New. Host should
    *  replace the loaded document with a blank one. */
   onNew?: () => void;
@@ -1568,6 +1574,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     onExport,
     onNew,
     onFileOpened,
+    onExportPdf,
     author = 'User',
     onChange,
     onSelectionChange,
@@ -6798,10 +6805,14 @@ body { background: white; }
   // (or a sensible default) so the saved file is `<doc>.pdf` rather
   // than `Print.pdf`. There is no JS API to preselect the PDF
   // destination — the user picks it once in the print dialog.
-  const handleExportPdf = useCallback(() => {
+  const handleExportPdf = useCallback(async () => {
     const base = (documentName?.trim() || 'Document').replace(/\.docx$/i, '');
+    // Desktop: route through the host's native print-to-PDF (selectable text,
+    // reliable on WebKitGTK) instead of the browser print dialog. If the host
+    // didn't handle it (web, or user cancelled the save dialog), fall back.
+    if (onExportPdf && (await onExportPdf(`${base}.pdf`))) return;
     triggerPrintFlow(base);
-  }, [triggerPrintFlow, documentName]);
+  }, [triggerPrintFlow, documentName, onExportPdf]);
 
   const handleDownloadDocument = useCallback(async () => {
     setIsSaving(true);


### PR DESCRIPTION
Editor-side wiring for native PDF export (pairs with the shell's `export_pdf` command, CasualOffice/desktop#21).

`DocxEditor` gains an `onExportPdf` hook: when the host handles it (resolves true), the browser print-dialog fallback is skipped. The desktop example wires it to a new `bridge.exportPdf`, which invokes the shell's `export_pdf` command (native webview print-to-PDF — selectable text, reliable on WebKitGTK). Web and cancelled-dialog paths still fall back to the existing print pipeline.

Verified by running: new e2e (`desktop-export-pdf.spec.ts`) stubs a desktop bridge and asserts Export as PDF calls `bridge.exportPdf('<doc>.pdf')` and does **not** open the print window; the existing `export-pdf.spec.ts` (web print path) is unchanged. typecheck + prettier clean.

Depends on CasualOffice/desktop#21 (the `export_pdf` command) being present in the shell for the end-to-end flow.