### PR TITLE
feat(editor): markdown heading shortcut (# / ## / ### + space)

### DIFF
--- a/docx-editor/.changeset/markdown-heading-shortcut.md
+++ b/docx-editor/.changeset/markdown-heading-shortcut.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Markdown heading shortcut: typing `# `, `## `, or `### ` at the start of a plain paragraph applies Heading 1/2/3 (Google Docs / Notion autoformat). It sets the real paragraph style with the document's resolved heading formatting, so the heading appears in the document outline and round-trips — not just direct bold/size formatting.

--- a/docx-editor/e2e/tests/markdown-heading-shortcut.spec.ts
+++ b/docx-editor/e2e/tests/markdown-heading-shortcut.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Markdown heading shortcut: "# " / "## " / "### " at the start of a plain
+ * paragraph applies Heading 1/2/3 (Google Docs / Notion autoformat). It sets
+ * the real paragraph style (data-style-id), not just direct formatting, so the
+ * heading appears in the outline and round-trips.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+const PM = '.paged-editor__hidden-pm .ProseMirror';
+
+test.describe('Markdown heading shortcut', () => {
+  let editor: EditorPage;
+
+  test.beforeEach(async ({ page }) => {
+    editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+  });
+
+  for (const [marker, styleId, label] of [
+    ['#', 'Heading1', 'H1'],
+    ['##', 'Heading2', 'H2'],
+    ['###', 'Heading3', 'H3'],
+  ] as const) {
+    test(`"${marker} " applies ${styleId}`, async ({ page }) => {
+      await editor.typeText(`${marker} ${label} text`);
+      const p = page.locator(`${PM} p[data-style-id="${styleId}"]`);
+      await expect(p).toHaveCount(1, { timeout: 2000 });
+      // Marker consumed; text kept.
+      await expect(p).toContainText(`${label} text`);
+      await expect(p).not.toContainText(`${marker} `);
+    });
+  }
+
+  test('four hashes does NOT trigger a heading', async ({ page }) => {
+    await editor.typeText('#### not a heading');
+    await expect(page.locator(`${PM} p[data-style-id^="Heading"]`)).toHaveCount(0);
+  });
+
+  test('a hash mid-paragraph does NOT trigger a heading', async ({ page }) => {
+    await editor.typeText('text # more');
+    await expect(page.locator(`${PM} p[data-style-id^="Heading"]`)).toHaveCount(0);
+  });
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -66,7 +66,7 @@ import { CommentMarginMarkers } from './CommentMarginMarkers';
 import { useCommentSidebarItems, type CommentCallbacks } from '../hooks/useCommentSidebarItems';
 import { useTrackedChanges } from '../hooks/useTrackedChanges';
 import type { EditorState as PMEditorState } from 'prosemirror-state';
-import { NodeSelection } from 'prosemirror-state';
+import { NodeSelection, Plugin } from 'prosemirror-state';
 import type { Mark as PMMark } from 'prosemirror-model';
 import { undo as pmUndo, redo as pmRedo } from 'prosemirror-history';
 import type { ReactSidebarItem } from '../plugin-api/types';
@@ -2098,9 +2098,39 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     () => createSuggestionModePlugin(editingMode === 'suggesting', author),
     [] // eslint-disable-line react-hooks/exhaustive-deps
   );
+  // Markdown heading shortcut: "# " / "## " / "### " at the start of a plain
+  // paragraph applies Heading 1/2/3. Lives at the React layer because applying
+  // a heading needs the document's RESOLVED style formatting (font/size/bold)
+  // — the resolver is React-side. The ref points at `applyHeadingStyle` below,
+  // which calls the applyStyle COMMAND directly (not handleFormat, whose
+  // selection-restoration clobbers the post-delete cursor).
+  const applyHeadingStyleRef = useRef<((styleId: string) => void) | null>(null);
+  const markdownHeadingPlugin = useMemo(
+    () =>
+      new Plugin({
+        props: {
+          handleTextInput(view, from, _to, text) {
+            if (text !== ' ') return false;
+            const apply = applyHeadingStyleRef.current;
+            if (!apply) return false;
+            const { state } = view;
+            const $from = state.doc.resolve(from);
+            if ($from.parent.type.name !== 'paragraph') return false;
+            if (($from.parent.attrs as { styleId?: string | null }).styleId) return false;
+            const before = state.doc.textBetween($from.start(), from);
+            const m = before.match(/^(#{1,3})$/);
+            if (!m) return false;
+            view.dispatch(state.tr.delete($from.start(), from));
+            apply(`Heading${m[1].length}`);
+            return true;
+          },
+        },
+      }),
+    []
+  );
   const allExternalPlugins = useMemo(
-    () => [suggestionPlugin, ...(externalPlugins ?? [])],
-    [suggestionPlugin, externalPlugins]
+    () => [suggestionPlugin, markdownHeadingPlugin, ...(externalPlugins ?? [])],
+    [suggestionPlugin, markdownHeadingPlugin, externalPlugins]
   );
 
   // Refs
@@ -4981,6 +5011,34 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     },
     [getActiveEditorView, openSplitCellDialog]
   );
+
+  // Apply a heading paragraph style at the cursor with its RESOLVED formatting
+  // (sets both styleId and the font/size/bold marks) — used by the markdown
+  // heading shortcut. Mirrors handleFormat's applyStyle case but calls the
+  // command directly so there's no selection restoration.
+  const applyHeadingStyle = useCallback(
+    (styleId: string) => {
+      const view = getActiveEditorView();
+      if (!view) return;
+      const currentDoc = historyStateRef.current;
+      const styleResolver = currentDoc?.package.styles
+        ? getCachedStyleResolver(currentDoc.package.styles)
+        : null;
+      if (styleResolver) {
+        const resolved = styleResolver.resolveParagraphStyle(styleId);
+        applyStyle(styleId, {
+          paragraphFormatting: resolved.paragraphFormatting,
+          runFormatting: resolved.runFormatting,
+        })(view.state, view.dispatch);
+      } else {
+        applyStyle(styleId)(view.state, view.dispatch);
+      }
+    },
+    [getActiveEditorView, getCachedStyleResolver]
+  );
+  useEffect(() => {
+    applyHeadingStyleRef.current = applyHeadingStyle;
+  }, [applyHeadingStyle]);
 
   const handleSplitCellDialogClose = useCallback(() => {
     setSplitCellDialogState((prev) => ({


### PR DESCRIPTION
Typing `# `, `## `, or `### ` at the start of a plain paragraph applies **Heading 1/2/3** (Google Docs / Notion autoformat). The editor had no markdown autoformat for headings.

Crucially it sets the **real paragraph style** (`data-style-id="Heading1"`) with the document's **resolved** heading formatting — so the heading appears in the document outline and round-trips — not just direct bold/size marks. It's a React-layer external plugin (the style resolver is React-side) that calls the `applyStyle` command **directly** with the resolver's attrs; going through `handleFormat` dropped the `styleId` because its selection-restoration clobbered the post-delete cursor (caught earlier via a DOM probe).

Verified: react typecheck, a new e2e (H1/H2/H3 set the style + keep the text; 4-hash and mid-paragraph cases do NOT trigger) and `text-editing` + `paragraph-styles` (62 tests) regression clean.