### PR TITLE
feat(editor): inline markdown autoformat (*italic* / **bold**)

### DIFF
--- a/docx-editor/.changeset/inline-markdown.md
+++ b/docx-editor/.changeset/inline-markdown.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Inline markdown autoformat: typing `*italic*` or `**bold**` applies the mark and removes the asterisks (standard Markdown convention). Spaced asterisks like `2 * 3` are left alone so arithmetic isn't affected. `_` is intentionally not used (avoids snake_case false positives).

--- a/docx-editor/e2e/tests/inline-markdown.spec.ts
+++ b/docx-editor/e2e/tests/inline-markdown.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Inline-markdown autoformat: typing `*italic*` / `**bold**` applies the mark.
+ * Spaced asterisks (`2 * 3`) must NOT trigger.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+const PM = '.paged-editor__hidden-pm .ProseMirror';
+
+test.describe('Inline markdown', () => {
+  let editor: EditorPage;
+
+  test.beforeEach(async ({ page }) => {
+    editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+  });
+
+  test('**bold** applies bold and removes the asterisks', async ({ page }) => {
+    await editor.typeText('say **hi** now');
+    const strong = page.locator(`${PM} strong`);
+    await expect(strong).toHaveText('hi', { timeout: 2000 });
+    const text = await page.locator(PM).innerText();
+    expect(text).toContain('say hi now');
+    expect(text).not.toContain('*');
+  });
+
+  test('*italic* applies italic and removes the asterisks', async ({ page }) => {
+    await editor.typeText('an *em* word');
+    const em = page.locator(`${PM} em`);
+    await expect(em).toHaveText('em', { timeout: 2000 });
+    const text = await page.locator(PM).innerText();
+    expect(text).toContain('an em word');
+    expect(text).not.toContain('*');
+  });
+
+  test('spaced asterisks (2 * 3) do NOT trigger italic', async ({ page }) => {
+    await editor.typeText('2 * 3 * 4');
+    await expect(page.locator(`${PM} em`)).toHaveCount(0);
+    await expect(page.locator(`${PM} strong`)).toHaveCount(0);
+    const text = await page.locator(PM).innerText();
+    expect(text).toContain('2 * 3 * 4');
+  });
+});

--- a/docx-editor/packages/core/src/prosemirror/extensions/StarterKit.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/StarterKit.ts
@@ -60,6 +60,7 @@ import { createTableExtensions } from './nodes/TableExtension';
 
 // Features
 import { ListExtension } from './features/ListExtension';
+import { InlineMarkdownExtension } from './features/InlineMarkdownExtension';
 import { BaseKeymapExtension } from './features/BaseKeymapExtension';
 import { SelectionTrackerExtension } from './features/SelectionTrackerExtension';
 import { ImageDragExtension } from './features/ImageDragExtension';
@@ -164,6 +165,7 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   // Features
   add('pasteStyleInliner', PasteStyleInlinerExtension());
   add('list', ListExtension());
+  add('inlineMarkdown', InlineMarkdownExtension());
   add('baseKeymap', BaseKeymapExtension());
   add(
     'selectionTracker',

--- a/docx-editor/packages/core/src/prosemirror/extensions/features/InlineMarkdownExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/features/InlineMarkdownExtension.ts
@@ -1,0 +1,75 @@
+/**
+ * Inline-markdown autoformat — typing `*italic*` / `**bold**` applies the mark
+ * (standard Markdown convention; `*` only — `_` is skipped to avoid snake_case
+ * false positives). Fires on the closing `*`:
+ *
+ *   "**X*" + "*"  → bold X      (X is the 2nd closing's completion of `**X**`)
+ *   "*X"  + "*"   → italic X    (opening `*` not preceded by another `*`)
+ *
+ * The inner text must start and end with a non-space, non-`*` character, so
+ * `2 * 3` (spaced) and `** **` never trigger — matching Markdown's no-adjacent-
+ * whitespace rule.
+ */
+import { Plugin } from 'prosemirror-state';
+import { createExtension } from '../create';
+import type { ExtensionContext, ExtensionRuntime } from '../types';
+
+// Inner = one non-space-non-* char, optionally more non-* then a non-space-non-*.
+const INNER = '[^*\\s](?:[^*]*[^*\\s])?';
+const BOLD_RE = new RegExp(`\\*\\*(${INNER})\\*$`);
+const ITALIC_RE = new RegExp(`(?:^|[^*])(\\*${INNER})$`);
+
+export const InlineMarkdownExtension = createExtension({
+  name: 'inlineMarkdown',
+  onSchemaReady(ctx: ExtensionContext): ExtensionRuntime {
+    const boldType = ctx.schema.marks.bold;
+    const italicType = ctx.schema.marks.italic;
+
+    const plugin = new Plugin({
+      props: {
+        handleTextInput(view, from, _to, text) {
+          if (text !== '*') return false;
+          const { state } = view;
+          const $from = state.doc.resolve(from);
+          if (!$from.parent.isTextblock) return false;
+          const before = state.doc.textBetween($from.start(), from);
+
+          // Bold first (it's a superset of the italic delimiter).
+          const bold = boldType && BOLD_RE.exec(before);
+          if (bold) {
+            const inner = bold[1];
+            const start = from - bold[0].length;
+            const node = state.schema.text(inner, [boldType.create()]);
+            view.dispatch(
+              state.tr
+                .delete(start, from)
+                .insert(start, node)
+                .removeStoredMark(boldType)
+                .scrollIntoView()
+            );
+            return true;
+          }
+
+          const italic = italicType && ITALIC_RE.exec(before);
+          if (italic) {
+            const token = italic[1]; // `*X`
+            const inner = token.slice(1);
+            const start = from - token.length;
+            const node = state.schema.text(inner, [italicType.create()]);
+            view.dispatch(
+              state.tr
+                .delete(start, from)
+                .insert(start, node)
+                .removeStoredMark(italicType)
+                .scrollIntoView()
+            );
+            return true;
+          }
+          return false;
+        },
+      },
+    });
+
+    return { plugins: [plugin] };
+  },
+});


### PR DESCRIPTION
Typing `*italic*` or `**bold**` applies the mark and removes the asterisks (standard Markdown). Completes the autoformat set alongside auto-link, auto-list, and the markdown heading shortcut.

Guards against false positives: the inner text must start and end with a non-space, non-`*` character, so `2 * 3` (arithmetic) and `** **` never trigger. `*`-only — `_` is intentionally excluded to avoid snake_case false positives.

Self-contained core plugin (the `bold`/`italic` marks already exist). Verified: core typecheck/lint, a new `inline-markdown` e2e (bold applies + strips asterisks, italic likewise, spaced `2 * 3 * 4` stays plain) and `formatting` + `text-editing` (57 tests) regression clean.