### PR TITLE
fix(layout): grouped connector lines render as thin rules, not inflated bars

### DIFF
--- a/docx-editor/.changeset/connector-line-render.md
+++ b/docx-editor/.changeset/connector-line-render.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Render grouped "Straight Connector" line shapes (prst="line") as a thin rule instead of a content-height filled box. A line shape with a fill (e.g. a gray divider under a header logo) was given an empty placeholder paragraph plus default text-box insets, inflating the ~1px line into a tall colored bar.

--- a/docx-editor/e2e/tests/connector-line-height.spec.ts
+++ b/docx-editor/e2e/tests/connector-line-height.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * A grouped "Straight Connector" (prst="line", cy=0) with a fill must render
+ * as a thin rule, NOT a content-height filled box. Regression: the medical-
+ * incident-form header divider rendered as a ~10px gray bar because the line
+ * shape was given an empty placeholder paragraph + default text-box insets,
+ * which inflated its height. See textBoxEnricher.extractShapeFromWsp.
+ */
+import { test, expect } from '@playwright/test';
+import { join } from 'path';
+
+test('grouped connector line renders thin, not as a tall filled bar', async ({ page }) => {
+  await page.goto('http://localhost:5173/?e2e=1', { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('[data-testid="docx-editor"]', { timeout: 20000 });
+  const input = page.locator('input[type="file"][accept*=".docx"]').first();
+  await input.setInputFiles(join(process.cwd(), 'e2e/fixtures/medical-incident-form.docx'));
+  await page.waitForSelector('.layout-page', { timeout: 30000 });
+  await page.waitForTimeout(800);
+  // The gray (bg1+lumMod85% = rgb(217,217,217)) divider must be a thin line.
+  const grayHeights = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('.layout-textbox'))
+      .filter((e) => getComputedStyle(e as HTMLElement).backgroundColor.includes('217, 217, 217'))
+      .map((e) => Math.round((e as HTMLElement).getBoundingClientRect().height))
+  );
+  expect(grayHeights.length).toBeGreaterThan(0);
+  for (const h of grayHeights) expect(h).toBeLessThanOrEqual(4);
+});

--- a/docx-editor/packages/core/src/docx/textBoxEnricher.ts
+++ b/docx-editor/packages/core/src/docx/textBoxEnricher.ts
@@ -337,9 +337,14 @@ function extractShapeFromWsp(
   const totalOff = { x: parentOffsetEmu.x + offX, y: parentOffsetEmu.y + offY };
   const childPosition = addOffsetToAnchor(anchorPosition, totalOff);
 
-  // Inner text content, if this wsp is text-bearing.
-  let content: Paragraph[] = [{ type: 'paragraph', content: [] }];
-  if (txbx) {
+  // Inner text content, if this wsp is text-bearing. A connector (line /
+  // divider) carries no text frame — give it EMPTY content so the empty
+  // placeholder paragraph's line height (+ the default text-box insets)
+  // don't inflate the thin line into a tall filled bar. Word's "Straight
+  // Connector" with a bg1+lumMod fill is a ~1px rule under a logo; without
+  // this it rendered as a ~10px gray block (medical-incident-form header).
+  let content: Paragraph[] = isConnector ? [] : [{ type: 'paragraph', content: [] }];
+  if (txbx && !isConnector) {
     const txbxContentEl = findDeep(txbx, 'w', 'txbxContent');
     if (txbxContentEl) {
       const parsed = parseTextBoxContent(
@@ -364,7 +369,10 @@ function extractShapeFromWsp(
     wrap: anchorWrap,
     fill,
     outline,
-    textBody: { content },
+    // Connectors get zero insets so the line thickness is exactly `cy`/`cx`.
+    textBody: isConnector
+      ? { content, margins: { top: 0, bottom: 0, left: 0, right: 0 } }
+      : { content },
   };
   if (id) shape.id = id;
   if (xform.rotation || xform.flipH || xform.flipV) {


### PR DESCRIPTION
Follow-up to the wpg connector fix already in main (`e149a25`). That commit bumps a `prst="line"` connector's zero axis to a ~2px floor and copies outline→fill — but a grouped divider still rendered as a **~10px filled bar**, because `extractShapeFromWsp` gave the connector an empty placeholder paragraph plus default text-box insets, and the shape measure takes `max(size.height, contentHeight + margins)`. The empty paragraph's line-height won.

Fix: a connector carries no text frame, so emit **empty content + zero insets** — the rendered thickness equals the line geometry. Verified on the medical-incident-form header divider (gray `bg1`+lumMod rule): 10px → 2px, no corpus regression. Adds `e2e/tests/connector-line-height.spec.ts`.

(Recovered from a stale branch whose PR #140 had already merged its first commit; re-cut clean off main.)