### PR TITLE
fix(desktop): harden crash-recovery against post-save resurrect + orphaned sidecars

### DIFF
--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -856,13 +856,22 @@ export function App() {
   // killed mid-edit the sidecar survives and the next open offers to restore it.
   // Declared before the save handlers since they list clearRecovery as a dep.
   const recoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Bumped on every clearRecovery(). A snapshot captures the generation (and the
+  // bound path) before its async serialize and re-checks both after: if a Save
+  // cleared the sidecar, or the window rebound to a different file, while we
+  // were serializing, the write is dropped — otherwise a late snapshot would
+  // resurrect a just-cleared sidecar or write to the wrong file's sidecar.
+  const recoveryGenRef = useRef(0);
   const writeRecoverySnapshot = useCallback(async () => {
     const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
     if (!bridge?.isDesktop || !bridge.writeRecovery || !bridge.filePath) return;
+    const gen = recoveryGenRef.current;
+    const keyPath = bridge.filePath;
     try {
       const agent = editorRef.current?.getAgent();
       if (!agent) return;
       const buffer = await agent.toBuffer();
+      if (recoveryGenRef.current !== gen || bridge.filePath !== keyPath) return;
       await bridge.writeRecovery(buffer);
     } catch (err) {
       // Best-effort — a recovery snapshot must never disrupt editing.
@@ -877,8 +886,10 @@ export function App() {
     }, 4000);
   }, [writeRecoverySnapshot]);
   // Drop any pending snapshot and the on-disk sidecar — called after a clean
-  // Save (the saved file IS the recovery now) and on Discard.
+  // Save (the saved file IS the recovery now) and on Discard. Bumping the
+  // generation invalidates any snapshot whose serialize is already in flight.
   const clearRecovery = useCallback(() => {
+    recoveryGenRef.current += 1;
     if (recoveryTimerRef.current) {
       clearTimeout(recoveryTimerRef.current);
       recoveryTimerRef.current = null;

--- a/docx-editor/examples/vite/src/desk-bridge-bootstrap.ts
+++ b/docx-editor/examples/vite/src/desk-bridge-bootstrap.ts
@@ -528,6 +528,16 @@ if (isDesktop) {
         } catch {
           /* recents persistence is best-effort */
         }
+        // The window rebinds from the old file to newPath. Clear the OLD file's
+        // recovery sidecar so it isn't orphaned — App's post-saveAs clearRecovery
+        // only targets the (now new) bound path.
+        if (filePath && filePath !== newPath) {
+          try {
+            await inv('clear_recovery', { path: filePath });
+          } catch {
+            /* best-effort */
+          }
+        }
         filePath = newPath;
         // Only mark clean if no edit landed while the write was in flight.
         if (editSeq === seqAtStart) setWindowDirty(false);


### PR DESCRIPTION
Three recovery races from the release bug-hunt (desktop entry glue only):

- **Post-save resurrect** — a debounced snapshot whose `agent.toBuffer()` was in flight when a Save cleared the sidecar could finish afterwards and re-write it, so the next launch offered a recovery that should have been gone. `clearRecovery` now bumps a generation the snapshot re-checks before writing.
- **filePath not captured** — `writeRecoverySnapshot` re-read `bridge.filePath` after the await, so a window that rebound to a different file mid-serialize could write one document's snapshot into another's sidecar. Capture the path up front, bail if it changed.
- **Save As orphan** — Save As rebinds the window to the new path but left the old file's sidecar orphaned on disk; clear it during `saveAs`.

Changes confined to `examples/vite/src/`; demo builds clean.