### PR TITLE
fix(autolink): drop trailing punctuation from auto-linked URLs

### DIFF
--- a/docx-editor/.changeset/fix-autolink-trailing-punct.md
+++ b/docx-editor/.changeset/fix-autolink-trailing-punct.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Auto-link no longer swallows trailing sentence punctuation: typing "see http://example.com." links the URL but leaves the period (and trailing `,;:!?` or an unbalanced `)]}`) as plain text, while keeping balanced parens like `…/Foo_(bar)` intact.

--- a/docx-editor/e2e/tests/auto-hyperlink.spec.ts
+++ b/docx-editor/e2e/tests/auto-hyperlink.spec.ts
@@ -32,6 +32,30 @@ test.describe('Auto-hyperlink', () => {
     ).toHaveCount(1, { timeout: 2000 });
   });
 
+  test('trailing sentence punctuation is left out of the link', async ({ page }) => {
+    await editor.typeText('see http://example.com. ');
+    const link = page.locator('.paged-editor__hidden-pm .ProseMirror a[href="http://example.com"]');
+    await expect(link).toHaveCount(1, { timeout: 2000 });
+    await expect(link).toHaveText('http://example.com'); // not "http://example.com."
+    // the period survives as plain text after the link
+    await expect(page.locator('.paged-editor__hidden-pm .ProseMirror')).toContainText('com.');
+  });
+
+  test('a trailing unbalanced closing paren is left out of the link', async ({ page }) => {
+    await editor.typeText('link http://example.com) ');
+    const link = page.locator('.paged-editor__hidden-pm .ProseMirror a[href="http://example.com"]');
+    await expect(link).toHaveCount(1, { timeout: 2000 });
+    await expect(link).toHaveText('http://example.com');
+  });
+
+  test('a balanced paren inside the URL is kept', async ({ page }) => {
+    await editor.typeText('ref www.example.org/a_(b) ');
+    const link = page.locator(
+      '.paged-editor__hidden-pm .ProseMirror a[href="http://www.example.org/a_(b)"]'
+    );
+    await expect(link).toHaveCount(1, { timeout: 2000 });
+  });
+
   test('pasting a URL over a selection links the selection (keeps the text)', async ({ page }) => {
     await editor.typeText('Anchor text');
     await editor.selectText('Anchor text');

--- a/docx-editor/packages/core/src/prosemirror/extensions/marks/HyperlinkExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/marks/HyperlinkExtension.ts
@@ -15,6 +15,33 @@ function toHref(url: string): string {
   return /^www\./i.test(url) ? `http://${url}` : url;
 }
 
+/**
+ * Trim trailing characters that punctuate the surrounding sentence rather than
+ * belong to the URL — so "see http://example.com." links the URL but not the
+ * period, and "(http://example.com)" doesn't swallow the closing paren. Matches
+ * the linkify convention used by Google Docs / GitHub / Slack: strip trailing
+ * `.,;:!?` always, and a trailing `)]}` only when it has no matching opener in
+ * the token (keeps balanced URLs like `…/Foo_(bar)` intact).
+ */
+function trimTrailingUrlPunct(url: string): string {
+  let s = url;
+  for (;;) {
+    const next = s.replace(/[.,;:!?]+$/, '');
+    const close = next[next.length - 1];
+    if (close === ')' || close === ']' || close === '}') {
+      const open = close === ')' ? '(' : close === ']' ? '[' : '{';
+      const opens = next.split(open).length - 1;
+      const closes = next.split(close).length - 1;
+      if (closes > opens) {
+        s = next.slice(0, -1);
+        continue;
+      }
+    }
+    if (next === s) return next;
+    s = next;
+  }
+}
+
 // ============================================================================
 // HYPERLINK QUERY HELPERS (exported for toolbar)
 // ============================================================================
@@ -195,17 +222,22 @@ export const HyperlinkExtension = createMarkExtension({
           const m = before.match(/(\S+)$/);
           if (!m || !URL_TOKEN_RE.test(m[1])) return false;
           const token = m[1];
+          // Link the URL but not the punctuation that ends the sentence around
+          // it ("see http://x.com." → link drops the period).
+          const linked = trimTrailingUrlPunct(token);
+          if (!URL_TOKEN_RE.test(linked)) return false;
           const tokenStart = from - token.length;
+          const linkEnd = tokenStart + linked.length;
           // Skip if the token is already (partly) linked.
           let alreadyLinked = false;
           state.doc.nodesBetween(tokenStart, from, (node) => {
             if (node.marks.some((mk) => mk.type === hlType)) alreadyLinked = true;
           });
           if (alreadyLinked) return false;
-          const mark = hlType.create({ href: toHref(token), tooltip: null });
+          const mark = hlType.create({ href: toHref(linked), tooltip: null });
           const tr = state.tr
             .insertText(text, from, to)
-            .addMark(tokenStart, from, mark)
+            .addMark(tokenStart, linkEnd, mark)
             .removeStoredMark(hlType); // don't carry the link onto further typing
           view.dispatch(tr);
           return true;


### PR DESCRIPTION
Typing a URL before a space auto-links the whole non-space token, so "see http://example.com." linked the trailing period (and `,;:!?` or an unbalanced `)]}`). 

Trim trailing sentence punctuation + unbalanced closing brackets from the linked span, leaving them as plain text — while keeping balanced in-URL parens like `.../Foo_(bar)` intact (Google Docs / GitHub linkify convention).

e2e coverage added (`auto-hyperlink.spec.ts`): trailing period, trailing unbalanced paren, balanced-paren-preserved. All 6 autolink tests pass; typecheck + lint clean.