### PR TITLE
fix(table): move border/color/fill into the Format panel, out of the toolbar

### DIFF
--- a/docx-editor/.changeset/fix-table-appearance-panel.md
+++ b/docx-editor/.changeset/fix-table-appearance-panel.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Table appearance controls (border, border color, border width, cell fill) now live in the Format (properties) panel instead of being appended to the formatting toolbar when the caret enters a table. The toolbar's table group keeps only the style gallery and the table-actions menu; the appearance pickers move to the panel — the single home for object appearance.

--- a/docx-editor/e2e/helpers/editor-page.ts
+++ b/docx-editor/e2e/helpers/editor-page.ts
@@ -678,14 +678,17 @@ export class EditorPage {
    * Shared helper: pick a color from an AdvancedColorPicker dropdown.
    * Opens the picker, finds/clicks a matching color button, or falls back to custom hex input.
    */
-  private async pickColorFromDropdown(buttonTitle: string, hexColor: string): Promise<void> {
+  private async pickColorFromDropdown(
+    buttonTitle: string,
+    hexColor: string,
+    scope: Locator = this.toolbar
+  ): Promise<void> {
     // Split-button picker (default): two buttons share the same title — apply
     // half on the left, arrow half on the right (aria-haspopup="true"). Click
     // the arrow to open the dropdown. Falls through to a single picker for
-    // legacy single-button mode (splitButton={false}).
-    const arrowOrSingle = this.toolbar
-      .locator(`[title="${buttonTitle}"][aria-haspopup="true"]`)
-      .first();
+    // legacy single-button mode (splitButton={false}). `scope` defaults to the
+    // toolbar; the table cell-fill picker lives in the Format panel instead.
+    const arrowOrSingle = scope.locator(`[title="${buttonTitle}"][aria-haspopup="true"]`).first();
     await arrowOrSingle.click();
 
     await this.page.waitForSelector('.docx-color-picker-dropdown', {
@@ -1293,6 +1296,26 @@ export class EditorPage {
   }
 
   /**
+   * Open the table Format panel and return its properties section. The
+   * border / border-color / width / cell-fill pickers live here now (not in
+   * the toolbar). Clicking the chip is idempotent enough — if the section is
+   * already showing we skip the click so a second call doesn't toggle it shut.
+   */
+  async openTableFormatPanel(): Promise<Locator> {
+    const section = this.page.locator('[data-testid="properties-table-section"]');
+    if ((await section.count()) === 0 || !(await section.first().isVisible())) {
+      // The chip only renders once the caret-in-table state has settled; under
+      // parallel CI load it can lag the cell click. Wait for it before clicking
+      // so we don't click into the void and time out on the section instead.
+      const chip = this.page.locator('[data-testid="table-format-chip"]');
+      await chip.waitFor({ state: 'visible', timeout: 5_000 });
+      await chip.click();
+      await section.first().waitFor({ state: 'visible', timeout: 5_000 });
+    }
+    return section.first();
+  }
+
+  /**
    * Set all borders on current cell. The borders flyout renders in a
    * portal that can land outside the viewport on CI runner sizes;
    * Playwright refuses to click off-screen elements even with
@@ -1302,7 +1325,8 @@ export class EditorPage {
    * cursor's ability to reach the button.
    */
   async setAllBorders(): Promise<void> {
-    await this.page.locator('[data-testid="toolbar-table-borders"]').click();
+    const section = await this.openTableFormatPanel();
+    await section.locator('[data-testid="toolbar-table-borders"]').click();
     const target = this.page.locator('button[title="All borders"]');
     await target.waitFor({ state: 'visible', timeout: 5_000 });
     await target.dispatchEvent('click');
@@ -1313,18 +1337,21 @@ export class EditorPage {
    * dispatchEvent rationale.
    */
   async removeBorders(): Promise<void> {
-    await this.page.locator('[data-testid="toolbar-table-borders"]').click();
+    const section = await this.openTableFormatPanel();
+    await section.locator('[data-testid="toolbar-table-borders"]').click();
     const target = this.page.locator('button[title="No borders"]');
     await target.waitFor({ state: 'visible', timeout: 5_000 });
     await target.dispatchEvent('click');
   }
 
   /**
-   * Set cell fill color
+   * Set cell fill color. The cell-fill picker moved from the toolbar into the
+   * table Format panel, so scope the dropdown lookup to the panel section.
    */
   async setCellFillColor(color: string): Promise<void> {
     const hexColor = color.replace(/^#/, '').toUpperCase();
-    await this.pickColorFromDropdown('Cell Fill Color', hexColor);
+    const section = await this.openTableFormatPanel();
+    await this.pickColorFromDropdown('Cell Fill Color', hexColor, section);
   }
 
   /**

--- a/docx-editor/e2e/tests/colors.spec.ts
+++ b/docx-editor/e2e/tests/colors.spec.ts
@@ -8,7 +8,7 @@
  * - Undo/redo for color changes
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect, type Locator } from '@playwright/test';
 import { EditorPage } from '../helpers/editor-page';
 import * as assertions from '../helpers/assertions';
 
@@ -365,6 +365,7 @@ test.describe('Color Edge Cases', () => {
 
 test.describe('Border Color Picker', () => {
   let editor: EditorPage;
+  let section: Locator;
 
   // Use wider viewport for table toolbar tests
   test.use({ viewport: { width: 1400, height: 900 } });
@@ -373,22 +374,22 @@ test.describe('Border Color Picker', () => {
     editor = new EditorPage(page);
     await editor.goto();
     await editor.waitForReady();
-    // Border-color picker is a table-context split-button — it only
-    // renders when the cursor is inside a table cell. Load the demo
-    // doc (which has tables) then click into one.
+    // Border-color picker is a table-appearance control. It lives in the
+    // table Format panel (not the toolbar), which only mounts after the
+    // caret is in a table cell and the Format chip is clicked. Load the demo
+    // doc (which has tables), click into one, then open the panel.
     await editor.loadDocxFile('fixtures/demo/demo.docx');
     await editor.focus();
     await editor.clickTableCell(0, 0, 0);
     await page.waitForTimeout(500);
+    section = await editor.openTableFormatPanel();
   });
 
   test('border color picker shows theme matrix in table context', async ({ page }) => {
     // The table-context color pickers render as split-button — an `apply`
     // half (left, applies the current swatch) and an `arrow` half (right,
     // opens the dropdown). The dropdown trigger is the arrow.
-    const borderColorBtn = page.locator(
-      '.docx-color-picker-arrow[title="Border Color"]'
-    );
+    const borderColorBtn = section.locator('.docx-color-picker-arrow[title="Border Color"]');
     await expect(borderColorBtn).toBeVisible({ timeout: 5000 });
     await borderColorBtn.click();
 
@@ -405,9 +406,7 @@ test.describe('Border Color Picker', () => {
 
   test('apply border color from standard colors', async ({ page }) => {
     // Open border color picker (dropdown arrow half of the split button)
-    const borderColorBtn = page.locator(
-      '.docx-color-picker-arrow[title="Border Color"]'
-    );
+    const borderColorBtn = section.locator('.docx-color-picker-arrow[title="Border Color"]');
     await expect(borderColorBtn).toBeVisible({ timeout: 5000 });
     await borderColorBtn.click();
 

--- a/docx-editor/e2e/tests/table-format-panel.spec.ts
+++ b/docx-editor/e2e/tests/table-format-panel.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Table appearance controls (border / border color / width / cell fill) live in
+ * the Format (properties) panel, NOT scattered into the formatting toolbar.
+ * Regression: they used to append to the toolbar when the caret entered a table.
+ */
+import { test, expect } from '@playwright/test';
+import { join } from 'path';
+
+test('table border/color/fill render in the Format panel, not the toolbar', async ({ page }) => {
+  await page.goto('http://localhost:5173/?e2e=1', { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('[data-testid="docx-editor"]', { timeout: 25000 });
+  const input = page.locator('input[type="file"][accept*=".docx"]').first();
+  await input.setInputFiles(join(process.cwd(), 'e2e/fixtures/medical-incident-form.docx'));
+  await page.waitForSelector('.layout-page', { timeout: 30000 });
+  await page.waitForTimeout(1200);
+
+  // Place the caret inside a table cell.
+  await page.getByText('Date and time of the incident', { exact: false }).first().click();
+  await page.waitForTimeout(700);
+
+  // Table group is active (so the toolbar absence below is meaningful)…
+  await expect(page.locator('[data-testid="toolbar-table-more"]')).toHaveCount(1);
+  // …but the border picker is NOT in the toolbar anymore.
+  await expect(page.locator('[data-testid="toolbar-table-borders"]')).toHaveCount(0);
+
+  // Open the table Format chip → the properties panel.
+  await page.locator('[data-testid="table-format-chip"]').click({ timeout: 2500 });
+  await page.waitForTimeout(700);
+
+  const section = page.locator('[data-testid="properties-table-section"]');
+  await expect(section).toHaveCount(1);
+  // The border picker now lives inside the panel.
+  await expect(section.locator('[data-testid="toolbar-table-borders"]')).toHaveCount(1);
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -9339,7 +9339,15 @@ body { background: white; }
                             />
                           )}
                           {propsKind === 'table' && (
-                            <TablePropertiesSection onAction={handleTableAction} />
+                            <TablePropertiesSection
+                              onAction={handleTableAction}
+                              theme={theme}
+                              borderColorHex={resolveColorToHex(
+                                state.pmTableContext?.cellBorderColor,
+                                theme
+                              )}
+                              cellBackgroundColor={state.pmTableContext?.cellBackgroundColor}
+                            />
                           )}
                           {propsKind === 'textbox' && state.pmTextBoxContext && (
                             <TextBoxPropertiesSection

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -9341,10 +9341,10 @@ body { background: white; }
                           {propsKind === 'table' && (
                             <TablePropertiesSection
                               onAction={handleTableAction}
-                              theme={theme}
+                              theme={history.state?.package.theme || theme}
                               borderColorHex={resolveColorToHex(
                                 state.pmTableContext?.cellBorderColor,
-                                theme
+                                history.state?.package.theme || theme
                               )}
                               cellBackgroundColor={state.pmTableContext?.cellBackgroundColor}
                             />

--- a/docx-editor/packages/react/src/components/FormattingBar.tsx
+++ b/docx-editor/packages/react/src/components/FormattingBar.tsx
@@ -9,7 +9,6 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from '../i18n';
 import type { ReactNode } from 'react';
 import type { ColorValue, ParagraphAlignment } from '@eigenpal/docx-core/types/document';
-import { resolveColorToHex } from '@eigenpal/docx-core/utils';
 import { FontPicker } from './ui/FontPicker';
 import { normalizeFontFamilies } from './ui/normalizeFontFamilies';
 import { FontSizePicker, halfPointsToPoints } from './ui/FontSizePicker';
@@ -20,10 +19,6 @@ import { LineSpacingPicker } from './ui/LineSpacingPicker';
 import { StylePicker } from './ui/StylePicker';
 import { MaterialSymbol } from './ui/MaterialSymbol';
 import { ZoomControl } from './ui/ZoomControl';
-import { TableBorderPicker } from './ui/TableBorderPicker';
-import { TableBorderColorPicker } from './ui/TableBorderColorPicker';
-import { TableBorderWidthPicker } from './ui/TableBorderWidthPicker';
-import { TableCellFillPicker } from './ui/TableCellFillPicker';
 import { TableMoreDropdown } from './ui/TableMoreDropdown';
 import { TableStyleGallery } from './ui/TableStyleGallery';
 import { ImageWrapDropdown } from './ui/ImageWrapDropdown';
@@ -702,23 +697,12 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
         </ToolbarGroup>
       )}
 
-      {/* Table Options - shown when cursor is in a table */}
+      {/* Table Options - shown when cursor is in a table. Border / color /
+          width / fill now live in the Format (properties) panel, not here —
+          the panel is the single home for object appearance, so they're no
+          longer scattered across the toolbar. */}
       {tableContext?.isInTable && onTableAction && (
         <ToolbarGroup label={t('formattingBar.groups.table')}>
-          <TableBorderPicker onAction={handleTableAction} disabled={disabled} />
-          <TableBorderColorPicker
-            onAction={handleTableAction}
-            disabled={disabled}
-            theme={theme}
-            value={resolveColorToHex(tableContext?.cellBorderColor, theme)}
-          />
-          <TableBorderWidthPicker onAction={handleTableAction} disabled={disabled} />
-          <TableCellFillPicker
-            onAction={handleTableAction}
-            disabled={disabled}
-            theme={theme}
-            value={tableContext?.cellBackgroundColor}
-          />
           <TableStyleGallery documentStyles={documentStyles} onAction={handleTableAction} />
           <TableMoreDropdown
             onAction={handleTableAction}

--- a/docx-editor/packages/react/src/components/sidebar/TablePropertiesSection.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/TablePropertiesSection.tsx
@@ -10,7 +10,12 @@
  * direction/effect reads at a glance.
  */
 import type { CSSProperties, ReactNode } from 'react';
+import type { Theme } from '@eigenpal/docx-core/types/document';
 import type { TableAction } from '../ui/TableToolbar';
+import { TableBorderPicker } from '../ui/TableBorderPicker';
+import { TableBorderColorPicker } from '../ui/TableBorderColorPicker';
+import { TableBorderWidthPicker } from '../ui/TableBorderWidthPicker';
+import { TableCellFillPicker } from '../ui/TableCellFillPicker';
 
 const ACCENT = 'var(--doc-primary, #1a73e8)';
 const ADD = '#1e8e3e';
@@ -218,11 +223,39 @@ const tile = (danger: boolean): CSSProperties => ({
 export interface TablePropertiesSectionProps {
   /** Dispatch a table action (host wires this to handleTableAction). */
   onAction: (action: TableAction) => void;
+  /** Active theme — used to resolve theme colors in the border/fill pickers. */
+  theme?: Theme | null;
+  /** Resolved hex of the selected cells' border color (for the swatch). */
+  borderColorHex?: string;
+  /** The selected cells' background fill (for the swatch). */
+  cellBackgroundColor?: string;
 }
 
-export function TablePropertiesSection({ onAction }: TablePropertiesSectionProps) {
+const APPEARANCE_ROW: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+  flexWrap: 'wrap',
+  padding: '0 12px 8px',
+};
+
+export function TablePropertiesSection({
+  onAction,
+  theme,
+  borderColorHex,
+  cellBackgroundColor,
+}: TablePropertiesSectionProps) {
   return (
     <div data-testid="properties-table-section">
+      {/* Borders & fill — the appearance controls live here, in the panel,
+          not scattered across the toolbar. */}
+      <div style={GROUP_HEADER}>Borders &amp; fill</div>
+      <div style={APPEARANCE_ROW} role="group" aria-label="Borders and fill">
+        <TableBorderPicker onAction={onAction} />
+        <TableBorderColorPicker onAction={onAction} theme={theme} value={borderColorHex} />
+        <TableBorderWidthPicker onAction={onAction} />
+        <TableCellFillPicker onAction={onAction} theme={theme} value={cellBackgroundColor} />
+      </div>
       {GROUPS.map((group) => (
         <div key={group.header}>
           <div style={GROUP_HEADER}>{group.header}</div>


### PR DESCRIPTION
When the caret entered a table, the border / border-color / border-width / cell-fill pickers appended to the formatting toolbar. The Format (properties) panel is the intended single home for object appearance, so these were scattering into the toolbar instead.

Moves the four appearance pickers into `TablePropertiesSection` (threading cell border color + fill + theme from DocxEditor) and drops them from `FormattingBar`'s table group, which keeps only the style gallery + table-actions menu.

Verified e2e (`table-format-panel.spec.ts`): caret-in-table → border picker absent from toolbar, present inside the Format panel. typecheck + lint clean.