### PR TITLE
fix(clipboard): make ⌘/Ctrl+Shift+V plain paste work in useClipboard

### DIFF
--- a/docx-editor/.changeset/clipboard-plain-paste-keydown.md
+++ b/docx-editor/.changeset/clipboard-plain-paste-keydown.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix `useClipboard` so paste-as-plain-text (⌘/Ctrl+Shift+V) works. The hook read `shiftKey` off the paste `ClipboardEvent`, which carries no keyboard-modifier state, so the flag was always false. The Shift state is now captured on the paste-initiating keydown (via the hook's `handleKeyDown`) and consumed in the paste handler.

--- a/docx-editor/packages/react/src/hooks/useClipboard.ts
+++ b/docx-editor/packages/react/src/hooks/useClipboard.ts
@@ -67,6 +67,12 @@ export function useClipboard(options: UseClipboardOptions = {}): UseClipboardRet
 
   const isProcessingRef = useRef<boolean>(false);
   const lastPastedContentRef = useRef<ParsedClipboardContent | null>(null);
+  // A paste `ClipboardEvent` carries no keyboard-modifier state, so we can't
+  // read shift off it to detect ⌘/Ctrl+Shift+V (paste-as-plain-text). Instead
+  // we remember whether the most recent paste-initiating keydown held Shift,
+  // and consume that in `handlePaste`. `handleKeyDown` must be wired by the
+  // consumer alongside `handlePaste` for the keyboard path to work.
+  const plainPasteArmedRef = useRef<boolean>(false);
 
   const copy = useCallback(
     async (selection: ClipboardSelection): Promise<boolean> => {
@@ -202,15 +208,23 @@ export function useClipboard(options: UseClipboardOptions = {}): UseClipboardRet
       const content = handlePasteEvent(event, { cleanWordFormatting });
       if (content) {
         lastPastedContentRef.current = content;
-        const asPlainText = (event as unknown as KeyboardEvent).shiftKey ?? false;
+        // The paste event has no modifier state; read the flag armed by the
+        // preceding keydown (⌘/Ctrl+Shift+V) and disarm it.
+        const asPlainText = plainPasteArmedRef.current;
+        plainPasteArmedRef.current = false;
         onPaste?.(content, asPlainText);
       }
     },
     [editable, cleanWordFormatting, onPaste]
   );
 
-  const handleKeyDown = useCallback((_event: KeyboardEvent) => {
-    // Let native copy/cut/paste events handle clipboard operations
+  const handleKeyDown = useCallback((event: KeyboardEvent) => {
+    // Native copy/cut/paste events do the actual clipboard work; we only
+    // record whether a paste keystroke (⌘/Ctrl+V) held Shift so the paste
+    // handler can branch to plain-text. Other keys leave the flag untouched.
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'v') {
+      plainPasteArmedRef.current = event.shiftKey;
+    }
   }, []);
 
   return {


### PR DESCRIPTION
`useClipboard` inferred paste-as-plain-text from `event.shiftKey` on the paste `ClipboardEvent`, which has no keyboard-modifier state — so the flag was always false and the keyboard plain-paste path was dead for hook consumers. The Shift state is now captured on the paste-initiating keydown (the hook already exposes `handleKeyDown`) and consumed in `handlePaste`.

The in-app editor already handles ⌘/Ctrl+Shift+V via its own keydown handler; this fixes the public hook for external consumers.