### PR TITLE
feat(vf): bounded vertical registration in scorer (recovered from #148)

### DIFF
--- a/docs/internal/28-visual-fidelity-to-90.md
+++ b/docs/internal/28-visual-fidelity-to-90.md
@@ -126,6 +126,27 @@ The mean is dragged by the **2 table-dense forms** (33.6 / 58.1) and a **prose c
 
 The editor's uniform ~1–2 % tightness is consistent with **Calibri `singleLineRatio` 1.205 < LibreOffice's measured ~1.22** — but 1.205 is the **corpus-validated** value (PR #80: rep VF 82.8→87.2). lo-probe in isolation says ~1.22; the full-corpus tune says 1.205. Per the meta-lesson, trust the corpus tune — **do not touch the Calibri ratio.** On 1-page docs the tightness is a harmless sub-10px offset; on the multi-page forms the same per-block tightness accumulates the _opposite_ direction's spill (see above). The two pull against each other — a global ratio change trades prose score for form score.
 
-**One real, localized, non-ratio bug found (candidate fix):** the editor does **not collapse vertical spacing before a heading that follows a list item.** Block-geometry, weekly-status: an H2 after a `ListBullet` ("Next week") has gap-before **67px** vs reference **34px**, and gap-after **50px** vs reference **66px** — the editor **front-loads** the inter-block space the reference **back-loads**, net ~+17px around each such heading. An H2 after a `Normal` paragraph ("Shipped this week") matches the reference exactly (66/51). So this is specifically a **list-item-after × heading-before spacing-collapse** difference, attributable and _not_ a global metric — the most promising corpus-safe lever for the prose cluster. Needs: confirm LibreOffice/Word's collapse rule for list→heading, implement at the spacing model, gate on the full corpus.
+**A suspected "list→heading spacing" bug was investigated and DISPROVEN** (recorded so no one re-chases it). `band-compare` suggested an H2 after a `ListBullet` had gap-before 67px (editor) vs 34px (reference). But `ListBullet` here inherits docDefault spacing (`after=120`, no `contextualSpacing`) — _identical_ to the `Normal` subtitle — so LibreOffice cannot treat the two differently. A **controlled lo-probe** (`Normal→H2` and `bullet-equiv→H2` in one doc) confirms LibreOffice gives **both the identical 61px gap**. The editor's uniform ~66px gap is **correct**; the 34px was **band-detection noise** on the thin H2 ink stroke. Lesson reinforced: never act on a `band-compare` delta near the ±5px ink-detection noise floor without a controlled-probe confirmation.
 
-**Net strategic read:** prose layout is already faithful (≤7px); the realistic VF wins are (a) the list→heading spacing collapse above, and (b) the multi-page form block-spacing accumulation — both specific spacing-model fixes, not font-ratio tweaks. The score metric itself over-penalizes small uniform offsets, so raw mean understates real visual fidelity.
+## Bounded vertical registration in the scorer (2026-06-27, cont.)
+
+The block-geometry result above (prose faithful to ≤7px yet scored 75–85) showed the **scorer**, not the renderer, was the prose bottleneck: `diff.py` gridded each page to a 64×48 ink-fraction grid and compared cell-by-cell with **no alignment**, so an imperceptible constant vertical offset pushed ink across grid-row boundaries and tanked L1/correlation.
+
+Added a **bounded global vertical registration** to `page_score`: search a small vertical shift (`VREG_MAX = 6` NORM px ≈ 11px@150dpi ≈ ½ a text line) that maximizes editor↔reference ink overlap, then grid + score from there. The bound is deliberately tight — it absorbs a constant offset no human notices but **cannot** rescue cumulative drift or a page-break spill (those exceed the bound and stay penalized), so the number still gates real regressions.
+
+**Validated the registration is honest, not goal-moving** (re-score only, same PNGs):
+
+| Fixture | before | after | reading |
+| --- | ---: | ---: | --- |
+| medical-incident-form | 33.6 | 39.2 | structural drift / spill — barely moves (correct) |
+| Form025U | 58.1 | 59.8 | structural — barely moves (correct) |
+| repr-resume | 75.5 | 75.5 | cumulative tightness (not a constant offset) — not rescued (correct) |
+| repr-project-proposal | 76.0 | 76.8 | cumulative — barely moves |
+| repr-essay | 83.6 | 90.8 | constant offset removed — true fidelity revealed |
+| repr-travel-itinerary | 82.7 | 90.1 | constant offset removed |
+| repr-lab-report | 85.1 | 93.0 | constant offset removed |
+| **corpus mean** | **81.7** | **84.1** | no good fixture regressed (meeting-notes −0.6 = gridding noise) |
+
+The signature is exactly right: docs with a pure constant offset rise to their true (high) fidelity; docs with **structural** problems (the forms) or **cumulative** drift (resume) stay flagged. This isolates real drift from imperceptible offset.
+
+**Net strategic read.** Prose layout is genuinely faithful — the prior 75–85 scores were mostly scorer artifact, now corrected. The remaining _real_ VF deficits are: (a) the **multi-page form block-spacing accumulation** (medical/Form025U — a true one-row-per-page spill, the only "broken" tier left), and (b) **resume/project-proposal cumulative tightness**, which is tied to the corpus-validated Calibri `1.205` and therefore can't be chased via the font ratio without trading the rest of the corpus. CJK stays font-environment-blocked. No font-ratio tweaks; the only safe engine lever left is the form block-spacing, and it needs the form's specific too-tall block source isolated (not a global change) before any edit.

--- a/docx-editor/scripts/visual-fidelity/diff.py
+++ b/docx-editor/scripts/visual-fidelity/diff.py
@@ -25,8 +25,6 @@ from collections import defaultdict
 import numpy as np
 from PIL import Image
 
-NORM_W = 680          # common width after registration
-NORM_H = 880          # common height after registration (≈ page aspect)
 INK_THRESH = 185      # grayscale < this = ink
 TOL = 3               # dilation tolerance (px) to absorb AA / sub-px offset
 out = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "visual-fidelity-out")
@@ -46,8 +44,44 @@ def pages_in(d):
 
 GX, GY = 48, 64       # density-grid resolution (cols, rows)
 
-def density_grid(path):
-    """Downsample a full page to a GY×GX grid of ink-fraction (0..1) per cell.
+# Bounded global vertical registration. Two correct renderers can sit a few
+# px apart vertically — a constant offset no human would notice (a paragraph
+# 4px lower down the whole page). Without alignment the cell-grid penalizes
+# that as if the layout were wrong, because ink crosses grid-row boundaries.
+# We search a SMALL vertical shift that best aligns the editor onto the
+# reference and score from there. The bound is deliberately tight (≈ half a
+# text line): it absorbs an imperceptible constant offset but CANNOT rescue
+# cumulative drift or a page-break spill (those exceed the bound and stay
+# penalized), so the metric still gates real fidelity regressions.
+NORM_W, NORM_H = 680, 880   # registration working resolution (page aspect)
+VREG_MAX = 6                # max vertical shift in NORM px (~11px@150dpi ≈ ½ line)
+
+
+def norm_mask(path):
+    """Full-page ink mask (0..1) at the common registration resolution."""
+    a = (np.asarray(Image.open(path).convert("L")) < INK_THRESH).astype("uint8") * 255
+    img = Image.fromarray(a).resize((NORM_W, NORM_H), Image.BILINEAR)
+    return np.asarray(img, dtype="float32") / 255.0
+
+
+def best_vshift(am, bm, max_shift=VREG_MAX):
+    """Vertical shift (NORM px) of editor mask `am` that maximizes ink overlap
+    with reference `bm`, searched within ±max_shift. Returns the best shift."""
+    best_s, best_o = 0, -1.0
+    for s in range(-max_shift, max_shift + 1):
+        sh = np.roll(am, s, axis=0)
+        if s > 0:
+            sh[:s] = 0
+        elif s < 0:
+            sh[s:] = 0
+        o = float(np.minimum(sh, bm).sum())  # overlapping ink mass
+        if o > best_o:
+            best_o, best_s = o, s
+    return best_s
+
+
+def grid(mask):
+    """Downsample a NORM-resolution ink mask to a GY×GX ink-fraction grid.
 
     We compare in the PAGE coordinate frame (no bbox trim): both the editor
     and the reference render one full page of the SAME aspect, so a paragraph
@@ -55,9 +89,7 @@ def density_grid(path):
     graining is what makes this robust across renderers — it captures 'a text
     block here, a blank line there, a table down there' without demanding
     glyph-level pixel overlap, which two different font engines never have."""
-    a = (np.asarray(Image.open(path).convert("L")) < INK_THRESH).astype("uint8") * 255
-    # PIL bilinear downsample of the 0/255 mask == per-cell mean ink fraction.
-    img = Image.fromarray(a).resize((GX, GY), Image.BILINEAR)
+    img = Image.fromarray((mask * 255).astype("uint8")).resize((GX, GY), Image.BILINEAR)
     return np.asarray(img, dtype="float32") / 255.0
 
 def corr(pa, pb):
@@ -67,8 +99,17 @@ def corr(pa, pb):
     return 1.0 if pa.sum() == 0 and pb.sum() == 0 else 0.0
 
 def page_score(ed_png, ref_png):
-    a = density_grid(ed_png)
-    b = density_grid(ref_png)
+    am = norm_mask(ed_png)
+    bm = norm_mask(ref_png)
+    # Bounded vertical registration before gridding (see VREG_MAX). Aligns out
+    # an imperceptible constant offset; too small to mask structural drift.
+    s = best_vshift(am, bm)
+    if s > 0:
+        am = np.roll(am, s, axis=0); am[:s] = 0
+    elif s < 0:
+        am = np.roll(am, s, axis=0); am[s:] = 0
+    a = grid(am)
+    b = grid(bm)
     # Both pages effectively blank → a match (avoid divide-by-near-zero noise).
     if a.sum() < 1.0 and b.sum() < 1.0:
         return 1.0, 100.0, 1.0, 1.0


### PR DESCRIPTION
Recovers a commit orphaned when #148 was squash-merged before this change landed on the branch.

**Bounded vertical registration in `diff.py`.** Block-geometry attribution (merged in #148) showed prose layout is faithful to ≤7px yet scored 75–85, because the scorer gridded pages with **no alignment** — an imperceptible constant vertical offset crossed grid-row boundaries and tanked the score. Adds a bounded global vertical registration (`VREG_MAX=6` NORM px ≈ ½ a text line) before gridding.

Validated honest, not goal-moving (re-score only, same PNGs):

| | before | after |
|---|---:|---:|
| medical-incident-form (structural) | 33.6 | 39.2 |
| Form025U (structural) | 58.1 | 59.8 |
| repr-resume (cumulative drift) | 75.5 | 75.5 |
| repr-essay (constant offset) | 83.6 | 90.8 |
| repr-lab-report (constant offset) | 85.1 | 93.0 |
| **mean** | **81.7** | **84.1** |

The bound is too tight to rescue the forms' structural drift/page-spill or resume's cumulative tightness — so the metric still gates real fidelity regressions; it only stops penalizing imperceptible constant offsets.

Also documents that a suspected list→heading spacing bug was **investigated and disproven** (controlled lo-probe: LibreOffice gives Normal→H2 and bullet→H2 the identical 61px gap; the band-compare delta was ink-detection noise).

Harness + docs only; no editor-engine change.