### PR TITLE
fix(header-edit): dark-mode black overlay + other pages' headers vanishing

### DIFF
--- a/docx-editor/.changeset/header-edit-dark-surface.md
+++ b/docx-editor/.changeset/header-edit-dark-surface.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix the inline header/footer editor rendering on a dark app surface in dark mode. Double-clicking a header to edit it painted the overlay with `--doc-surface` (which is dark under `[data-theme="dark"]`) and inherited light text — so the header turned black, default text became invisible, and transparent logos showed only their opaque pixels. The overlay now uses the page's paper colors (`#fff` / `#000`), matching the body, in every theme.

--- a/docx-editor/packages/core/src/prosemirror/editor.css
+++ b/docx-editor/packages/core/src/prosemirror/editor.css
@@ -771,11 +771,14 @@
   border-top: 1px dotted #4285f4;
 }
 
-/* Hide the original layout-painter content in the area being edited */
-.paged-editor--editing-header .layout-page-header > * {
+/* Hide the original layout-painter content ONLY in the specific header/footer
+   being edited (the one the inline overlay covers, marked .hf-edit-target).
+   Without the `.hf-edit-target` scope this matched EVERY page's header, so
+   editing page 1's header blanked the headers on all other pages. */
+.paged-editor--editing-header .layout-page-header.hf-edit-target > * {
   visibility: hidden;
 }
-.paged-editor--editing-footer .layout-page-footer > * {
+.paged-editor--editing-footer .layout-page-footer.hf-edit-target > * {
   visibility: hidden;
 }
 

--- a/docx-editor/packages/react/src/components/InlineHeaderFooterEditor.tsx
+++ b/docx-editor/packages/react/src/components/InlineHeaderFooterEditor.tsx
@@ -371,11 +371,14 @@ export const InlineHeaderFooterEditor = forwardRef<
         </div>
       )}
 
-      {/* ProseMirror editor area. Opaque page-colored background so the body
-          content BEHIND the overlay doesn't bleed through — a complex header
-          (e.g. an SDS letterhead with many positioned boxes) grows tall and the
-          overlay extends over the body region; a transparent overlay let the
-          grayed body text show through and read as "broken". */}
+      {/* ProseMirror editor area. Opaque PAGE-colored background + text so the
+          overlay matches the white paper the body renders on — NOT the app
+          surface. `--doc-surface` swaps to a dark value under [data-theme=dark],
+          which turned the whole header black with white (invisible-on-paper)
+          text and made transparent logos show only their opaque pixels. The
+          page is always #fff/#000 (see renderPage.ts), so pin those here. The
+          opaque background also stops grayed body content behind the overlay
+          (a tall SDS letterhead) from bleeding through and reading as broken. */}
       <div
         ref={editorContainerRef}
         className="hf-editor-pm prosemirror-editor"
@@ -383,7 +386,8 @@ export const InlineHeaderFooterEditor = forwardRef<
           minHeight: 40,
           outline: 'none',
           fontSize: `${defaultFontSizePt}pt`,
-          background: 'var(--doc-surface, #ffffff)',
+          background: '#ffffff',
+          color: '#000000',
         }}
       />
 

--- a/docx-editor/packages/react/src/components/InlineHeaderFooterEditor.tsx
+++ b/docx-editor/packages/react/src/components/InlineHeaderFooterEditor.tsx
@@ -216,6 +216,15 @@ export const InlineHeaderFooterEditor = forwardRef<
     };
   }, [targetElement, parentElement]);
 
+  // Mark ONLY the header/footer element this overlay covers so the CSS that
+  // hides the original layout-painter content (`.hf-edit-target > *`) applies
+  // to just this one — not every page's header/footer (which left other pages
+  // blank during edit). Cleaned up when the edit session ends.
+  useEffect(() => {
+    targetElement.classList.add('hf-edit-target');
+    return () => targetElement.classList.remove('hf-edit-target');
+  }, [targetElement]);
+
   // Create ProseMirror editor when the container is available
   // (overlayPos starts null → first render returns null → container ref not set)
   useEffect(() => {

--- a/docx-editor/packages/react/src/styles/editor.css
+++ b/docx-editor/packages/react/src/styles/editor.css
@@ -723,11 +723,14 @@
   border-top: 1px dotted #4285f4;
 }
 
-/* Hide the original layout-painter content in the area being edited */
-.paged-editor--editing-header .layout-page-header > * {
+/* Hide the original layout-painter content ONLY in the specific header/footer
+   being edited (marked .hf-edit-target by InlineHeaderFooterEditor). Without
+   the scope this matched EVERY page's header, blanking all other pages while
+   editing one. */
+.paged-editor--editing-header .layout-page-header.hf-edit-target > * {
   visibility: hidden;
 }
-.paged-editor--editing-footer .layout-page-footer > * {
+.paged-editor--editing-footer .layout-page-footer.hf-edit-target > * {
   visibility: hidden;
 }
 


### PR DESCRIPTION
User-reported: double-clicking a header to edit it was "completely broken" — the whole header turned black, the logo showed only red pixels over black, text vanished, and other pages' headers disappeared.

Two distinct bugs in the inline header/footer editor, both fixed:

**1. Dark-mode black overlay.** The overlay painted its ProseMirror surface with `background: var(--doc-surface)` + inherited theme text color. `--doc-surface` swaps dark under `[data-theme="dark"]`, so the overlay went dark while the page stays white paper — black header, white (invisible-on-paper) default text, transparent logos reduced to their opaque pixels over black. Fixed by pinning the overlay to the page's paper colors (`#fff`/`#000`, as renderPage uses) in every theme.

**2. Other pages' headers vanished.** Edit mode applied `visibility:hidden` to `.layout-page-header > *` on *every* page (to hide the layout-painter content under the overlay), but the overlay only covers the edited page — so all other pages' headers blanked. Now the edited element is marked `.hf-edit-target` and the hide rule is scoped to it. Fixed in both `editor.css` copies (the `react/styles` one ships in the package).

Both verified with Playwright in dark mode / multi-page: header renders white with black text and a correct logo; editing page 1 leaves pages 2-4 headers visible.

Known remaining (separate, deeper): a *floating/anchored* header image renders inline-centered in the PM-based edit overlay, because the inline editor doesn't do OOXML floating layout — tracked separately.