### PR TITLE
fix(darkmode): render endnotes + note tooltips on page paper, not app surface

### DIFF
--- a/docx-editor/.changeset/darkmode-content-surfaces.md
+++ b/docx-editor/.changeset/darkmode-content-surfaces.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix endnotes and footnote/endnote tooltips becoming unreadable in dark mode. Both rendered document text with a hardcoded dark color on a `--doc-surface` background, which swaps to a dark value under `[data-theme="dark"]` — black-on-dark, invisible. They now use the page's paper background, matching the document content they belong to.

--- a/docx-editor/packages/react/src/components/render/FootnoteRef.tsx
+++ b/docx-editor/packages/react/src/components/render/FootnoteRef.tsx
@@ -105,7 +105,10 @@ function FootnoteTooltip({
         zIndex: 1000,
         maxWidth: '300px',
         padding: '8px 12px',
-        backgroundColor: 'var(--doc-surface, white)',
+        // Paper colors: the tooltip shows footnote/endnote document text with a
+        // hardcoded dark color below, so a theme-swapping --doc-surface made it
+        // dark-on-dark (unreadable) in dark mode.
+        backgroundColor: '#fff',
         border: '1px solid #ccc',
         borderRadius: '4px',
         boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',

--- a/docx-editor/packages/react/src/paged-editor/EndnoteSection.tsx
+++ b/docx-editor/packages/react/src/paged-editor/EndnoteSection.tsx
@@ -23,7 +23,10 @@ const WRAP: CSSProperties = {
 };
 
 const CARD: CSSProperties = {
-  background: 'var(--doc-surface, #fff)',
+  // Paper colors, not app-surface tokens: this card is document content on
+  // the page. `--doc-surface` swaps dark under [data-theme="dark"], which put
+  // black endnote text (color below) on a dark card — invisible.
+  background: '#fff',
   boxShadow: '0 1px 3px rgba(60,64,67,0.15)',
   padding: '24px 48px',
   fontSize: '10px',


### PR DESCRIPTION
From a scan for siblings of the header-edit dark-mode bug (#151).

Two on-page document surfaces painted document text with **hardcoded dark colors** on a `var(--doc-surface)` background. `--doc-surface` swaps to a dark value under `[data-theme="dark"]`, so:
- **Endnotes** (`EndnoteSection`): `#000` text on a dark card → invisible endnotes.
- **Footnote/endnote tooltip** (`FootnoteRef`): `#333` text on a dark popover → unreadable.

Both now use the page paper background (`#fff`), matching the body content they belong to. (The table-insert "+" button also uses `--doc-surface`, but that's genuine chrome — correctly themed, left as-is.)

Same root cause and fix as #151; no fixture has endnotes so verified by code inspection against the already-confirmed header repro.