### PR TITLE
fix(paged-editor): skip re-render on pure selection changes

### DIFF
--- a/docx-editor/.changeset/skip-pure-selection-rerender.md
+++ b/docx-editor/.changeset/skip-pure-selection-rerender.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Skip the DecorationLayer re-sync bump on pure local selection changes (clicks / arrow keys). Only doc edits and meta-only transactions (e.g. collaboration cursor awareness) can change decorations, so bumping on every selection forced a needless PagedEditor + DecorationLayer re-render on every cursor placement — visible as flicker, especially without collaboration. The selection overlay still updates on every selection change.

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -2695,10 +2695,22 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
      */
     const handleTransaction = useCallback(
       (transaction: Transaction, newState: EditorState) => {
-        // Bump on every transaction (including selection-only and meta-only
-        // ones) so DecorationLayer re-syncs — yCursorPlugin awareness updates
-        // arrive as meta transactions with no doc change.
-        setTransactionVersion((v) => v + 1);
+        // Re-sync DecorationLayer when decorations may actually have changed:
+        // doc edits (positions shift) and meta-only transactions (yCursorPlugin
+        // awareness pings carry remote-cursor decoration changes as meta, no doc
+        // change). A PURE local selection change — a click or arrow key, where
+        // the selection is set with no steps and no doc change — never alters
+        // decorations, so skip the bump there. Otherwise every cursor placement
+        // forces a full PagedEditor + DecorationLayer re-render; with no collab
+        // (e.g. the desktop build) that bump is pure overhead and shows up as
+        // flicker on every click. The selection overlay is still updated below.
+        const isPureSelectionChange =
+          !transaction.docChanged &&
+          transaction.selectionSet &&
+          transaction.steps.length === 0;
+        if (!isPureSelectionChange) {
+          setTransactionVersion((v) => v + 1);
+        }
 
         if (transaction.docChanged) {
           // Increment state sequence to signal document changed

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -2705,9 +2705,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         // (e.g. the desktop build) that bump is pure overhead and shows up as
         // flicker on every click. The selection overlay is still updated below.
         const isPureSelectionChange =
-          !transaction.docChanged &&
-          transaction.selectionSet &&
-          transaction.steps.length === 0;
+          !transaction.docChanged && transaction.selectionSet && transaction.steps.length === 0;
         if (!isPureSelectionChange) {
           setTransactionVersion((v) => v + 1);
         }


### PR DESCRIPTION
handleTransaction bumped `transactionVersion` on every transaction so DecorationLayer re-syncs. That's only needed for doc edits and meta-only transactions (yCursorPlugin awareness), but it also fired on plain selection-only transactions (clicks/arrow keys), forcing a full PagedEditor + DecorationLayer re-render on every cursor placement — visible as flicker, especially without collaboration. Skip the bump for pure selection changes (selection set, no steps, no doc change); still bump on doc edits and meta transactions. Selection overlay unaffected.

typecheck + cursor-paragraph-ops + comments-sidebar pass.