### PR TITLE
fix(header-edit): render filled no-text boxes as thin rules, not black bars

### DIFF
--- a/docx-editor/.changeset/header-edit-divider-rule.md
+++ b/docx-editor/.changeset/header-edit-divider-rule.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix decorative divider rules rendering as thick black bars when editing a header/footer. In the inline header editor, a filled text box with no text (a hairline rule, common in letterheads) got the default text-box chrome — a content-growing min-height, 8px padding, and a 1px border — ballooning a thin rule into a black bar. Such rules now render at their declared thin height with no padding or border. (Phase 2 of the header-edit positioned-layout work.)

--- a/docx-editor/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -186,11 +186,26 @@ export const TextBoxExtension = createNodeExtension({
       if (attrs.posAlignH) domAttrs['data-pos-align-h'] = attrs.posAlignH;
       if (attrs.posAlignV) domAttrs['data-pos-align-v'] = attrs.posAlignV;
 
+      // A filled box with no real text is a decorative divider / rule (e.g. the
+      // hairline bars in an SDS letterhead), NOT an editable text box. The
+      // default text-box chrome (min-height that grows to a line, 8px padding,
+      // a 1px border) turned these into thick black bars in the edit overlay.
+      // Render them as their declared thin rule: fixed height, no padding, no
+      // border. (Phase 2 of docs/internal/30.)
+      const isFilledRule = !!attrs.fillColor && node.textContent.trim() === '';
+
       // Build inline styles
       const styles: string[] = [];
 
       if (attrs.width) styles.push(`width: ${attrs.width}px`);
-      if (attrs.height) styles.push(`min-height: ${attrs.height}px`);
+      if (attrs.height) {
+        // Rule: fixed thin height (clamped ≥1px so a sub-px rule still paints),
+        // clipping the empty paragraph. Text box: height is a minimum that
+        // grows to fit content.
+        styles.push(
+          isFilledRule ? `height: ${Math.max(attrs.height, 1)}px` : `min-height: ${attrs.height}px`
+        );
+      }
 
       // Background
       if (attrs.fillColor) {
@@ -202,17 +217,19 @@ export const TextBoxExtension = createNodeExtension({
         const style = attrs.outlineStyle || 'solid';
         const color = attrs.outlineColor || '#000000';
         styles.push(`border: ${attrs.outlineWidth}px ${style} ${color}`);
-      } else {
-        // Default thin border for text boxes
+      } else if (!isFilledRule) {
+        // Default thin border for text boxes (not for decorative rules).
         styles.push('border: 1px solid var(--doc-border, #d1d5db)');
       }
 
-      // Internal margins/padding
-      const mt = attrs.marginTop ?? 4;
-      const mb = attrs.marginBottom ?? 4;
-      const ml = attrs.marginLeft ?? 7;
-      const mr = attrs.marginRight ?? 7;
-      styles.push(`padding: ${mt}px ${mr}px ${mb}px ${ml}px`);
+      // Internal margins/padding (rules carry no text, so no padding).
+      if (!isFilledRule) {
+        const mt = attrs.marginTop ?? 4;
+        const mb = attrs.marginBottom ?? 4;
+        const ml = attrs.marginLeft ?? 7;
+        const mr = attrs.marginRight ?? 7;
+        styles.push(`padding: ${mt}px ${mr}px ${mb}px ${ml}px`);
+      }
 
       // Vertical alignment
       if (attrs.verticalAlign === 'middle' || attrs.verticalAlign === 'center') {


### PR DESCRIPTION
Phase 2a of the header-edit positioned-layout project (design: #155).

In the PM-based inline header editor, a **filled text box with no text** — a decorative hairline rule, common in letterheads (e.g. the SDS divider under a logo) — got the default text-box chrome: a content-growing `min-height`, 8px padding, and a 1px border. That ballooned a thin rule into a thick **black bar**.

Now filled+no-text boxes render at their declared thin height (clamped ≥1px), with no padding or border. The guard requires `fillColor` AND empty text, so real text boxes and round-trip are unaffected.

Verified on `sds-anti-t-zh` header edit: the black bar is now a thin rule matching view mode. 959 core tests pass.

(Positioned text boxes still stack rather than sit at their authored offsets — that's the next Phase 2 increment.)