### PR TITLE
feat(desktop): open-where prompt for File → Open

### DIFF
--- a/docx-editor/.changeset/editor-on-request-open.md
+++ b/docx-editor/.changeset/editor-on-request-open.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': minor
+---
+
+Add an `onRequestOpen` prop to `DocxEditor`. When provided, File → Open (and Ctrl/Cmd-O) calls it instead of opening the browser file picker, letting a host run its own open flow (e.g. a native dialog + "this window or a new window?" prompt). Falls back to the in-window browser picker when absent.

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -991,27 +991,30 @@ export function App() {
   // DocxEditor's handleSave useCallback (which lists onSave in its deps) does
   // NOT get a new reference every time status changes (Saving → Saved → '').
   // Accessing bridge via window avoids closing over a stale reference.
-  const onSaveDesktop = useCallback(async (buffer: ArrayBuffer) => {
-    const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
-    if (!bridge?.isDesktop) return;
-    setStatus('Saving…');
-    try {
-      const written = await bridge.save(buffer);
-      if (typeof written === 'string') {
-        const name = written.split(/[\\/]/).pop();
-        if (name) setFileName(name);
+  const onSaveDesktop = useCallback(
+    async (buffer: ArrayBuffer) => {
+      const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
+      if (!bridge?.isDesktop) return;
+      setStatus('Saving…');
+      try {
+        const written = await bridge.save(buffer);
+        if (typeof written === 'string') {
+          const name = written.split(/[\\/]/).pop();
+          if (name) setFileName(name);
+        }
+        // Clean save: the file on disk now IS the latest state, so drop the
+        // crash-recovery sidecar (and any pending snapshot timer).
+        clearRecovery();
+        setStatus('Saved');
+        setTimeout(() => setStatus(''), 1500);
+      } catch (err) {
+        console.error('desktop save failed', err);
+        setStatus('Save failed');
+        setTimeout(() => setStatus(''), 2500);
       }
-      // Clean save: the file on disk now IS the latest state, so drop the
-      // crash-recovery sidecar (and any pending snapshot timer).
-      clearRecovery();
-      setStatus('Saved');
-      setTimeout(() => setStatus(''), 1500);
-    } catch (err) {
-      console.error('desktop save failed', err);
-      setStatus('Save failed');
-      setTimeout(() => setStatus(''), 2500);
-    }
-  }, [clearRecovery]); // bridge.save, setStatus, setFileName are stable across renders
+    },
+    [clearRecovery]
+  ); // bridge.save, setStatus, setFileName are stable across renders
 
   const onExportDesktop = useCallback(async (blob: Blob, suggestedName: string) => {
     const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
@@ -1080,6 +1083,15 @@ export function App() {
     if (typeof window !== 'undefined' && window.__deskApp__) {
       window.__deskApp__.filePath = null;
     }
+  }, []);
+
+  // Desktop only: File → Open routes through the shell's native dialog +
+  // "this window or a new window?" prompt instead of the browser file picker,
+  // so a menu-opened file can be opened in its own window. The bridge handles
+  // the actual open (new window, or navigating this one), so the in-window
+  // onFileOpened path doesn't fire for it.
+  const onRequestOpenDesktop = useCallback(() => {
+    void window.__deskApp__?.openViaMenu?.();
   }, []);
 
   // Dismiss the boot overlay once DocxEditor's PM view is live and the
@@ -1466,6 +1478,7 @@ export function App() {
           // Desktop only: unbind the old file path when a file is opened
           // in-window, so a later Save can't overwrite the previous file.
           onFileOpened={isDesktop ? onFileOpenedDesktop : undefined}
+          onRequestOpen={isDesktop ? onRequestOpenDesktop : undefined}
           // Dismiss the boot splash after DocxEditor has parsed the DOCX and
           // created its PM view, avoiding the blank-editor flash that occurred
           // when dismissBoot fired immediately after setDocumentBuffer.

--- a/docx-editor/examples/vite/src/desk-bridge-bootstrap.ts
+++ b/docx-editor/examples/vite/src/desk-bridge-bootstrap.ts
@@ -72,10 +72,7 @@ function setupDeskTheme(getBridge: () => Record<string, unknown> | undefined) {
       try {
         document.documentElement.dataset.theme = resolved;
         document.documentElement.style.colorScheme = resolved;
-        window.localStorage.setItem(
-          'casual-editor:color-theme',
-          mode === 'system' ? 'auto' : mode,
-        );
+        window.localStorage.setItem('casual-editor:color-theme', mode === 'system' ? 'auto' : mode);
       } catch {
         /* dataset / localStorage may be unavailable; hint is best-effort */
       }
@@ -92,9 +89,7 @@ function setupDeskTheme(getBridge: () => Record<string, unknown> | undefined) {
       lastMode = mode;
       lastResolved = resolved;
       try {
-        window.dispatchEvent(
-          new CustomEvent('deskapp:theme', { detail: { mode, resolved } }),
-        );
+        window.dispatchEvent(new CustomEvent('deskapp:theme', { detail: { mode, resolved } }));
       } catch {
         /* CustomEvent unsupported — nothing more we can do */
       }
@@ -108,16 +103,13 @@ function setupDeskTheme(getBridge: () => Record<string, unknown> | undefined) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const tauriEvent = (window as any).__TAURI__?.event;
       if (tauriEvent?.listen) {
-        void tauriEvent.listen(
-          'deskapp://theme',
-          (e: { payload?: { theme?: string } }) => {
-            const next = e?.payload?.theme;
-            if (next && VALID.has(next)) {
-              mode = next as 'system' | 'light' | 'dark';
-              apply();
-            }
-          },
-        );
+        void tauriEvent.listen('deskapp://theme', (e: { payload?: { theme?: string } }) => {
+          const next = e?.payload?.theme;
+          if (next && VALID.has(next)) {
+            mode = next as 'system' | 'light' | 'dark';
+            apply();
+          }
+        });
       }
     } catch {
       /* no Tauri event bus (web/iframe) — launcher live-sync just won't run */
@@ -142,11 +134,7 @@ function setupDeskTheme(getBridge: () => Record<string, unknown> | undefined) {
 // desktop shell at `./fonts/` (relative to the editor's `--base` mount under
 // /docx/), NOT shipped in the web bundle. Body text already uses system fonts,
 // so only the icon font needs bundling. Mirrors the sheets bootstrap.
-if (
-  typeof window !== 'undefined' &&
-  isDesktop &&
-  !document.getElementById('__deskapp_fonts__')
-) {
+if (typeof window !== 'undefined' && isDesktop && !document.getElementById('__deskapp_fonts__')) {
   const css = `
 @font-face{font-family:'Material Symbols Outlined';font-style:normal;font-weight:100 700;font-display:block;src:local('Material Symbols Outlined'),url('./fonts/material-symbols-outlined.woff2') format('woff2');}`;
   const style = document.createElement('style');
@@ -204,8 +192,7 @@ let dismissBoot: () => void = () => undefined;
     // editor's own styles.
     const style = document.createElement('style');
     style.id = '__deskapp_boot_style__';
-    style.textContent =
-      '@keyframes __deskapp_boot_spin__{to{transform:rotate(360deg)}}';
+    style.textContent = '@keyframes __deskapp_boot_spin__{to{transform:rotate(360deg)}}';
     (document.head || document.documentElement).appendChild(style);
 
     const overlay = document.createElement('div');
@@ -294,6 +281,57 @@ let dismissBoot: () => void = () => undefined;
   }
 })();
 
+/** Bridge-rendered "open where?" prompt. The editor's React modals aren't
+ *  reachable from this bootstrap, so render a self-contained one. Resolves the
+ *  chosen target + whether to remember it as the default, or null if dismissed. */
+function askOpenWhere(path: string): Promise<{ where: 'same' | 'new'; remember: boolean } | null> {
+  return new Promise((resolve) => {
+    const name = path.split(/[\\/]/).pop() ?? path;
+    const esc = (s: string) =>
+      s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c]!);
+    const backdrop = document.createElement('div');
+    backdrop.setAttribute(
+      'style',
+      'position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.45);font:14px system-ui,-apple-system,sans-serif;'
+    );
+    backdrop.innerHTML = `
+      <div role="dialog" aria-modal="true" style="background:#fff;color:#111;max-width:380px;width:90%;border-radius:12px;padding:22px 22px 16px;box-shadow:0 12px 40px rgba(0,0,0,.3);">
+        <h2 style="margin:0 0 6px;font-size:17px;">Open &ldquo;${esc(name)}&rdquo;</h2>
+        <p style="margin:0 0 4px;color:#666;">Open it in this window or a new window?</p>
+        <label style="display:flex;align-items:center;gap:8px;margin:16px 0;color:#666;cursor:pointer;">
+          <input type="checkbox" data-act="remember" /> Remember my choice
+        </label>
+        <div style="display:flex;gap:8px;">
+          <button data-act="same" style="flex:1;padding:9px;border-radius:8px;border:1px solid #ccc;background:#f5f5f5;cursor:pointer;">This window</button>
+          <button data-act="new" style="flex:1;padding:9px;border-radius:8px;border:0;background:#2563eb;color:#fff;font-weight:600;cursor:pointer;">New window</button>
+        </div>
+        <button data-act="cancel" style="margin-top:10px;width:100%;background:none;border:0;color:#888;cursor:pointer;padding:6px;">Cancel</button>
+      </div>`;
+    document.body.appendChild(backdrop);
+    const remember = () =>
+      (backdrop.querySelector('[data-act=remember]') as HTMLInputElement | null)?.checked ?? false;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') finish(null);
+    };
+    const finish = (result: { where: 'same' | 'new'; remember: boolean } | null) => {
+      window.removeEventListener('keydown', onKey);
+      backdrop.remove();
+      resolve(result);
+    };
+    window.addEventListener('keydown', onKey);
+    backdrop.addEventListener('mousedown', (e) => {
+      if (e.target === backdrop) finish(null);
+    });
+    backdrop
+      .querySelector('[data-act=same]')!
+      .addEventListener('click', () => finish({ where: 'same', remember: remember() }));
+    backdrop
+      .querySelector('[data-act=new]')!
+      .addEventListener('click', () => finish({ where: 'new', remember: remember() }));
+    backdrop.querySelector('[data-act=cancel]')!.addEventListener('click', () => finish(null));
+  });
+}
+
 if (isDesktop) {
   const isTopLevel = window.parent === window;
   let filePath = url.searchParams.get('file');
@@ -326,6 +364,7 @@ if (isDesktop) {
         saveAs(name: string, bytes: ArrayBuffer): Promise<string | null>;
         setDirty?(dirty: boolean): void;
         exportPdf?(suggestedName: string): Promise<string | null>;
+        openViaMenu?(): Promise<void>;
       }
     | undefined;
 
@@ -433,9 +472,7 @@ if (isDesktop) {
       let offset = 0;
       while (offset < total) {
         const length = Math.min(CHUNK, total - offset);
-        const chunk = asArrayBuffer(
-          await inv('read_document_chunk', { path, offset, length }),
-        );
+        const chunk = asArrayBuffer(await inv('read_document_chunk', { path, offset, length }));
         out.set(new Uint8Array(chunk), offset);
         offset += chunk.byteLength;
         if (chunk.byteLength === 0) break;
@@ -445,10 +482,16 @@ if (isDesktop) {
 
     bridge = {
       isDesktop: true,
-      get filePath() { return filePath; },
+      get filePath() {
+        return filePath;
+      },
       // @ts-expect-error setter on getter via Object.defineProperty pattern
-      set filePath(v: string | null) { filePath = v; },
-      get fileKind() { return fileKindFor(filePath); },
+      set filePath(v: string | null) {
+        filePath = v;
+      },
+      get fileKind() {
+        return fileKindFor(filePath);
+      },
       // Editor → bridge dirty signal. App.tsx forwards DocxEditor's `onChange`
       // here, so every real document change (mouse/toolbar/menu edits included)
       // marks the window dirty for the Rust close-guard. save()/saveAs() clear it.
@@ -457,6 +500,52 @@ if (isDesktop) {
         // in-flight save can detect a change that landed during the write.
         if (dirty) editSeq++;
         setWindowDirty(dirty);
+      },
+      // File → Open from the editor menu (desktop). Uses the NATIVE dialog so
+      // the picked file has a real path (the browser picker doesn't), then
+      // honours the open-where preference: 'same' navigates this window, 'new'
+      // spawns another, 'ask' prompts (with a remember checkbox that updates
+      // the setting). A spreadsheet picked here always opens in a new window —
+      // this window hosts the doc editor.
+      async openViaMenu(): Promise<void> {
+        const path = (await inv('pick_open_document').catch(() => null)) as string | null;
+        if (!path) return; // user cancelled the dialog
+        const ext = path.split('.').pop()?.toLowerCase() ?? '';
+        const kind = ['xlsx', 'xlsm', 'ods', 'csv', 'tsv', 'tab'].includes(ext) ? 'sheets' : 'docx';
+        let settings: { open_window_preference?: 'ask' | 'same' | 'new' } = {};
+        try {
+          settings = (await inv('get_settings')) as typeof settings;
+        } catch {
+          /* fall through to 'ask' */
+        }
+        const pref = settings.open_window_preference ?? 'ask';
+        let where: 'same' | 'new';
+        if (kind !== 'docx') {
+          where = 'new';
+        } else if (pref === 'same' || pref === 'new') {
+          where = pref;
+        } else {
+          const choice = await askOpenWhere(path);
+          if (!choice) return; // dismissed
+          where = choice.where;
+          if (choice.remember) {
+            await inv('save_settings', {
+              settings: { ...settings, open_window_preference: where },
+            }).catch(() => undefined);
+          }
+        }
+        if (where === 'new') {
+          await inv('open_document_window', { kind, filePath: path }).catch((e) =>
+            console.error('[deskApp] open in new window failed', e)
+          );
+        } else {
+          // Same window: navigate this window to the picked file. The editor's
+          // bootstrap re-reads ?file= on load and binds the new path so Save
+          // overwrites it (no Save-As prompt).
+          const u = new URL(window.location.href);
+          u.searchParams.set('file', path);
+          window.location.href = u.toString();
+        }
       },
       async loadText(p?: string): Promise<string> {
         const path = p ?? filePath;
@@ -476,22 +565,30 @@ if (isDesktop) {
         // "Can't find end of central directory", a confusing error that
         // looks like a parse failure. Catch it earlier with a clear
         // message so the user knows the file itself is the problem.
-        if (out.byteLength < 4 ||
-            out[0] !== 0x50 || out[1] !== 0x4b ||
-            out[2] !== 0x03 || out[3] !== 0x04) {
+        if (
+          out.byteLength < 4 ||
+          out[0] !== 0x50 ||
+          out[1] !== 0x4b ||
+          out[2] !== 0x03 ||
+          out[3] !== 0x04
+        ) {
           // OLE compound signature for legacy .doc / encrypted .docx
-          const isOLE = out.byteLength >= 8 &&
-            out[0] === 0xd0 && out[1] === 0xcf && out[2] === 0x11 && out[3] === 0xe0;
+          const isOLE =
+            out.byteLength >= 8 &&
+            out[0] === 0xd0 &&
+            out[1] === 0xcf &&
+            out[2] === 0x11 &&
+            out[3] === 0xe0;
           if (isOLE) {
             throw new Error(
               "This file isn't a plain .docx — it's an OLE compound file " +
-              "(usually a password-protected .docx or a legacy .doc). " +
-              "Open it in Word or LibreOffice and Save As .docx (without a password), then try again."
+                '(usually a password-protected .docx or a legacy .doc). ' +
+                'Open it in Word or LibreOffice and Save As .docx (without a password), then try again.'
             );
           }
           throw new Error(
             "This file doesn't look like a valid .docx. It's missing the ZIP header " +
-            "(first bytes should be PK 03 04). It may be corrupted or not actually a Word document."
+              '(first bytes should be PK 03 04). It may be corrupted or not actually a Word document.'
           );
         }
         return out.buffer as ArrayBuffer;
@@ -589,7 +686,10 @@ if (isDesktop) {
     // Iframe mode — postMessage to launcher.
     type RequestMethod = 'loadDocument' | 'save' | 'saveAs';
     let nextId = 0;
-    const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: unknown) => void }>();
+    const pending = new Map<
+      number,
+      { resolve: (v: unknown) => void; reject: (e: unknown) => void }
+    >();
 
     function request<T>(method: RequestMethod, params: Record<string, unknown>): Promise<T> {
       return new Promise<T>((resolve, reject) => {
@@ -598,10 +698,7 @@ if (isDesktop) {
           resolve: resolve as (v: unknown) => void,
           reject,
         });
-        window.parent.postMessage(
-          { src: 'deskApp', kind: 'request', id, method, params },
-          '*',
-        );
+        window.parent.postMessage({ src: 'deskApp', kind: 'request', id, method, params }, '*');
       });
     }
 
@@ -618,7 +715,9 @@ if (isDesktop) {
     bridge = {
       isDesktop: true,
       filePath,
-      get fileKind() { return fileKindFor(filePath); },
+      get fileKind() {
+        return fileKindFor(filePath);
+      },
       async loadDocument(p?: string): Promise<ArrayBuffer> {
         const bytes = await request<number[]>('loadDocument', { path: p ?? filePath });
         return new Uint8Array(bytes).buffer;
@@ -685,20 +784,17 @@ if (isDesktop) {
       const tauriEvent = (window as any).__TAURI__?.event;
       if (tauriEvent?.listen) {
         void tauriEvent
-          .listen(
-            'deskapp://file-changed',
-            (e: { payload?: { kind?: string; path?: string } }) => {
-              const { kind, path } = e?.payload ?? {};
-              if (!kind || !path) return;
-              try {
-                window.dispatchEvent(
-                  new CustomEvent('deskapp:file-changed', { detail: { kind, path } })
-                );
-              } catch {
-                /* CustomEvent not supported */
-              }
+          .listen('deskapp://file-changed', (e: { payload?: { kind?: string; path?: string } }) => {
+            const { kind, path } = e?.payload ?? {};
+            if (!kind || !path) return;
+            try {
+              window.dispatchEvent(
+                new CustomEvent('deskapp:file-changed', { detail: { kind, path } })
+              );
+            } catch {
+              /* CustomEvent not supported */
             }
-          )
+          })
           .catch(() => undefined);
       }
     }

--- a/docx-editor/examples/vite/src/deskapp-bridge.d.ts
+++ b/docx-editor/examples/vite/src/deskapp-bridge.d.ts
@@ -67,6 +67,11 @@ declare global {
        *  window to a selectable-text PDF via the shell's export_pdf command.
        *  Returns the written path, or null if cancelled. */
       exportPdf?(suggestedName: string): Promise<string | null>;
+      /** File → Open from the editor menu (desktop): native open dialog +
+       *  "this window or a new window?" prompt, honouring open_window_preference.
+       *  The bridge performs the open itself (new window, or navigating this
+       *  one), so the host's in-window open path is not used for it. */
+      openViaMenu?(): Promise<void>;
       /**
        * Crash-recovery sidecar I/O (desktop only), keyed by the window's bound
        * `filePath`. The editor calls `writeRecovery` on a debounced schedule

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -498,6 +498,13 @@ export interface DocxEditorProps {
    *  being replaced — e.g. the desktop shell unbinds the previous file path so
    *  a later Save can't overwrite the old file with the newly-opened content. */
   onFileOpened?: () => void;
+  /** When provided, File → Open (and the Ctrl/Cmd-O shortcut) calls this
+   *  instead of opening the browser file picker. The desktop shell uses it to
+   *  run a native open dialog + "this window or a new window?" prompt; if the
+   *  host opens the file itself (e.g. in a new window) it simply doesn't call
+   *  back into the editor. Falls back to the in-window browser picker when
+   *  absent (web). */
+  onRequestOpen?: () => void;
   /** Author name used for comments and track changes */
   author?: string;
   /** Callback when document changes */
@@ -1574,6 +1581,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     onExport,
     onNew,
     onFileOpened,
+    onRequestOpen,
     onExportPdf,
     author = 'User',
     onChange,
@@ -7069,8 +7077,14 @@ body { background: white; }
   const handleExportTxt = useCallback(() => handleExportAs('txt'), [handleExportAs]);
 
   const handleOpenDocument = useCallback(() => {
+    // Host override (desktop shell): native dialog + open-where prompt. The
+    // host opens the file itself, so don't also trigger the browser picker.
+    if (onRequestOpen) {
+      onRequestOpen();
+      return;
+    }
     docxInputRef.current?.click();
-  }, []);
+  }, [onRequestOpen]);
 
   // Keep the global-keydown handler in sync with the latest file-op
   // callbacks without recreating the listener. `save` → handleDownloadDocument,


### PR DESCRIPTION
Desktop only: File → Open now uses the shell's native dialog and asks whether to open in this window or a new one, instead of always loading in-window via the browser picker.

- `DocxEditor` gains `onRequestOpen`; `handleOpenDocument` calls it instead of the browser picker when set (web unchanged — prop absent).
- Bridge `openViaMenu`: native pick → real path → `open_window_preference` → same (navigate this window) / new (`open_document_window`) / ask (prompt + remember checkbox → `save_settings`). Remembered default editable from Settings.

Pairs with the shell's `pick_open_document` command. CI typecheck passes; prettier-formatted.