### PR TITLE
fix(header-edit): End key no longer swallows the next keystrokes

### DIFF
--- a/docx-editor/.changeset/header-editor-end-key.md
+++ b/docx-editor/.changeset/header-editor-end-key.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix the `End` key swallowing the next keystrokes while editing a header/footer. In the inline header editor, native `End` desynced ProseMirror's selection from the DOM (in the clipped overlay) and silently dropped the following input — so a user who pressed End then typed lost their text. `End` now maps to a ProseMirror command that moves the caret to the end of the current textblock, keeping the selection valid; the overlay also no longer lets PM scroll its ancestors to reveal the selection.

--- a/docx-editor/packages/react/src/components/InlineHeaderFooterEditor.tsx
+++ b/docx-editor/packages/react/src/components/InlineHeaderFooterEditor.tsx
@@ -17,7 +17,8 @@ import React, {
   forwardRef,
 } from 'react';
 import type { CSSProperties } from 'react';
-import { EditorState } from 'prosemirror-state';
+import { EditorState, TextSelection } from 'prosemirror-state';
+import { keymap } from 'prosemirror-keymap';
 import { useTranslation } from '../i18n';
 import { EditorView } from 'prosemirror-view';
 import { undo, redo } from 'prosemirror-history';
@@ -323,7 +324,24 @@ export const InlineHeaderFooterEditor = forwardRef<
     const hfMgr = new ExtensionManager(createStarterKit());
     hfMgr.buildSchema();
     hfMgr.initializeRuntime();
-    const plugins = hfMgr.getPlugins();
+    // Take `End` over from the browser. Native `End` in this clipped/positioned
+    // overlay desynced ProseMirror's selection from the DOM and then silently
+    // swallowed the following keystrokes (Home / arrows were unaffected). Map it
+    // to a real PM command that moves the caret to the end of the current
+    // textblock, so the selection stays valid. `keymap` is prepended so it wins
+    // over PM's built-in key capture.
+    const endKeymap = keymap({
+      End: (state, dispatch) => {
+        const { $head, empty } = state.selection;
+        if (!empty) return false; // let the browser extend/collapse a range
+        const pos = $head.end();
+        if (dispatch) {
+          dispatch(state.tr.setSelection(TextSelection.create(state.doc, pos)).scrollIntoView());
+        }
+        return true;
+      },
+    });
+    const plugins = [endKeymap, ...hfMgr.getPlugins()];
 
     const state = EditorState.create({
       doc: pmDoc,
@@ -333,6 +351,12 @@ export const InlineHeaderFooterEditor = forwardRef<
 
     const view = new EditorView(editorContainerRef.current, {
       state,
+      // The overlay owns its own layout; never let ProseMirror scroll the
+      // viewport/ancestors to reveal the selection. Without this, `End` (which
+      // requests a scroll-to-selection) desynced the selection in this
+      // clipped/positioned overlay and silently swallowed the next keystrokes.
+      // The body editor (HiddenProseMirror) suppresses this for the same reason.
+      handleScrollToSelection: () => true,
       dispatchTransaction(tr) {
         const newState = view.state.apply(tr);
         view.updateState(newState);


### PR DESCRIPTION
While verifying the header work I found a real **pre-existing** bug (it failed `header-overflow-diagnostic.spec.ts` on main, independent of the positioned-layout PRs).

**Bug:** in the inline header/footer editor, pressing **End then typing loses the input** — focus stays in the editor, but the keystrokes silently drop. Home and arrow keys are unaffected, and the body editor is fine — it's specific to this clipped/positioned overlay, where native `End` desyncs ProseMirror's selection from the DOM.

**Fix:** map `End` to a PM command that moves the caret to the end of the current textblock (a valid `TextSelection`), prepended so it wins over PM's built-in key capture. Also suppress PM's scroll-to-selection on the overlay (`handleScrollToSelection: () => true`), matching the body editor — the overlay owns its own layout.

**Verified:** End-then-type now registers; Home/arrows/typing unaffected. The previously-failing `header-overflow-diagnostic` test now passes; 24 header/footer + comments-sidebar e2e green.