### PR TITLE
fix(desktop): open files dropped onto the editor window

### DIFF
--- a/docx-editor/examples/vite/src/desk-bridge-bootstrap.ts
+++ b/docx-editor/examples/vite/src/desk-bridge-bootstrap.ts
@@ -756,6 +756,40 @@ if (isDesktop) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).__deskApp__ = bridge;
 
+    // Drag-and-drop onto the editor window → open the dropped file(s). Only the
+    // launcher had a drop handler, so dropping a file on a document window did
+    // nothing. Opens each supported file in a NEW window via
+    // open_document_window (which dedups, so re-dropping an already-open file
+    // just focuses it) — dragging never replaces the document you're viewing.
+    try {
+      // withGlobalTauri exposes the window API at __TAURI__.window; mirror the
+      // launcher's getCurrentWindow().onDragDropEvent without adding the
+      // @tauri-apps/api dep to the editor bundle.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const tauriWindow = (window as any).__TAURI__?.window;
+      const currentWindow = tauriWindow?.getCurrentWindow?.();
+      void currentWindow?.onDragDropEvent?.(
+        (event: { payload?: { type?: string; paths?: string[] } }) => {
+          if (event?.payload?.type !== 'drop') return;
+          for (const p of event.payload.paths ?? []) {
+            const ext = p.split('.').pop()?.toLowerCase() ?? '';
+            const kind = ['xlsx', 'xlsm', 'ods', 'csv', 'tsv', 'tab'].includes(ext)
+              ? 'sheets'
+              : ['docx', 'txt', 'md', 'markdown'].includes(ext)
+                ? 'docx'
+                : null;
+            if (kind) {
+              void inv('open_document_window', { kind, filePath: p }).catch((e) =>
+                console.error('[deskApp] drop-open failed', e)
+              );
+            }
+          }
+        }
+      );
+    } catch {
+      /* drag-drop is best-effort — never break editor boot */
+    }
+
     // Theme plumbing — top-level desktop windows only (guarded inside).
     // Seeds the page-level light/dark hint + bridge.themeMode and keeps
     // them in sync with the launcher's `deskapp://theme` events.


### PR DESCRIPTION
Only the launcher had a drop handler, so dragging a file onto an open document window (e.g. one opened via OS "Open With → Casual Office") did nothing. Registers `onDragDropEvent` on the editor window and opens each supported dropped file in a **new** window via `open_document_window` (dedups; never replaces the current doc). Uses the withGlobalTauri window API. CI typecheck passes.