### PR TITLE
polish(toolbar): tokenize ToolbarSeparator color (was hardcoded slate)

### DIFF
--- a/docx-editor/.changeset/toolbar-separator-token.md
+++ b/docx-editor/.changeset/toolbar-separator-token.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Use the shared border token for `ToolbarSeparator` instead of a hardcoded `slate` color, so it stays visually consistent with the rest of the toolbar (and with the group dividers) across light/dark themes and any theme retint.

--- a/docx-editor/packages/react/src/components/Toolbar.tsx
+++ b/docx-editor/packages/react/src/components/Toolbar.tsx
@@ -537,7 +537,9 @@ export function ToolbarGroup({ label, children, className }: ToolbarGroupProps) 
  * Toolbar separator
  */
 export function ToolbarSeparator() {
-  return <div className="w-px h-6 bg-slate-200 dark:bg-slate-700 mx-1.5" role="separator" />;
+  // Use the shared border token (like ToolbarGroup's divider), not hardcoded
+  // slate — so it stays consistent across light/dark and any theme retint.
+  return <div className="w-px h-6 mx-1.5 bg-[color:var(--doc-border-light)]" role="separator" />;
 }
 
 // ============================================================================


### PR DESCRIPTION
From a visual/UI-polish audit of the editor chrome. The chrome is otherwise fully token-based; this was the **only** remaining hardcoded Tailwind palette color (`bg-slate-200 dark:bg-slate-700`), which diverged from the token-based group dividers and wouldn't follow a theme retint. Now uses `--doc-border-light` like the rest. Visual consistency only.