### PR TITLE
feat(comments): host-supplied people for @-mention typeahead

### DIFF
--- a/docx-editor/.changeset/comment-mentionable-users.md
+++ b/docx-editor/.changeset/comment-mentionable-users.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Add a `mentionableUsers` prop so the host can supply the people directory for comment @-mentions. Previously the @-mention typeahead only knew about people who had already commented, so you couldn't mention a collaborator who hadn't participated yet. Hosts (e.g. Drive) can now pass the known users; they're merged into the suggestion list and deduped against historical authors.

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -381,6 +381,12 @@ export function App() {
     () => `Docx Editor User ${Math.floor(Math.random() * 900) + 100}`,
     []
   );
+  // Demo stand-in for the people the host (Drive) would supply — surfaces them
+  // in the comment @-mention typeahead even before they've commented.
+  const mentionableUsers = useMemo(
+    () => ['Alex Morgan', 'Jordan Lee', 'Sam Rivera', 'Priya Nair', 'Chen Wei'],
+    []
+  );
   const editorRef = useRef<DocxEditorRef>(null);
   const suppressSeedDocumentRef = useRef(false);
   const [view, setView] = useState<'home' | 'editor'>(getInitialView);
@@ -1453,6 +1459,7 @@ export function App() {
           document={documentBuffer ? undefined : currentDocument}
           documentBuffer={documentBuffer}
           author={randomAuthor}
+          mentionableUsers={mentionableUsers}
           onError={handleError}
           onFontsLoaded={handleFontsLoaded}
           showToolbar={true}

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -507,6 +507,10 @@ export interface DocxEditorProps {
   onRequestOpen?: () => void;
   /** Author name used for comments and track changes */
   author?: string;
+  /** People the host (e.g. Drive) knows about, surfaced in the comment
+   *  @-mention typeahead so collaborators who haven't commented yet are still
+   *  mentionable. When omitted, only historical comment authors are suggested. */
+  mentionableUsers?: readonly string[];
   /** Callback when document changes */
   onChange?: (document: Document) => void;
   /** Callback when selection changes */
@@ -1584,6 +1588,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     onRequestOpen,
     onExportPdf,
     author = 'User',
+    mentionableUsers,
     onChange,
     onSelectionChange,
     onError,
@@ -8304,6 +8309,7 @@ body { background: white; }
     isAddingComment: showCommentsSidebar ? isAddingComment : false,
     addCommentYPosition,
     currentAuthor: author,
+    mentionableUsers,
   });
 
   const allSidebarItems = useMemo(() => {

--- a/docx-editor/packages/react/src/hooks/useCommentSidebarItems.tsx
+++ b/docx-editor/packages/react/src/hooks/useCommentSidebarItems.tsx
@@ -31,6 +31,9 @@ export interface UseCommentSidebarItemsProps {
   /** Current author — included in @-mention suggestions so the
    *  composer can mention themselves in a doc with no other peers. */
   currentAuthor?: string;
+  /** People the host (e.g. Drive) knows about, so @-mentions can reach
+   *  collaborators who haven't commented yet — not just historical authors. */
+  mentionableUsers?: readonly string[];
 }
 
 export function useCommentSidebarItems({
@@ -41,6 +44,7 @@ export function useCommentSidebarItems({
   isAddingComment = false,
   addCommentYPosition = null,
   currentAuthor,
+  mentionableUsers,
 }: UseCommentSidebarItemsProps): ReactSidebarItem[] {
   // Distinct author names from every comment + tracked-change + the
   // current author. Drives the @-mention typeahead in AddCommentCard
@@ -60,8 +64,11 @@ export function useCommentSidebarItems({
     push(currentAuthor);
     for (const c of comments) push(c.author);
     for (const tc of trackedChanges) push(tc.author);
+    // Host-supplied people (Drive) come last so collaborators who haven't
+    // commented yet are still mentionable, deduped against the live authors.
+    if (mentionableUsers) for (const name of mentionableUsers) push(name);
     return out;
-  }, [comments, trackedChanges, currentAuthor]);
+  }, [comments, trackedChanges, currentAuthor, mentionableUsers]);
   // Active comments always, resolved only when showResolved
   const visibleComments = useMemo(
     () =>


### PR DESCRIPTION
From the Google-Docs gap analysis — item #1 (@mentions). The mention UI already existed (typeahead + chip rendering), but the suggestion list was limited to **people who had already commented** — so you couldn't @-mention a collaborator who hadn't participated yet.

Adds a `mentionableUsers` prop (DocxEditor → `useCommentSidebarItems` → merged into `knownAuthors`, deduped against historical authors). Per the scope decision, **Drive supplies the user directory**; the editor just exposes the hook. The demo wires a sample list.

Verified with Playwright: typing `@` in a fresh comment surfaces the host people (correctly query-filtered), even with no prior comments; comments-sidebar e2e passes.