### PR TITLE
feat(editor): smart-chip @ menu (@date) + fix field measure-cache collision

### DIFF
--- a/docx-editor/.changeset/smart-chips-date.md
+++ b/docx-editor/.changeset/smart-chips-date.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': minor
+---
+
+Add a Google-Docs-style smart-chip "@" menu in the body: typing `@` opens a caret-anchored menu, and choosing "Date" inserts a DATE field. Also fixes a measure-cache collision where a field inserted as a paragraph's trailing run (e.g. Insert > Date) stayed invisible until the next keystroke.

--- a/docx-editor/e2e/tests/field-insert-paint.spec.ts
+++ b/docx-editor/e2e/tests/field-insert-paint.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Regression: a dynamic field (DATE/TIME) inserted as a paragraph's trailing
+ * run must paint immediately, not only after the next keystroke.
+ *
+ * Root cause was the paragraph measure-cache key (`hashParagraphBlock`) omitting
+ * `field` runs: a paragraph that differed from a previously-measured one only by
+ * an inserted field collided on the key and got a stale, field-less measure.
+ * The field then stayed invisible until an unrelated edit re-keyed the cache.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test.describe('Field insert — paints immediately', () => {
+  test('Insert > Date renders the date without a follow-up keystroke', async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.loadDocxFile('fixtures/empty.docx');
+
+    await editor.focusParagraph(0);
+    await editor.pressEnd();
+    // Type a space then a couple of chars + backspace them, to seed the measure
+    // cache with the "space-only" paragraph that previously caused the collision.
+    await editor.typeText('hello ');
+
+    await page.getByRole('button', { name: /^Insert$/ }).click();
+    await page.getByRole('menuitem', { name: /^Field/ }).first().hover();
+    await page.getByRole('menuitem', { name: /^Date$/i }).first().click();
+
+    const today = await page.evaluate(() => new Date().toLocaleDateString());
+    const body = page.locator('.layout-page').first();
+    await expect(body).toContainText(today);
+  });
+});

--- a/docx-editor/e2e/tests/smart-chip-date.spec.ts
+++ b/docx-editor/e2e/tests/smart-chip-date.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Smart chips — the Google-Docs "@" menu in the body.
+ *
+ * Typing `@` at a word boundary opens a caret-anchored menu; choosing "Date"
+ * replaces the `@query` with a DATE field (which paints as today's date and
+ * round-trips natively). These checks lock the trigger → menu → insert flow.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test.describe('Smart chips — @date', () => {
+  test('typing @ opens the menu and selecting Date inserts a DATE field', async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.loadDocxFile('fixtures/empty.docx');
+
+    await editor.focusParagraph(0);
+    await editor.pressEnd();
+
+    const menu = page.getByTestId('smart-chip-menu');
+
+    // `@` at a word boundary opens the menu (space first so the `@` is
+    // whitespace-preceded — `user@host` must NOT trigger).
+    await editor.typeText(' @');
+    await expect(menu).toBeVisible();
+
+    // Narrowing the query keeps the Date row.
+    await editor.typeText('da');
+    const dateItem = page.getByTestId('smart-chip-item-date');
+    await expect(dateItem).toBeVisible();
+
+    // Today's date as the painted DATE field will render it.
+    const today = await page.evaluate(() => new Date().toLocaleDateString());
+
+    await dateItem.click();
+
+    // Menu closes, `@da` is gone, and the date is now in the body.
+    await expect(menu).toHaveCount(0);
+    const body = page.locator('.layout-page').first();
+    await expect(body).toContainText(today);
+    await expect(body).not.toContainText('@da');
+  });
+
+  test('Escape dismisses the menu without inserting anything', async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.loadDocxFile('fixtures/empty.docx');
+
+    await editor.focusParagraph(0);
+    await editor.pressEnd();
+
+    const menu = page.getByTestId('smart-chip-menu');
+    await editor.typeText(' @');
+    await expect(menu).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(menu).toHaveCount(0);
+
+    // The literal `@` text is still there (nothing was inserted/replaced).
+    const body = page.locator('.layout-page').first();
+    await expect(body).toContainText('@');
+  });
+});

--- a/docx-editor/packages/core/src/layout-bridge/measuring/cache.test.ts
+++ b/docx-editor/packages/core/src/layout-bridge/measuring/cache.test.ts
@@ -48,4 +48,31 @@ describe('hashParagraphBlock', () => {
     const withSize = hashParagraphBlock(emptyParagraph({ defaultFontSize: 48 }));
     expect(noDefaults).not.toBe(withSize);
   });
+
+  // Regression: a paragraph differing from a previously-measured one ONLY by a
+  // field run used to collide on this key (field runs weren't hashed), so a
+  // freshly-inserted DATE field got a stale, field-less cached measure and
+  // stayed invisible until the next keystroke re-keyed the cache.
+  test('a field run changes the hash (no collision with a field-less paragraph)', () => {
+    const space: ParagraphBlock = {
+      ...emptyParagraph(),
+      runs: [{ kind: 'text', text: ' ' }] as ParagraphBlock['runs'],
+    };
+    const spaceThenField: ParagraphBlock = {
+      ...emptyParagraph(),
+      runs: [
+        { kind: 'text', text: ' ' },
+        { kind: 'field', fieldType: 'DATE', fallback: '' },
+      ] as ParagraphBlock['runs'],
+    };
+    expect(hashParagraphBlock(space)).not.toBe(hashParagraphBlock(spaceThenField));
+  });
+
+  test('different field types produce different hashes', () => {
+    const mk = (fieldType: string): ParagraphBlock => ({
+      ...emptyParagraph(),
+      runs: [{ kind: 'field', fieldType, fallback: '' }] as ParagraphBlock['runs'],
+    });
+    expect(hashParagraphBlock(mk('DATE'))).not.toBe(hashParagraphBlock(mk('TIME')));
+  });
 });

--- a/docx-editor/packages/core/src/layout-bridge/measuring/cache.ts
+++ b/docx-editor/packages/core/src/layout-bridge/measuring/cache.ts
@@ -274,6 +274,13 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
       parts.push(`img:${run.width}x${run.height}`);
     } else if (run.kind === 'lineBreak') {
       parts.push('br');
+    } else if (run.kind === 'field') {
+      // Field runs are measured by their fallback text (the dynamic value is
+      // substituted only at paint). Two paragraphs that differ ONLY by a field
+      // run — e.g. inserting a DATE field where there was just a space — must
+      // not collide on this key, or the freshly-inserted field gets a stale
+      // (field-less) cached measure and never paints until the next edit.
+      parts.push(`fld:${run.fieldType}|${run.fallback}|${run.fontFamily}|${run.fontSize}`);
     }
   }
 

--- a/docx-editor/packages/core/src/prosemirror/extensions/StarterKit.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/StarterKit.ts
@@ -73,6 +73,7 @@ import { BidiShortcutExtension } from './features/BidiShortcutExtension';
 import { PasteStyleInlinerExtension } from './features/PasteStyleInlinerExtension';
 import { SmartQuotesExtension } from './features/SmartQuotesExtension';
 import { AutocorrectExtension } from './features/AutocorrectExtension';
+import { SmartChipExtension } from './features/SmartChipExtension';
 import { SpellcheckExtension } from './features/SpellcheckExtension';
 import { WordNavigationExtension } from './features/WordNavigationExtension';
 
@@ -195,6 +196,9 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   // quotes, single-transaction so Ctrl+Z reverts. Defaults on;
   // disable via createStarterKit({ disable: ['autocorrect'] }).
   add('autocorrect', AutocorrectExtension());
+  // Smart-chip trigger: tracks an active `@query` so the React layer can show
+  // a caret-anchored chip menu (currently `@date` → DATE field).
+  add('smartChip', SmartChipExtension());
   // Spell-check decorations — inert until the React side calls
   // `setSpellChecker(...)` with an nspell-backed engine + the user
   // toggles it on. Off by default so the ~500 KB dictionary download

--- a/docx-editor/packages/core/src/prosemirror/extensions/features/SmartChipExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/features/SmartChipExtension.ts
@@ -1,0 +1,94 @@
+/**
+ * Smart-chip trigger — Google-Docs-style `@` menu in the body.
+ *
+ * Typing `@` at a word boundary opens a chip menu; this extension only owns the
+ * *detection* (which `@query` is active and where it sits). The React layer
+ * reads the plugin state (`smartChipKey`) to render a caret-anchored menu, and
+ * calls `insertSmartChip(...)` to replace the `@query` with the chosen chip.
+ *
+ * For now the only chip is `@date`, which inserts a DATE field (so it
+ * round-trips natively). `@person` etc. can reuse the same trigger later.
+ */
+import { Plugin, PluginKey, TextSelection } from 'prosemirror-state';
+import type { EditorState, Transaction } from 'prosemirror-state';
+import { createExtension } from '../create';
+import type { ExtensionRuntime } from '../types';
+
+export interface SmartChipTrigger {
+  /** Document position of the `@`. */
+  from: number;
+  /** Cursor position (end of the `@query` run). */
+  to: number;
+  /** Characters typed after the `@` (lowercased), used to filter the menu. */
+  query: string;
+}
+
+export const smartChipKey = new PluginKey<SmartChipTrigger | null>('smartChip');
+
+// Match an active `@query` immediately before the (collapsed) cursor. The
+// `(?:^|\s)` guard means `user@host` does NOT trigger — the `@` there is
+// preceded by a letter, not whitespace/line-start.
+const TRIGGER_RE = /(?:^|\s)@([\w-]*)$/;
+
+function computeTrigger(state: EditorState): SmartChipTrigger | null {
+  const sel = state.selection;
+  if (!sel.empty) return null;
+  const $from = sel.$from;
+  if (!$from.parent.isTextblock) return null;
+  // Text from the start of the textblock up to the cursor. Atoms collapse to a
+  // sentinel so an inline node before the `@` still counts as a boundary.
+  const before = $from.parent.textBetween(0, $from.parentOffset, undefined, '￼');
+  const m = TRIGGER_RE.exec(before);
+  if (!m) return null;
+  const query = m[1];
+  // `@` offset within the parent = cursor offset − query length − 1.
+  const atOffset = $from.parentOffset - query.length - 1;
+  const from = $from.start() + atOffset;
+  return { from, to: sel.from, query: query.toLowerCase() };
+}
+
+/**
+ * Replace the active `@query` trigger with a DATE field. Returns false when no
+ * trigger is active (so callers can no-op safely).
+ */
+export function insertSmartChipDate(
+  state: EditorState,
+  dispatch?: (tr: Transaction) => void
+): boolean {
+  const trigger = smartChipKey.getState(state);
+  if (!trigger) return false;
+  const fieldType = state.schema.nodes.field;
+  if (!fieldType) return false;
+  if (dispatch) {
+    const node = fieldType.create({
+      fieldType: 'DATE',
+      instruction: ' DATE ',
+      displayText: '',
+      fieldKind: 'complex',
+      fldLock: false,
+      dirty: true,
+    });
+    const tr = state.tr.replaceRangeWith(trigger.from, trigger.to, node);
+    const after = tr.mapping.map(trigger.to);
+    tr.setSelection(TextSelection.create(tr.doc, after));
+    dispatch(tr.scrollIntoView());
+  }
+  return true;
+}
+
+export const SmartChipExtension = createExtension({
+  name: 'smartChip',
+  onSchemaReady(): ExtensionRuntime {
+    return {
+      plugins: [
+        new Plugin<SmartChipTrigger | null>({
+          key: smartChipKey,
+          state: {
+            init: () => null,
+            apply: (_tr, _value, _oldState, newState) => computeTrigger(newState),
+          },
+        }),
+      ],
+    };
+  },
+});

--- a/docx-editor/packages/core/src/prosemirror/index.ts
+++ b/docx-editor/packages/core/src/prosemirror/index.ts
@@ -182,6 +182,9 @@ export {
   generateTOC,
 } from './commands';
 export type { TableContextInfo, BorderPreset, InsertableFieldType } from './commands';
+// Smart-chip trigger (`@` menu): plugin state key + the date-chip command.
+export { smartChipKey, insertSmartChipDate } from './extensions/features/SmartChipExtension';
+export type { SmartChipTrigger } from './extensions/features/SmartChipExtension';
 
 /** Word `w14:paraId` → ProseMirror position before matching paragraph. */
 export { findStartPosForParaId } from './utils/findStartPosForParaId';

--- a/docx-editor/packages/react/i18n/de.json
+++ b/docx-editor/packages/react/i18n/de.json
@@ -997,5 +997,9 @@
     "readyToLoad": null,
     "running": null,
     "unloading": null
+  },
+  "smartChip": {
+    "date": null,
+    "dateHint": null
   }
 }

--- a/docx-editor/packages/react/i18n/en.json
+++ b/docx-editor/packages/react/i18n/en.json
@@ -695,6 +695,10 @@
     "mentionSuggestions": "Mention suggestions"
   },
   "trackedChanges": {
+    "previous": "Previous change",
+    "next": "Next change",
+    "acceptAll": "Accept all changes",
+    "rejectAll": "Reject all changes",
     "unknown": "Unknown",
     "replaced": "Replaced",
     "with": "with",
@@ -931,17 +935,6 @@
     "linkCopied": "Link copied to clipboard",
     "failedToSave": "Failed to save document"
   },
-  "trackedChanges": {
-    "previous": "Previous change",
-    "next": "Next change",
-    "acceptAll": "Accept all changes",
-    "rejectAll": "Reject all changes",
-    "unknown": "Unknown",
-    "replaced": "Replaced",
-    "with": "with",
-    "added": "Added",
-    "deleted": "Deleted"
-  },
   "hyperlinkPopup": {
     "displayTextPlaceholder": "Display text",
     "urlPlaceholder": "https://example.com",
@@ -1004,5 +997,9 @@
       "summary": "{count, plural, one {# step} other {# steps}}",
       "earlier": "+ {count, plural, one {# earlier step} other {# earlier steps}}"
     }
+  },
+  "smartChip": {
+    "date": "Date",
+    "dateHint": "Insert today's date"
   }
 }

--- a/docx-editor/packages/react/i18n/he.json
+++ b/docx-editor/packages/react/i18n/he.json
@@ -997,5 +997,9 @@
     "readyToLoad": null,
     "running": null,
     "unloading": null
+  },
+  "smartChip": {
+    "date": null,
+    "dateHint": null
   }
 }

--- a/docx-editor/packages/react/i18n/pl.json
+++ b/docx-editor/packages/react/i18n/pl.json
@@ -997,5 +997,9 @@
     "readyToLoad": null,
     "running": null,
     "unloading": null
+  },
+  "smartChip": {
+    "date": null,
+    "dateHint": null
   }
 }

--- a/docx-editor/packages/react/i18n/pt-BR.json
+++ b/docx-editor/packages/react/i18n/pt-BR.json
@@ -997,5 +997,9 @@
     "readyToLoad": null,
     "running": null,
     "unloading": null
+  },
+  "smartChip": {
+    "date": null,
+    "dateHint": null
   }
 }

--- a/docx-editor/packages/react/i18n/tr.json
+++ b/docx-editor/packages/react/i18n/tr.json
@@ -997,5 +997,9 @@
     "readyToLoad": null,
     "running": null,
     "unloading": null
+  },
+  "smartChip": {
+    "date": null,
+    "dateHint": null
   }
 }

--- a/docx-editor/packages/react/i18n/zh-CN.json
+++ b/docx-editor/packages/react/i18n/zh-CN.json
@@ -997,5 +997,9 @@
     "readyToLoad": null,
     "running": null,
     "unloading": null
+  },
+  "smartChip": {
+    "date": null,
+    "dateHint": null
   }
 }

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -41,6 +41,11 @@ import { EndnoteSection } from './EndnoteSection';
 import { DecorationLayer } from './DecorationLayer';
 import { spellcheckPluginKey } from '@eigenpal/docx-core/prosemirror/extensions';
 import { getTableContext } from '@eigenpal/docx-core/prosemirror';
+import {
+  smartChipKey,
+  insertSmartChipDate,
+  type SmartChipTrigger,
+} from '@eigenpal/docx-core/prosemirror';
 
 // Layout engine
 import {
@@ -120,6 +125,8 @@ import {
 
 // Selection sync
 import { LayoutSelectionGate } from './LayoutSelectionGate';
+import { SmartChipMenu, type SmartChipMenuItem } from './SmartChipMenu';
+import { useTranslation } from '../i18n';
 
 // Visual line navigation hook
 import { useVisualLineNavigation } from './useVisualLineNavigation';
@@ -1449,6 +1456,33 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     const hiddenPMRef = useRef<HiddenProseMirrorRef>(null);
     const painterRef = useRef<LayoutPainter | null>(null);
 
+    const { t } = useTranslation();
+
+    // Smart-chip menu items. Selecting one dispatches the matching insertion on
+    // the hidden PM view, then refocuses so typing continues seamlessly.
+    const smartChipItems = useMemo<SmartChipMenuItem[]>(() => {
+      const insertDate = (): void => {
+        const view = hiddenPMRef.current?.getView();
+        if (!view) return;
+        insertSmartChipDate(view.state, view.dispatch);
+        view.focus();
+      };
+      return [
+        {
+          id: 'date',
+          label: t('smartChip.date'),
+          hint: t('smartChip.dateHint'),
+          keywords: ['date', 'today'],
+          icon: (
+            <svg viewBox="0 0 24 24" width="100%" height="100%" fill="currentColor">
+              <path d="M19 4h-1V2h-2v2H8V2H6v2H5a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2V6a2 2 0 00-2-2zm0 16H5V10h14v10zm0-12H5V6h14v2z" />
+            </svg>
+          ),
+          onSelect: insertDate,
+        },
+      ];
+    }, [t]);
+
     // Visual line navigation (ArrowUp/ArrowDown with sticky X)
     const { handlePMKeyDown } = useVisualLineNavigation({ pagesContainerRef });
 
@@ -1534,6 +1568,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     const [isFocused, setIsFocused] = useState(false);
     const [selectionRects, setSelectionRects] = useState<SelectionRect[]>([]);
     const [caretPosition, setCaretPosition] = useState<CaretPosition | null>(null);
+    // Active `@` smart-chip trigger (Google-Docs "@" menu), or null. Read from
+    // the core SmartChipExtension's plugin state on every selection change.
+    const [smartChip, setSmartChip] = useState<SmartChipTrigger | null>(null);
 
     // Image selection state
     const [selectedImageInfo, setSelectedImageInfo] = useState<ImageSelectionInfo | null>(null);
@@ -2361,6 +2398,10 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           lastNotifiedStateRef.current = state;
           onSelectionChangeRef.current?.(from, to);
         }
+
+        // Smart-chip `@` trigger — surfaced by the core SmartChipExtension. The
+        // caret-anchored menu (rendered below) reads this to decide what to show.
+        setSmartChip(smartChipKey.getState(state) ?? null);
 
         // Update visual cell selection highlighting on visible layout table cells
         if (pagesContainerRef.current) {
@@ -4635,6 +4676,18 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
                 variant="desktop"
               />
             </>
+          )}
+
+          {/* Smart-chip `@` menu — anchored just below the caret while an
+           *  `@query` trigger is active in the body. */}
+          {!readOnly && (
+            <SmartChipMenu
+              trigger={smartChip}
+              caret={caretPosition}
+              isFocused={isFocused}
+              zoom={zoom}
+              items={smartChipItems}
+            />
           )}
 
           {/* Image selection overlay */}

--- a/docx-editor/packages/react/src/paged-editor/SmartChipMenu.tsx
+++ b/docx-editor/packages/react/src/paged-editor/SmartChipMenu.tsx
@@ -1,0 +1,174 @@
+/**
+ * Smart-chip menu — the caret-anchored popup that appears while an `@query`
+ * trigger is active in the body (Google-Docs "@" menu). Detection lives in the
+ * core `SmartChipExtension`; this component only renders the choices and routes
+ * a selection back to the caller, which dispatches the actual insertion.
+ *
+ * Positioned in the same overlay-relative space as the caret (see
+ * `CaretPosition`), so it tracks the cursor as the user keeps typing.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { CaretPosition } from '@eigenpal/docx-core/layout-bridge';
+import type { SmartChipTrigger } from '@eigenpal/docx-core/prosemirror';
+
+export interface SmartChipMenuItem {
+  /** Stable id for keys. */
+  id: string;
+  /** Label shown in the row. */
+  label: string;
+  /** Secondary hint (e.g. a preview of what gets inserted). */
+  hint?: string;
+  /** Inline SVG icon (24×24 viewBox, `currentColor` fill). */
+  icon: React.ReactNode;
+  /** Lowercase strings the `@query` is matched against. */
+  keywords: string[];
+  /** Invoked when the row is chosen. */
+  onSelect: () => void;
+}
+
+interface SmartChipMenuProps {
+  /** Active trigger, or null when no `@query` is open. */
+  trigger: SmartChipTrigger | null;
+  /** Caret position in overlay space; the menu anchors just below it. */
+  caret: CaretPosition | null;
+  /** Whether the editor body is focused (menu hides otherwise). */
+  isFocused: boolean;
+  /** Current zoom — caret coords are pre-zoom, the overlay is scaled. */
+  zoom: number;
+  /** The full menu (filtered by the trigger query before render). */
+  items: SmartChipMenuItem[];
+}
+
+const ROW_HEIGHT = 34;
+
+export function SmartChipMenu({
+  trigger,
+  caret,
+  isFocused,
+  zoom,
+  items,
+}: SmartChipMenuProps): React.ReactElement | null {
+  const [active, setActive] = useState(0);
+  // Suppress the menu for a trigger the user dismissed with Escape, until the
+  // trigger position changes (i.e. they moved on or re-typed `@`).
+  const dismissedFromRef = useRef<number | null>(null);
+
+  const filtered = useMemo(() => {
+    if (!trigger) return [];
+    const q = trigger.query;
+    if (!q) return items;
+    return items.filter((it) => it.keywords.some((k) => k.includes(q)));
+  }, [trigger, items]);
+
+  // Reset the highlighted row whenever the candidate set changes.
+  useEffect(() => {
+    setActive(0);
+  }, [trigger?.query, filtered.length]);
+
+  const dismissed = trigger != null && dismissedFromRef.current === trigger.from;
+  const open = isFocused && trigger != null && caret != null && filtered.length > 0 && !dismissed;
+
+  // Keyboard: the hidden ProseMirror holds focus, so intercept navigation keys
+  // at the window (capture phase) and stop them from reaching the editor.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        e.stopPropagation();
+        setActive((i) => (i + 1) % filtered.length);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        e.stopPropagation();
+        setActive((i) => (i - 1 + filtered.length) % filtered.length);
+      } else if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault();
+        e.stopPropagation();
+        filtered[active]?.onSelect();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        dismissedFromRef.current = trigger?.from ?? null;
+        // Force a re-render so `dismissed` recomputes and the menu hides.
+        setActive((i) => i);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [open, filtered, active, trigger]);
+
+  if (!open || !caret) return null;
+
+  return (
+    <div
+      data-testid="smart-chip-menu"
+      role="listbox"
+      onMouseDown={(e) => {
+        // Keep ProseMirror focus / selection — clicking a row must not move
+        // the caret out of the `@query` before we replace it.
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+      style={{
+        position: 'absolute',
+        left: caret.x * zoom,
+        top: (caret.y + caret.height) * zoom + 4,
+        minWidth: 200,
+        background: '#fff',
+        border: '1px solid #dadce0',
+        borderRadius: 8,
+        boxShadow: '0 2px 10px rgba(0,0,0,0.18)',
+        padding: '6px 0',
+        zIndex: 220,
+        fontSize: 13,
+        color: '#202124',
+      }}
+    >
+      {filtered.map((it, i) => (
+        <button
+          key={it.id}
+          type="button"
+          role="option"
+          aria-selected={i === active}
+          data-testid={`smart-chip-item-${it.id}`}
+          onMouseEnter={() => setActive(i)}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            it.onSelect();
+          }}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            width: '100%',
+            height: ROW_HEIGHT,
+            padding: '0 14px',
+            border: 'none',
+            background: i === active ? '#e8f0fe' : 'transparent',
+            color: 'inherit',
+            font: 'inherit',
+            textAlign: 'left',
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              display: 'inline-flex',
+              width: 18,
+              height: 18,
+              color: '#5f6368',
+              flexShrink: 0,
+            }}
+          >
+            {it.icon}
+          </span>
+          <span style={{ flex: 1 }}>{it.label}</span>
+          {it.hint && <span style={{ color: '#80868b', fontSize: 12 }}>{it.hint}</span>}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Typing `@` at a word boundary opens a caret-anchored menu (Google-Docs "@" chips). Choosing **Date** replaces the `@query` with a DATE field that round-trips natively. Arrows navigate, Enter/Tab insert, Esc dismisses.

While building this I found and fixed a pre-existing bug: `hashParagraphBlock` (the paragraph measure-cache key) ignored `field` runs, so a paragraph differing from a previously-measured one only by an inserted field collided on the key and got a stale, field-less measure. The field (e.g. Insert > Date as a paragraph's trailing run) stayed invisible until the next keystroke. Now hashed.

Tests: `smart-chip-date.spec.ts` (trigger/insert/escape), `field-insert-paint.spec.ts` (canonical Insert > Date paints immediately), plus `hashParagraphBlock` unit coverage for field runs.