### PR TITLE
hotfix(desktop): bug batch from real-world testing (WIP — accumulating)

### DIFF
--- a/docx-editor/examples/vite/src/desk-bridge-bootstrap.ts
+++ b/docx-editor/examples/vite/src/desk-bridge-bootstrap.ts
@@ -289,23 +289,38 @@ function askOpenWhere(path: string): Promise<{ where: 'same' | 'new'; remember: 
     const name = path.split(/[\\/]/).pop() ?? path;
     const esc = (s: string) =>
       s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c]!);
+    // Theme-aware: resolved <html data-theme> (set by setupDeskTheme), else the
+    // launcher's ?theme= param, else the OS preference. Without this the modal
+    // was hardcoded white and invisible in dark mode.
+    const dark = (() => {
+      const r = document.documentElement.dataset.theme;
+      if (r === 'dark') return true;
+      if (r === 'light') return false;
+      const tp = new URLSearchParams(window.location.search).get('theme');
+      if (tp === 'dark') return true;
+      if (tp === 'light') return false;
+      return typeof matchMedia === 'function' && matchMedia('(prefers-color-scheme: dark)').matches;
+    })();
+    const c = dark
+      ? { bg: '#242528', fg: '#e9eaec', muted: '#a3a6ad', btnBg: '#33353a', btnBorder: '#4a4d54' }
+      : { bg: '#ffffff', fg: '#111111', muted: '#666666', btnBg: '#f5f5f5', btnBorder: '#cccccc' };
     const backdrop = document.createElement('div');
     backdrop.setAttribute(
       'style',
       'position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.45);font:14px system-ui,-apple-system,sans-serif;'
     );
     backdrop.innerHTML = `
-      <div role="dialog" aria-modal="true" style="background:#fff;color:#111;max-width:380px;width:90%;border-radius:12px;padding:22px 22px 16px;box-shadow:0 12px 40px rgba(0,0,0,.3);">
+      <div role="dialog" aria-modal="true" style="background:${c.bg};color:${c.fg};max-width:380px;width:90%;border-radius:12px;padding:22px 22px 16px;box-shadow:0 12px 40px rgba(0,0,0,.45);">
         <h2 style="margin:0 0 6px;font-size:17px;">Open &ldquo;${esc(name)}&rdquo;</h2>
-        <p style="margin:0 0 4px;color:#666;">Open it in this window or a new window?</p>
-        <label style="display:flex;align-items:center;gap:8px;margin:16px 0;color:#666;cursor:pointer;">
+        <p style="margin:0 0 4px;color:${c.muted};">Open it in this window or a new window?</p>
+        <label style="display:flex;align-items:center;gap:8px;margin:16px 0;color:${c.muted};cursor:pointer;">
           <input type="checkbox" data-act="remember" /> Remember my choice
         </label>
         <div style="display:flex;gap:8px;">
-          <button data-act="same" style="flex:1;padding:9px;border-radius:8px;border:1px solid #ccc;background:#f5f5f5;cursor:pointer;">This window</button>
+          <button data-act="same" style="flex:1;padding:9px;border-radius:8px;border:1px solid ${c.btnBorder};background:${c.btnBg};color:${c.fg};cursor:pointer;">This window</button>
           <button data-act="new" style="flex:1;padding:9px;border-radius:8px;border:0;background:#2563eb;color:#fff;font-weight:600;cursor:pointer;">New window</button>
         </div>
-        <button data-act="cancel" style="margin-top:10px;width:100%;background:none;border:0;color:#888;cursor:pointer;padding:6px;">Cancel</button>
+        <button data-act="cancel" style="margin-top:10px;width:100%;background:none;border:0;color:${c.muted};cursor:pointer;padding:6px;">Cancel</button>
       </div>`;
     document.body.appendChild(backdrop);
     const remember = () =>


### PR DESCRIPTION
Rolling hotfix branch for the desktop bug batch reported from real-world testing. Commits land here as each fix is verified; this PR aggregates them for the v0.0.3 desktop hotfix.

**Landed:**
- Dark-mode open-where modal — was hardcoded white (`#fff/#111/#666/#ccc`), invisible in dark mode; now theme-aware.

**Queued (this branch):**
- External links / Help / document hyperlinks (`window.open` blocked in Tauri → `shell.open`)
- Native `confirm`/`prompt` → styled modal (delete-version, name-a-version)
- ODT/txt desktop export path (web export is valid — desktop worker/save path is the bug)
- Dark-mode: header/footer editor (`#fff/#000`)

Tracking: CasualOffice/desktop#47 + a batch of editor-side issues.