### PR TITLE
feat(dark-mode): dim the default page paper, deepen the desk

### DIFF
--- a/docx-editor/.changeset/dark-mode-dim-page.md
+++ b/docx-editor/.changeset/dark-mode-dim-page.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+In dark mode, dim the default white page to a soft off-white and deepen the desk behind it to near-black, so the page reads as a calm card instead of glaring. Display-only — documents with an explicit page color are unchanged, and export keeps the real colors.

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -2025,7 +2025,11 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             // (font-load, rAF) uses the current document, not a stale closure.
             const currentDoc = documentRef.current;
             const docBgColor = currentDoc?.package.document.background?.color?.rgb ?? undefined;
-            const pageBackground = docBgColor ? `#${docBgColor}` : '#fff';
+            // Explicit doc backgrounds render verbatim (fidelity); the default
+            // "white paper" resolves through a token so dark mode can dim it to
+            // a soft off-white (display-only — `docBgColor` / the model is what
+            // serializes, so export is unaffected).
+            const pageBackground = docBgColor ? `#${docBgColor}` : 'var(--doc-page-paper, #fff)';
             // Document-level text watermark (C5). Painter draws it as a
             // rotated overlay behind the content on every page.
             const watermark = currentDoc?.package.document.watermark;

--- a/docx-editor/packages/react/src/styles/editor.css
+++ b/docx-editor/packages/react/src/styles/editor.css
@@ -86,6 +86,12 @@
      with the suite chrome strip. */
   --doc-bg: var(--color-surface-strip);
 
+  /* The page "paper" fill for the DEFAULT (no explicit `<w:background>`) case.
+     White in light mode; dark mode dims it to a soft off-white so a bright
+     page doesn't glare against the dark desk. Display-only — the document
+     model / export is unaffected (see PagedEditor `pageBackground`). */
+  --doc-page-paper: #ffffff;
+
   /* Chrome strips (title bar, toolbar, status bar) — one consistent suite
      grey so only the page + floating panels read as white cards. */
   --doc-chrome: var(--color-surface-strip);
@@ -188,6 +194,11 @@
   --color-text-muted: #969aa3;
   --color-text-disabled: #8b8e96;
   --color-border-strong: #646a76;
+  /* Dim the white page to a soft off-white and deepen the desk to near-black
+     so the page reads as a calm card instead of a glaring panel. Paper stays
+     light (text unchanged); display-only, export keeps the real colors. */
+  --doc-page-paper: #ececec;
+  --doc-bg: #1b1c1e;
   /* shadcn vars — used by ui/Button.tsx and any consumer of
      bg-background / bg-card / bg-popover / bg-muted / text-foreground. */
   --background: 220 6% 19%; /* #2d2f31 in HSL */


### PR DESCRIPTION
In dark mode a pure-white page glared against the dark chrome. The default page fill now routes through a new `--doc-page-paper` token (white in light, soft off-white `#ececec` in dark), and the desk (`--doc-bg`) deepens to near-black.

Display-only and fidelity-safe: documents with an explicit `<w:background>` render verbatim, and export serializes the model, not the painted fill. Text color is unchanged (black on off-white stays readable).