### PR TITLE
fix(desktop): styled confirm/prompt for version save/rename/delete

### DIFF
--- a/docx-editor/packages/react/src/components/sidebar/VersionHistoryPanel.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/VersionHistoryPanel.tsx
@@ -21,6 +21,7 @@
  * cross-peer log is the Yjs op-log (out of scope for v1).
  */
 import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { confirmModal, promptModal } from '../../utils/modals';
 import { MaterialSymbol } from '../ui/MaterialSymbol';
 import { PanelState } from '../ui/PanelState';
 import { Tooltip } from '../ui/Tooltip';
@@ -542,11 +543,7 @@ function VersionsTab({
 
   const handleSaveVersion = useCallback(async () => {
     if (!saveNamedVersion) return;
-    // Native prompt — small, deterministic, works in Playwright.
-    // A future iteration can replace it with the styled
-    // InlineRenameDialog used elsewhere in the editor.
-    // eslint-disable-next-line no-alert
-    const raw = window.prompt('Name this version', '');
+    const raw = await promptModal({ title: 'Name this version', confirmLabel: 'Save' });
     if (raw == null) return;
     const trimmed = raw.trim();
     if (!trimmed) return;
@@ -571,8 +568,11 @@ function VersionsTab({
 
   const handleRename = useCallback(async (snap: VersionSnapshot) => {
     if (snap.serverVersion != null || snap.id == null) return; // server versions are host-owned
-    // eslint-disable-next-line no-alert
-    const next = window.prompt('Rename version', snap.name);
+    const next = await promptModal({
+      title: 'Rename version',
+      defaultValue: snap.name,
+      confirmLabel: 'Rename',
+    });
     if (next == null) return;
     const trimmed = next.trim();
     if (!trimmed || trimmed === snap.name) return;
@@ -582,7 +582,13 @@ function VersionsTab({
   const handleDelete = useCallback(async (snap: VersionSnapshot) => {
     if (snap.serverVersion != null || snap.id == null) return; // server versions are host-owned
     // eslint-disable-next-line no-alert
-    if (!window.confirm(`Delete "${snap.name}"? This cannot be undone.`)) return;
+    const ok = await confirmModal({
+      title: 'Delete version',
+      body: `Delete "${snap.name}"? This cannot be undone.`,
+      confirmLabel: 'Delete',
+      danger: true,
+    });
+    if (!ok) return;
     await deleteVersion(snap.id);
   }, []);
 

--- a/docx-editor/packages/react/src/utils/modals.ts
+++ b/docx-editor/packages/react/src/utils/modals.ts
@@ -1,0 +1,144 @@
+/**
+ * Lightweight, theme-aware confirm/prompt modals.
+ *
+ * Replaces window.confirm()/window.prompt(), which render the native OS dialog
+ * (jarring in the Casual Office desktop shell, and unstyled everywhere). These
+ * paint a small in-app modal and resolve a Promise. Self-contained vanilla DOM
+ * so they're callable from anywhere (components or plain handlers).
+ */
+
+function isDark(): boolean {
+  if (typeof document !== 'undefined') {
+    const t = document.documentElement.dataset.theme;
+    if (t === 'dark') return true;
+    if (t === 'light') return false;
+    try {
+      const ls = window.localStorage.getItem('casual-editor:color-theme');
+      if (ls === 'dark') return true;
+      if (ls === 'light') return false;
+    } catch {
+      /* localStorage may be unavailable */
+    }
+  }
+  return typeof matchMedia === 'function' && matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+function palette() {
+  return isDark()
+    ? {
+        bg: '#242528',
+        fg: '#e9eaec',
+        muted: '#a3a6ad',
+        btnBg: '#33353a',
+        btnBorder: '#4a4d54',
+        inputBg: '#1c1d20',
+        overlay: 'rgba(0,0,0,.55)',
+      }
+    : {
+        bg: '#ffffff',
+        fg: '#111111',
+        muted: '#666666',
+        btnBg: '#f5f5f5',
+        btnBorder: '#cccccc',
+        inputBg: '#ffffff',
+        overlay: 'rgba(0,0,0,.45)',
+      };
+}
+
+const esc = (s: string) =>
+  s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c]!);
+
+function mountBackdrop(c: ReturnType<typeof palette>): HTMLDivElement {
+  const backdrop = document.createElement('div');
+  backdrop.setAttribute(
+    'style',
+    `position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;background:${c.overlay};font:14px system-ui,-apple-system,sans-serif;`
+  );
+  return backdrop;
+}
+
+export interface ConfirmOptions {
+  title?: string;
+  body: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  danger?: boolean;
+}
+
+export function confirmModal(opts: ConfirmOptions): Promise<boolean> {
+  return new Promise((resolve) => {
+    const c = palette();
+    const backdrop = mountBackdrop(c);
+    const confirmBg = opts.danger ? '#dc2626' : '#2563eb';
+    backdrop.innerHTML = `
+      <div role="dialog" aria-modal="true" style="background:${c.bg};color:${c.fg};max-width:400px;width:90%;border-radius:12px;padding:22px 22px 16px;box-shadow:0 12px 40px rgba(0,0,0,.45);white-space:pre-line;">
+        ${opts.title ? `<h2 style="margin:0 0 8px;font-size:17px;">${esc(opts.title)}</h2>` : ''}
+        <p style="margin:0 0 18px;color:${c.muted};">${esc(opts.body)}</p>
+        <div style="display:flex;gap:8px;justify-content:flex-end;">
+          <button data-act="cancel" style="padding:8px 14px;border-radius:8px;border:1px solid ${c.btnBorder};background:${c.btnBg};color:${c.fg};cursor:pointer;">${esc(opts.cancelLabel ?? 'Cancel')}</button>
+          <button data-act="ok" style="padding:8px 14px;border-radius:8px;border:0;background:${confirmBg};color:#fff;font-weight:600;cursor:pointer;">${esc(opts.confirmLabel ?? 'OK')}</button>
+        </div>
+      </div>`;
+    document.body.appendChild(backdrop);
+    const finish = (v: boolean) => {
+      window.removeEventListener('keydown', onKey);
+      backdrop.remove();
+      resolve(v);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') finish(false);
+      else if (e.key === 'Enter') finish(true);
+    };
+    window.addEventListener('keydown', onKey);
+    backdrop.addEventListener('mousedown', (e) => {
+      if (e.target === backdrop) finish(false);
+    });
+    backdrop.querySelector('[data-act=cancel]')!.addEventListener('click', () => finish(false));
+    backdrop.querySelector('[data-act=ok]')!.addEventListener('click', () => finish(true));
+    (backdrop.querySelector('[data-act=ok]') as HTMLButtonElement)?.focus();
+  });
+}
+
+export interface PromptOptions {
+  title?: string;
+  label?: string;
+  defaultValue?: string;
+  confirmLabel?: string;
+}
+
+export function promptModal(opts: PromptOptions): Promise<string | null> {
+  return new Promise((resolve) => {
+    const c = palette();
+    const backdrop = mountBackdrop(c);
+    backdrop.innerHTML = `
+      <div role="dialog" aria-modal="true" style="background:${c.bg};color:${c.fg};max-width:400px;width:90%;border-radius:12px;padding:22px 22px 16px;box-shadow:0 12px 40px rgba(0,0,0,.45);">
+        ${opts.title ? `<h2 style="margin:0 0 8px;font-size:17px;">${esc(opts.title)}</h2>` : ''}
+        ${opts.label ? `<label style="display:block;margin:0 0 6px;color:${c.muted};">${esc(opts.label)}</label>` : ''}
+        <input data-act="input" type="text" style="box-sizing:border-box;width:100%;padding:9px 10px;border-radius:8px;border:1px solid ${c.btnBorder};background:${c.inputBg};color:${c.fg};margin-bottom:16px;font:inherit;" />
+        <div style="display:flex;gap:8px;justify-content:flex-end;">
+          <button data-act="cancel" style="padding:8px 14px;border-radius:8px;border:1px solid ${c.btnBorder};background:${c.btnBg};color:${c.fg};cursor:pointer;">Cancel</button>
+          <button data-act="ok" style="padding:8px 14px;border-radius:8px;border:0;background:#2563eb;color:#fff;font-weight:600;cursor:pointer;">${esc(opts.confirmLabel ?? 'OK')}</button>
+        </div>
+      </div>`;
+    document.body.appendChild(backdrop);
+    const input = backdrop.querySelector('[data-act=input]') as HTMLInputElement;
+    input.value = opts.defaultValue ?? '';
+    const finish = (v: string | null) => {
+      window.removeEventListener('keydown', onKey);
+      backdrop.remove();
+      resolve(v);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') finish(null);
+      else if (e.key === 'Enter') finish(input.value);
+    };
+    window.addEventListener('keydown', onKey);
+    backdrop.addEventListener('mousedown', (e) => {
+      if (e.target === backdrop) finish(null);
+    });
+    backdrop.querySelector('[data-act=cancel]')!.addEventListener('click', () => finish(null));
+    backdrop.querySelector('[data-act=ok]')!.addEventListener('click', () => finish(input.value));
+    input.focus();
+    input.select();
+  });
+}


### PR DESCRIPTION
window.prompt/window.confirm render the native OS dialog (jarring in the desktop shell). Add theme-aware confirmModal/promptModal and use them for **naming a version**, renaming, and deleting (delete = danger confirm). typecheck clean.