### PR TITLE
feat(version-history): single auto-saved timeline + re-land orphaned follow-ups

### DIFF
--- a/docx-editor/.changeset/smart-chip-dark-tokens.md
+++ b/docx-editor/.changeset/smart-chip-dark-tokens.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Theme the smart-chip "@" menu with design tokens so it renders correctly in dark mode (it previously hardcoded a white background).

--- a/docx-editor/.changeset/version-history-clarity.md
+++ b/docx-editor/.changeset/version-history-clarity.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@eigenpal/docx-js-editor': minor
 ---
 
-Clarify the version-history panel: rename the "Activity" tab to "Recent edits" and add a one-line caption under each tab so the two timelines aren't confused — "Versions" are durable, named, restorable snapshots; "Recent edits" is the live, this-session change feed that clears when the document is closed.
+Rework version history to match Google Docs. The panel is now a single auto-saved timeline (the separate "Activity" / recent-edits tab is gone), and a version is also captured on every explicit save (Ctrl+S / File → Save) in addition to the idle interval. Each entry shows who captured it; auto snapshots read as "Auto-saved" with the time alongside. The in-canvas preview gains up/down controls to step between changes, and the panel states up front that versions save automatically (so the optional "Save version…" reads as name-only).

--- a/docx-editor/e2e/helpers/editor-page.ts
+++ b/docx-editor/e2e/helpers/editor-page.ts
@@ -1453,6 +1453,20 @@ export class EditorPage {
     this.currentTableCell = null;
   }
 
+  /**
+   * Save a named version via the version-history panel. The panel must
+   * already be open. "Save version…" opens a styled prompt modal
+   * (`promptModal`, not a native dialog), so fill its input + confirm.
+   */
+  async saveNamedVersion(name: string): Promise<void> {
+    await this.page.getByTestId('version-history-save-version').click();
+    const input = this.page.locator('[data-act=input]');
+    await input.waitFor({ state: 'visible', timeout: 5000 });
+    await input.fill(name);
+    await this.page.locator('[data-act=ok]').click();
+    await this.page.locator('[data-act=input]').waitFor({ state: 'detached', timeout: 5000 });
+  }
+
   // ============================================================================
   // FIND & REPLACE
   // ============================================================================

--- a/docx-editor/e2e/tests/panel-state.spec.ts
+++ b/docx-editor/e2e/tests/panel-state.spec.ts
@@ -17,13 +17,11 @@ test.describe('PanelState (X5)', () => {
 
     const panel = page.locator('[data-testid="version-history-panel"]');
     await expect(panel).toBeVisible();
-    // Phase 7 split the panel into Versions (persisted, default) +
-    // Activity (live edit feed). 'No edits yet' lives on the Activity
-    // tab; switch there before asserting.
-    await page.getByTestId('version-history-tab-activity').click();
+    // Single auto-saved timeline: a fresh doc has no versions yet, so the
+    // empty state explains how versions get created.
     const empty = panel.locator('[data-testid="panel-state-empty"]');
     await expect(empty).toBeVisible();
-    await expect(empty).toContainText(/No edits yet/);
+    await expect(empty).toContainText(/No saved versions yet/);
     // PanelState marks itself role="status" so screen readers don't
     // interrupt, but assistive tech still announces it on focus.
     await expect(empty).toHaveAttribute('role', 'status');

--- a/docx-editor/e2e/tests/smoke.spec.ts
+++ b/docx-editor/e2e/tests/smoke.spec.ts
@@ -91,12 +91,6 @@ test.describe('Smoke — editor + AI surfaces mount without runtime errors', () 
         await page.waitForTimeout(200);
         const panel = page.getByTestId('version-history-panel');
         await expect(panel).toBeVisible();
-        // Expand the diff toggle on the first entry if there is one.
-        const showBtn = panel.getByTestId('version-history-toggle-diff').first();
-        if (await showBtn.count()) {
-          await showBtn.click();
-          await page.waitForTimeout(150);
-        }
         await histBtn.first().click(); // close
       }
       // Comments.

--- a/docx-editor/e2e/tests/version-history-audit.spec.ts
+++ b/docx-editor/e2e/tests/version-history-audit.spec.ts
@@ -51,25 +51,13 @@ test.describe('Version history visual audit', () => {
       fullPage: false,
     });
 
-    // State 4: switch to Activity tab and expand the latest entry's diff.
-    await page.getByTestId('version-history-tab-activity').click();
-    await page.waitForTimeout(200);
-    const toggleDiff = page
-      .locator('[data-testid="version-history-toggle-diff"]')
-      .first();
-    await toggleDiff.click();
-    await page.waitForSelector('[data-testid="version-history-diff"]');
-    await page.waitForTimeout(200);
-    await page.screenshot({
-      path: 'screenshots/audit/vh-4-diff.png',
-      fullPage: false,
-    });
+    // State 4 (formerly the "Activity tab diff") was removed when the panel
+    // collapsed to a single auto-saved timeline — there is no separate
+    // recent-edits feed anymore.
 
-    // State 5: back to Versions tab — capture the persisted snapshot
-    // list. Trigger TWO manual snapshots with edits between so the
-    // newer one has a "previous" to diff against.
-    await page.getByTestId('version-history-tab-versions').click();
-    await page.waitForTimeout(200);
+    // State 5: capture the persisted snapshot list. Trigger TWO manual
+    // snapshots with edits between so the newer one has a "previous" to
+    // diff against.
     page.once('dialog', (d) => d.accept('Initial draft'));
     await page.getByTestId('version-history-save-version').click();
     await page.waitForSelector('[data-testid="version-history-version-row"]');

--- a/docx-editor/e2e/tests/version-history-audit.spec.ts
+++ b/docx-editor/e2e/tests/version-history-audit.spec.ts
@@ -58,14 +58,12 @@ test.describe('Version history visual audit', () => {
     // State 5: capture the persisted snapshot list. Trigger TWO manual
     // snapshots with edits between so the newer one has a "previous" to
     // diff against.
-    page.once('dialog', (d) => d.accept('Initial draft'));
-    await page.getByTestId('version-history-save-version').click();
+    await editor.saveNamedVersion('Initial draft');
     await page.waitForSelector('[data-testid="version-history-version-row"]');
 
     await editor.focus();
     await editor.typeText(' Added a paragraph after the initial save.');
-    page.once('dialog', (d) => d.accept('Post-edit checkpoint'));
-    await page.getByTestId('version-history-save-version').click();
+    await editor.saveNamedVersion('Post-edit checkpoint');
     await page.waitForFunction(
       () => document.querySelectorAll('[data-testid="version-history-version-row"]').length >= 2
     );

--- a/docx-editor/e2e/tests/version-history.spec.ts
+++ b/docx-editor/e2e/tests/version-history.spec.ts
@@ -20,7 +20,7 @@ test.describe('Version history panel', () => {
     await editor.focus();
   });
 
-  test('toolbar toggle mounts the panel and captures edits', async ({ page }) => {
+  test('toolbar toggle mounts the single version timeline', async ({ page }) => {
     const toggle = page.getByRole('button', { name: 'Version history' });
     await expect(toggle).toBeVisible();
 
@@ -30,70 +30,19 @@ test.describe('Version history panel', () => {
     await toggle.click();
     await expect(page.locator('[data-testid="version-history-panel"]')).toBeVisible();
 
-    // The panel is a two-tab container — Versions (persisted IDB
-    // snapshots, default) + Activity (live edit feed). The per-edit
-    // entries this spec checks live in the Activity tab.
-    await page.getByTestId('version-history-tab-activity').click();
+    // One timeline now — no Versions/Activity tab split.
+    await expect(page.getByTestId('version-history-tab-activity')).toHaveCount(0);
 
-    // Type so the capture plugin records at least one entry. The hook
-    // coalesces rapid typing into one entry within a 2s idle window, so
-    // a single character is sufficient to produce one visible row.
-    await editor.typeText('hello');
-    await page.waitForTimeout(150);
-
-    // The panel renders an aria-labeled list (see VersionHistoryPanel).
-    // Just assert that *something* renders inside the panel body — the
-    // empty-state text disappears once entries exist.
+    // The auto-save explainer and the "Save version…" (name-only) action
+    // are the panel's anchors.
     const panel = page.locator('[data-testid="version-history-panel"]');
-    const entryCount = await panel.locator('li, [role="listitem"]').count();
-    expect(entryCount).toBeGreaterThan(0);
-  });
+    await expect(panel.getByTestId('version-history-caption')).toBeVisible();
+    await expect(panel.getByTestId('version-history-save-version')).toBeVisible();
 
-  test('Show changes reveals an inline word diff for the latest entry', async ({ page }) => {
-    const toggle = page.getByRole('button', { name: 'Version history' });
-    await toggle.click();
-    await expect(page.locator('[data-testid="version-history-panel"]')).toBeVisible();
-    await page.getByTestId('version-history-tab-activity').click();
-
-    // Type so an entry lands. The diff is computed against the live
-    // doc, so "hello world" landing as the latest entry produces a +2
-    // word stats pill on the row.
-    await editor.typeText('hello world');
-    await page.waitForTimeout(200);
-
-    const panel = page.locator('[data-testid="version-history-panel"]');
-    const showBtn = panel.getByTestId('version-history-toggle-diff').first();
-    await expect(showBtn).toBeVisible();
-    await showBtn.click();
-    const diffBox = panel.getByTestId('version-history-diff').first();
-    await expect(diffBox).toBeVisible();
-    // The diff should contain green INS marks for the new text.
-    const insCount = await diffBox.locator('ins').count();
-    expect(insCount).toBeGreaterThan(0);
-  });
-
-  test('inserted segments in the diff are interactive revert targets', async ({ page }) => {
-    const toggle = page.getByRole('button', { name: 'Version history' });
-    await toggle.click();
-    await expect(page.locator('[data-testid="version-history-panel"]')).toBeVisible();
-    await page.getByTestId('version-history-tab-activity').click();
-
-    await editor.typeText('alpha bravo');
-    await page.waitForTimeout(200);
-
-    const panel = page.locator('[data-testid="version-history-panel"]');
-    const showBtn = panel.getByTestId('version-history-toggle-diff').first();
-    await showBtn.click();
-    const insSpans = panel.getByTestId('version-history-diff-add');
-    await expect(insSpans.first()).toBeVisible();
-
-    // Phase B contract: inserted spans are clickable buttons with the
-    // right tooltip. Actual revert dispatch is exercised by manual
-    // verification — the test environment doesn't reliably round-trip
-    // PM dispatch + layout-painter repaint within timing windows.
-    const first = insSpans.first();
-    await expect(first).toHaveAttribute('role', 'button');
-    await expect(first).toHaveAttribute('title', /revert/i);
+    // A named save produces a row.
+    page.once('dialog', (d) => d.accept('Checkpoint'));
+    await panel.getByTestId('version-history-save-version').click();
+    await expect(panel.getByTestId('version-history-version-row').first()).toBeVisible();
   });
 
   test('toggling the panel off hides it', async ({ page }) => {

--- a/docx-editor/e2e/tests/version-history.spec.ts
+++ b/docx-editor/e2e/tests/version-history.spec.ts
@@ -40,8 +40,7 @@ test.describe('Version history panel', () => {
     await expect(panel.getByTestId('version-history-save-version')).toBeVisible();
 
     // A named save produces a row.
-    page.once('dialog', (d) => d.accept('Checkpoint'));
-    await panel.getByTestId('version-history-save-version').click();
+    await editor.saveNamedVersion('Checkpoint');
     await expect(panel.getByTestId('version-history-version-row').first()).toBeVisible();
   });
 

--- a/docx-editor/e2e/tests/version-panel-layout.spec.ts
+++ b/docx-editor/e2e/tests/version-panel-layout.spec.ts
@@ -25,8 +25,7 @@ test.describe('Version panel layout', () => {
     // One named version.
     await editor.focus();
     await editor.typeText('Draft body.');
-    page.once('dialog', (d) => d.accept('Milestone one'));
-    await page.getByTestId('version-history-save-version').click();
+    await editor.saveNamedVersion('Milestone one');
     await page.waitForSelector('[data-testid="version-history-version-row"]');
 
     // Pinned "Current version" row is present and active (not previewing).
@@ -67,8 +66,7 @@ test.describe('Version panel layout', () => {
     await page.getByRole('button', { name: 'Version history' }).click();
     await editor.focus();
     await editor.typeText('Some content here.');
-    page.once('dialog', (d) => d.accept('Named A'));
-    await page.getByTestId('version-history-save-version').click();
+    await editor.saveNamedVersion('Named A');
     await page.waitForSelector('[data-testid="version-history-version-row"]');
 
     // With only a manual version, the named-only filter is hidden (nothing

--- a/docx-editor/e2e/tests/version-preview-pinned.spec.ts
+++ b/docx-editor/e2e/tests/version-preview-pinned.spec.ts
@@ -26,14 +26,12 @@ test.describe('Version preview — pinned banner', () => {
 
     await page.getByRole('button', { name: 'Version history' }).click();
     await page.waitForSelector('[data-testid="version-history-panel"]');
-    page.once('dialog', (d) => d.accept('v1'));
-    await page.getByTestId('version-history-save-version').click();
+    await editor.saveNamedVersion('v1');
     await page.waitForSelector('[data-testid="version-history-version-row"]');
 
     await editor.focus();
     await editor.typeText('More edits. ');
-    page.once('dialog', (d) => d.accept('v2'));
-    await page.getByTestId('version-history-save-version').click();
+    await editor.saveNamedVersion('v2');
     await page.waitForFunction(
       () => document.querySelectorAll('[data-testid="version-history-version-row"]').length >= 2
     );

--- a/docx-editor/e2e/tests/version-preview.spec.ts
+++ b/docx-editor/e2e/tests/version-preview.spec.ts
@@ -28,14 +28,12 @@ test.describe('Version preview', () => {
     // previous version to diff against.
     await editor.focus();
     await editor.typeText('First draft of the memo.');
-    page.once('dialog', (d) => d.accept('Initial draft'));
-    await page.getByTestId('version-history-save-version').click();
+    await editor.saveNamedVersion('Initial draft');
     await page.waitForSelector('[data-testid="version-history-version-row"]');
 
     await editor.focus();
     await editor.typeText(' A freshly added sentence.');
-    page.once('dialog', (d) => d.accept('Post-edit checkpoint'));
-    await page.getByTestId('version-history-save-version').click();
+    await editor.saveNamedVersion('Post-edit checkpoint');
     await page.waitForFunction(
       () => document.querySelectorAll('[data-testid="version-history-version-row"]').length >= 2
     );
@@ -72,8 +70,7 @@ test.describe('Version preview', () => {
 
     await editor.focus();
     await editor.typeText('Only version.');
-    page.once('dialog', (d) => d.accept('Sole version'));
-    await page.getByTestId('version-history-save-version').click();
+    await editor.saveNamedVersion('Sole version');
     await page.waitForSelector('[data-testid="version-history-version-row"]');
 
     await page.getByText('Sole version').click();

--- a/docx-editor/e2e/tests/vh-change-nav.spec.ts
+++ b/docx-editor/e2e/tests/vh-change-nav.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+test('preview change navigation scrolls between changes', async ({ page }) => {
+  test.setTimeout(70000);
+  const editor = new EditorPage(page);
+  await editor.goto(); await editor.waitForReady(); await editor.newDocument(); await editor.focus();
+  // Build a tall doc.
+  for (let i = 0; i < 20; i++) { await editor.typeText(`Original paragraph ${i} of the document body. `); await editor.pressEnter(); }
+  await page.waitForTimeout(2200);
+  await page.getByRole('button', { name: 'Version history' }).click();
+  await page.waitForSelector('[data-testid="version-history-panel"]');
+  page.once('dialog', (d) => d.accept('v1'));
+  await page.getByTestId('version-history-save-version').click();
+  await page.waitForSelector('[data-testid="version-history-version-row"]');
+  // Edit near the top and near the bottom so changes are spread out.
+  await editor.focus();
+  await editor.selectText('Original paragraph 1 ');
+  await editor.typeText('EDITED-TOP paragraph one ');
+  await editor.selectText('Original paragraph 18 ');
+  await editor.typeText('EDITED-BOTTOM paragraph eighteen ');
+  page.once('dialog', (d) => d.accept('v2'));
+  await page.getByTestId('version-history-save-version').click();
+  await page.waitForFunction(() => document.querySelectorAll('[data-testid="version-history-version-row"]').length >= 2);
+  // Preview the latest (v2) with show changes.
+  await page.locator('[data-testid="version-history-version-row"]').first().click();
+  await page.waitForSelector('[data-testid="version-preview-overlay"]');
+  await page.waitForTimeout(400);
+  await expect(page.getByTestId('version-preview-next-change')).toBeVisible();
+  const scrollTop = () => page.evaluate(() => {
+    const ov = document.querySelector('[data-testid="version-preview-overlay"]')!;
+    const sc = Array.from(ov.querySelectorAll('div')).find(d => getComputedStyle(d).overflowY === 'auto') as HTMLElement;
+    return sc?.scrollTop ?? -1;
+  });
+  const before = await scrollTop();
+  await page.getByTestId('version-preview-next-change').click();
+  await page.waitForTimeout(500);
+  const after = await scrollTop();
+  console.log('SCROLL before', before, 'after', after);
+  expect(after).toBeGreaterThan(before);
+});

--- a/docx-editor/e2e/tests/vh-change-nav.spec.ts
+++ b/docx-editor/e2e/tests/vh-change-nav.spec.ts
@@ -9,8 +9,7 @@ test('preview change navigation scrolls between changes', async ({ page }) => {
   await page.waitForTimeout(2200);
   await page.getByRole('button', { name: 'Version history' }).click();
   await page.waitForSelector('[data-testid="version-history-panel"]');
-  page.once('dialog', (d) => d.accept('v1'));
-  await page.getByTestId('version-history-save-version').click();
+  await editor.saveNamedVersion('v1');
   await page.waitForSelector('[data-testid="version-history-version-row"]');
   // Edit near the top and near the bottom so changes are spread out.
   await editor.focus();
@@ -18,8 +17,7 @@ test('preview change navigation scrolls between changes', async ({ page }) => {
   await editor.typeText('EDITED-TOP paragraph one ');
   await editor.selectText('Original paragraph 18 ');
   await editor.typeText('EDITED-BOTTOM paragraph eighteen ');
-  page.once('dialog', (d) => d.accept('v2'));
-  await page.getByTestId('version-history-save-version').click();
+  await editor.saveNamedVersion('v2');
   await page.waitForFunction(() => document.querySelectorAll('[data-testid="version-history-version-row"]').length >= 2);
   // Preview the latest (v2) with show changes.
   await page.locator('[data-testid="version-history-version-row"]').first().click();

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -2220,6 +2220,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   const versionCapture = useVersionHistoryCapture({
     docId: documentName?.trim() || 'Untitled',
     view: bodyView,
+    author,
   });
 
   // Restore a snapshot's PM doc JSON into the live editor. Mirrors
@@ -2261,6 +2262,37 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     if (versionPreview) handleRestoreSnapshot(versionPreview.data);
     setVersionPreview(null);
   }, [versionPreview, handleRestoreSnapshot]);
+
+  // Step the preview between changes (Google-Docs ^ / v). Walks the painted
+  // diff marks (.docx-insertion / .docx-deletion) inside the preview scroll
+  // container, clustering marks that sit on the same line into one stop, and
+  // nudges scrollTop so the next/previous change lands near the top. Uses
+  // viewport-relative deltas (not scrollIntoView) so the zoom transform on the
+  // preview's pages doesn't throw the math off.
+  const stepPreviewChange = useCallback((dir: 'next' | 'prev') => {
+    const sc = previewScrollRef.current;
+    if (!sc) return;
+    const marks = Array.from(
+      sc.querySelectorAll('.docx-insertion, .docx-deletion')
+    ) as HTMLElement[];
+    if (marks.length === 0) return;
+    // Cluster by vertical position so a multi-mark edit on one line is a
+    // single stop. Sorted tops; a >24px gap starts a new cluster.
+    const tops = marks.map((m) => m.getBoundingClientRect().top).sort((a, b) => a - b);
+    const stops: number[] = [];
+    for (const t of tops) {
+      if (stops.length === 0 || t - stops[stops.length - 1] > 24) stops.push(t);
+    }
+    const scRect = sc.getBoundingClientRect();
+    const refY = scRect.top + 90; // reference line just below the banner
+    let targetTop: number | undefined;
+    if (dir === 'next') {
+      targetTop = stops.find((t) => t > refY + 4) ?? stops[stops.length - 1];
+    } else {
+      targetTop = [...stops].reverse().find((t) => t < refY - 4) ?? stops[0];
+    }
+    if (targetTop != null) sc.scrollTop += targetTop - refY;
+  }, []);
 
   // Detect whether the collab session wired the Strict co-editing plugin
   // into the body view (only then does the View-menu toggle appear).
@@ -6898,6 +6930,10 @@ body { background: white; }
     try {
       const buffer = await handleSave();
       if (!buffer) return;
+      // Checkpoint a version on explicit save (Google-Docs parity). No-op
+      // when nothing changed since the last capture, so repeated saves don't
+      // pile up identical entries.
+      void versionCapture.captureOnSave();
       // When a parent supplied `onSave`, it owns persistence — `handleSave`
       // has already passed it the buffer. A browser blob download on top
       // of that would drop a duplicate file into ~/Downloads on every Save
@@ -6923,7 +6959,7 @@ body { background: white; }
     } finally {
       setIsSaving(false);
     }
-  }, [handleSave, documentName, markDirty, onSave]);
+  }, [handleSave, documentName, markDirty, onSave, versionCapture]);
 
   // Autosave to IndexedDB (sheet parity). A periodic interval polls the
   // dirty flag every 30s; if dirty, it serializes and writes the buffer.
@@ -8383,6 +8419,20 @@ body { background: white; }
     return ids;
   }, [resolvedCommentIds, expandedSidebarItem]);
 
+  const PREVIEW_CHANGE_NAV_BTN_STYLE: CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 28,
+    height: 28,
+    padding: 0,
+    border: '1px solid var(--doc-border)',
+    borderRadius: 4,
+    background: 'transparent',
+    color: 'var(--doc-text)',
+    cursor: 'pointer',
+  };
+
   const editorContainerStyle: CSSProperties = {
     flex: 1,
     minHeight: 0,
@@ -9135,9 +9185,47 @@ body { background: white; }
                                     {' · '}
                                     {new Date(versionPreview.savedAt).toLocaleString()}
                                   </span>
+                                  {/* Step between changes (Google-Docs ^ / v).
+                                      Only meaningful while a diff is shown. */}
+                                  {previewShowChanges && versionPreview.previousData != null && (
+                                    <span
+                                      style={{
+                                        marginLeft: 'auto',
+                                        display: 'inline-flex',
+                                        alignItems: 'center',
+                                        gap: 2,
+                                      }}
+                                    >
+                                      <Tooltip content="Previous change">
+                                        <button
+                                          type="button"
+                                          onClick={() => stepPreviewChange('prev')}
+                                          data-testid="version-preview-prev-change"
+                                          aria-label="Previous change"
+                                          style={PREVIEW_CHANGE_NAV_BTN_STYLE}
+                                        >
+                                          <MaterialSymbol name="keyboard_arrow_up" size={18} />
+                                        </button>
+                                      </Tooltip>
+                                      <Tooltip content="Next change">
+                                        <button
+                                          type="button"
+                                          onClick={() => stepPreviewChange('next')}
+                                          data-testid="version-preview-next-change"
+                                          aria-label="Next change"
+                                          style={PREVIEW_CHANGE_NAV_BTN_STYLE}
+                                        >
+                                          <MaterialSymbol name="keyboard_arrow_down" size={18} />
+                                        </button>
+                                      </Tooltip>
+                                    </span>
+                                  )}
                                   <label
                                     style={{
-                                      marginLeft: 'auto',
+                                      marginLeft:
+                                        previewShowChanges && versionPreview.previousData != null
+                                          ? 8
+                                          : 'auto',
                                       display: 'inline-flex',
                                       alignItems: 'center',
                                       gap: 6,
@@ -9342,7 +9430,6 @@ body { background: white; }
                       fixed width. */}
                   {showVersionHistory && (
                     <VersionHistoryPanel
-                      history={editHistory}
                       docId={documentName?.trim() || 'Untitled'}
                       saveNamedVersion={versionCapture.saveNamedVersion}
                       onRestoreSnapshot={handleRestoreSnapshot}

--- a/docx-editor/packages/react/src/components/sidebar/VersionHistoryPanel.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/VersionHistoryPanel.tsx
@@ -1,32 +1,22 @@
 /**
- * Version-history side panel — surfaces the feed produced by
- * `useEditHistory` as a scrollable timeline with a revert button
- * per entry. Mirrors the Sheets `HistoryPanel` shape so the two
- * products feel like cousins.
+ * Version-history side panel — a single Google-Docs-style timeline of
+ * persisted snapshots (`useVersionHistoryCapture` → IndexedDB store).
+ * Versions are captured automatically (on save + on an idle interval);
+ * "Save version…" only NAMES the current one. There is no separate
+ * "recent edits" feed — the timeline is the one history view.
  *
- * Layout: vertical list, newest-first. Each entry shows author,
- * elapsed-time stamp, coalesced edit count, summary, and a "Revert
- * to here" button. Reverting takes the doc back to the entry's `before`
- * snapshot (captured when the entry opened) and wraps the change in a
- * new transaction so Ctrl+Z reverses the revert.
- *
- * Consumer pattern — solo session:
- *
- *   const history = useEditHistory({ author: 'You' });
- *   useEffect(() => view ? history.attach(view) : undefined, [view, history]);
- *   return <VersionHistoryPanel history={history} />;
- *
- * Collab session — pass `author={presenceName}` so peer entries show
- * the right name when capturing locally-applied transactions; the
- * cross-peer log is the Yjs op-log (out of scope for v1).
+ * Layout: newest-first, grouped by day, with a pinned "Current version"
+ * row. Each row shows a label ("Auto-saved", or the user's name for a
+ * named version), the author who captured it, size, relative time, and a
+ * kebab (preview / rename / restore / delete). Selecting a row opens the
+ * in-canvas preview with an optional changes-vs-previous diff.
  */
-import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { useCallback, useMemo, useState, type CSSProperties } from 'react';
 import { MaterialSymbol } from '../ui/MaterialSymbol';
 import { PanelState } from '../ui/PanelState';
 import { Tooltip } from '../ui/Tooltip';
 import { RightDockPanel } from '../RightDockPanel';
 import { useFixedDropdown } from '../ui/useFixedDropdown';
-import type { EditHistoryEntry, UseEditHistoryReturn } from '../../hooks/useEditHistory';
 import { diffStats, diffWords, extractText } from '../../hooks/wordDiff';
 import { useLiveVersionList } from '../../version-history/useLiveVersionList';
 import type { ServerVersionBackend } from '../../version-history/server-source';
@@ -38,10 +28,8 @@ import {
 } from '../../version-history/store';
 
 export interface VersionHistoryPanelProps {
-  history: UseEditHistoryReturn;
-  /** Active document id — drives the per-doc Versions tab. When null,
-   *  the Versions tab shows a "no document" state and the Activity tab
-   *  is the default. */
+  /** Active document id — drives the per-doc version timeline. When null,
+   *  the panel shows an "open a document" state. */
   docId?: string | null;
   /** Imperative API exposed by `useVersionHistoryCapture`. The "Save
    *  version…" button calls this; if absent, the button is hidden. */
@@ -79,22 +67,13 @@ export interface VersionHistoryPanelProps {
   onRestoreServerVersion?: (version: number) => void;
   /** Display title for the panel. Default "Version history". */
   title?: string;
-  /** Empty-state message when no entries exist yet. */
-  emptyHint?: string;
   /** Optional extra style applied to the panel root. */
   style?: CSSProperties;
 }
 
-type Tab = 'versions' | 'activity';
-
 // Width / outer chrome / header come from RightDockPanel — the old
 // ROOT_STYLE and HEADER_STYLE were removed in Phase 3 (panel chrome
 // unification).
-
-const TABS_STYLE: CSSProperties = {
-  display: 'flex',
-  borderBottom: '1px solid var(--doc-border, #e0e0e0)',
-};
 
 const TAB_CAPTION_STYLE: CSSProperties = {
   padding: '8px 16px 0',
@@ -188,30 +167,6 @@ const AUTHOR_STYLE: CSSProperties = {
   fontWeight: 600,
 };
 
-const SUMMARY_STYLE: CSSProperties = {
-  fontSize: 13,
-  color: 'var(--doc-text-on-surface, #1f2937)',
-};
-
-const REVERT_BUTTON_STYLE: CSSProperties = {
-  alignSelf: 'flex-start',
-  marginTop: 4,
-  padding: '4px 10px',
-  border: '1px solid var(--doc-border-strong, var(--doc-border))',
-  borderRadius: 4,
-  background: 'transparent',
-  color: 'var(--doc-text)',
-  fontSize: 12,
-  cursor: 'pointer',
-};
-
-const ENTRY_ACTIONS_STYLE: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: 8,
-  marginTop: 4,
-};
-
 const STATS_PILL_STYLE: CSSProperties = {
   display: 'inline-flex',
   alignItems: 'center',
@@ -229,46 +184,6 @@ const STAT_ADD_STYLE: CSSProperties = {
 const STAT_REMOVE_STYLE: CSSProperties = {
   color: '#dc2626',
   fontWeight: 600,
-};
-
-const DIFF_BOX_STYLE: CSSProperties = {
-  marginTop: 8,
-  padding: '8px 10px',
-  background: 'var(--doc-surface-sunken, #f6f8fa)',
-  border: '1px solid var(--doc-border-light, #e7eaee)',
-  borderRadius: 6,
-  fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
-  fontSize: 12,
-  lineHeight: 1.5,
-  whiteSpace: 'pre-wrap',
-  wordBreak: 'break-word',
-  maxHeight: 320,
-  overflow: 'auto',
-};
-
-const DIFF_ADD_STYLE: CSSProperties = {
-  background: '#defbe1',
-  color: '#15803d',
-  borderRadius: 2,
-  padding: '0 2px',
-};
-
-const DIFF_REMOVE_STYLE: CSSProperties = {
-  background: '#fde2e1',
-  color: '#b91c1c',
-  borderRadius: 2,
-  padding: '0 2px',
-  textDecoration: 'line-through',
-};
-
-const SHOW_DIFF_BTN_STYLE: CSSProperties = {
-  padding: '4px 8px',
-  border: '1px solid transparent',
-  borderRadius: 4,
-  background: 'transparent',
-  color: 'var(--doc-primary, #1a73e8)',
-  fontSize: 12,
-  cursor: 'pointer',
 };
 
 const NAMED_FILTER_STYLE: CSSProperties = {
@@ -349,7 +264,6 @@ function relativeTime(time: number, now: number): string {
 }
 
 export function VersionHistoryPanel({
-  history,
   docId = null,
   saveNamedVersion,
   onRestoreSnapshot,
@@ -358,15 +272,9 @@ export function VersionHistoryPanel({
   isPreviewing = false,
   onClose,
   title = 'Version history',
-  emptyHint = 'No edits yet. Type into the document to start recording.',
   serverBackend,
   onRestoreServerVersion,
 }: VersionHistoryPanelProps) {
-  // Default to Versions when we have a docId (the persisted timeline
-  // is what users come here for); Activity is the secondary "what
-  // just changed" feed. With no docId only Activity makes sense.
-  const [tab, setTab] = useState<Tab>(docId ? 'versions' : 'activity');
-
   // Render via the shared RightDockPanel shell so every right-edge
   // panel inherits the same width, header chrome, slide-in motion,
   // and close-X affordance. The tab strip + tab body live in
@@ -379,114 +287,30 @@ export function VersionHistoryPanel({
       ariaLabel={title}
       onClose={onClose ?? (() => {})}
     >
-      <div style={TABS_STYLE} role="tablist" aria-label="Version history tabs">
-        <button
-          type="button"
-          role="tab"
-          aria-selected={tab === 'versions'}
-          data-testid="version-history-tab-versions"
-          onClick={() => setTab('versions')}
-          style={tabButtonStyle(tab === 'versions')}
-        >
-          Versions
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={tab === 'activity'}
-          data-testid="version-history-tab-activity"
-          onClick={() => setTab('activity')}
-          style={tabButtonStyle(tab === 'activity')}
-        >
-          Recent edits
-        </button>
-      </div>
-      {/* One-line explainer so the two timelines aren't mistaken for each
-          other: Versions are durable, named, restorable snapshots; Recent
-          edits is the live, this-session change feed (cleared on reload). */}
+      {/* Single Google-Docs-style timeline. Versions are captured
+          automatically — there's no manual "create version" step; the
+          optional "Save version…" action only NAMES the current one. */}
       <div style={TAB_CAPTION_STYLE} data-testid="version-history-caption">
-        {tab === 'versions'
-          ? 'Saved snapshots you can name, preview, and restore.'
-          : 'Edits from this session — cleared when the document is closed.'}
+        Versions save automatically as you edit — on save and about every 10 minutes. Open one to
+        preview or restore it.
       </div>
-      {tab === 'versions' ? (
-        <VersionsTab
-          docId={docId}
-          saveNamedVersion={saveNamedVersion}
-          onRestoreSnapshot={onRestoreSnapshot}
-          onPreviewVersion={onPreviewVersion}
-          onShowCurrent={onShowCurrent}
-          isPreviewing={isPreviewing}
-          serverBackend={serverBackend}
-          onRestoreServerVersion={onRestoreServerVersion}
-        />
-      ) : (
-        <ActivityTab history={history} emptyHint={emptyHint} />
-      )}
+      <VersionsTab
+        docId={docId}
+        saveNamedVersion={saveNamedVersion}
+        onRestoreSnapshot={onRestoreSnapshot}
+        onPreviewVersion={onPreviewVersion}
+        onShowCurrent={onShowCurrent}
+        isPreviewing={isPreviewing}
+        serverBackend={serverBackend}
+        onRestoreServerVersion={onRestoreServerVersion}
+      />
     </RightDockPanel>
   );
 }
 
 /* ============================================================
-   Activity tab — the existing edit-feed UI (unchanged behavior,
-   just hoisted into a sub-component so the tab container can
-   render either side).
-   ============================================================ */
-
-function ActivityTab({ history, emptyHint }: { history: UseEditHistoryReturn; emptyHint: string }) {
-  // Newest-first display so the latest edit is at the top — humans
-  // scan downward. The hook returns oldest-first so the ring trim
-  // semantics stay obvious.
-  const sorted = useMemo(
-    () => [...history.entries].sort((a, b) => b.time - a.time),
-    [history.entries]
-  );
-  // Precompute (before, after) pairs for each entry. Older entries
-  // use the next-newer entry's `before` as their "after"; the very
-  // latest entry uses the live document text.
-  const afterByEntryId = useMemo(() => {
-    const map = new Map<string, string>();
-    const liveText = history.getCurrentText();
-    let nextAfter = liveText;
-    for (const e of sorted) {
-      map.set(e.id, nextAfter);
-      nextAfter = extractText(e.before);
-    }
-    return map;
-  }, [sorted, history]);
-  const now = Date.now();
-
-  return (
-    <>
-      <div style={SUBHEADER_STYLE}>
-        <span>Recent edits</span>
-        <span style={COUNT_STYLE} data-testid="version-history-count">
-          {history.entries.length}
-        </span>
-      </div>
-      {sorted.length === 0 ? (
-        <PanelState kind="empty" message={emptyHint} />
-      ) : (
-        <ol style={LIST_STYLE} role="list">
-          {sorted.map((entry) => (
-            <EditHistoryEntryRow
-              key={entry.id}
-              entry={entry}
-              now={now}
-              afterText={afterByEntryId.get(entry.id) ?? ''}
-              onRevert={() => history.revert(entry.id)}
-              onRevertChange={(op, text, context) => history.revertHunk(op, text, context)}
-            />
-          ))}
-        </ol>
-      )}
-    </>
-  );
-}
-
-/* ============================================================
-   Versions tab — IDB-backed persisted snapshots. Mirrors sheets'
-   `apps/web/src/shell/VersionHistoryPanel.tsx` VersionsTab.
+   Versions timeline — IDB-backed persisted snapshots (auto-saved +
+   named). Mirrors sheets' `apps/web/src/shell/VersionHistoryPanel.tsx`.
    ============================================================ */
 
 function VersionsTab({
@@ -760,7 +584,9 @@ function VersionRow({
       }
     >
       <div style={ENTRY_HEAD_STYLE}>
-        <span style={AUTHOR_STYLE}>{snap.name}</span>
+        {/* Auto snapshots show a clean "Auto-saved" label (the time sits on
+            the right); only named versions surface their user-given name. */}
+        <span style={AUTHOR_STYLE}>{snap.kind === 'manual' ? snap.name : 'Auto-saved'}</span>
         {snap.kind === 'manual' && (
           <Tooltip content="Named version — kept until deleted">
             <span style={KIND_BADGE_STYLE} tabIndex={0}>
@@ -785,8 +611,12 @@ function VersionRow({
           <RowKebabMenu items={menuItems} />
         </span>
       </div>
-      {typeof snap.size === 'number' && snap.size > 0 && (
-        <div style={SIZE_STYLE}>{formatSize(snap.size)}</div>
+      {(snap.author || (typeof snap.size === 'number' && snap.size > 0)) && (
+        <div style={SIZE_STYLE}>
+          {snap.author && <span data-testid="version-history-author">{snap.author}</span>}
+          {snap.author && typeof snap.size === 'number' && snap.size > 0 && ' · '}
+          {typeof snap.size === 'number' && snap.size > 0 && formatSize(snap.size)}
+        </div>
       )}
       {stats && (stats.added > 0 || stats.removed > 0) && (
         <div style={STATS_PILL_STYLE} data-testid="version-history-version-stats">
@@ -924,188 +754,4 @@ function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function tabButtonStyle(active: boolean): CSSProperties {
-  return {
-    flex: 1,
-    padding: '8px 12px',
-    border: 'none',
-    background: 'transparent',
-    color: active ? 'var(--doc-primary, #1a73e8)' : 'var(--doc-text-muted)',
-    fontSize: 13,
-    fontWeight: active ? 600 : 400,
-    borderBottom: active ? '2px solid var(--doc-primary, #1a73e8)' : '2px solid transparent',
-    cursor: 'pointer',
-  };
-}
-
-function EditHistoryEntryRow({
-  entry,
-  now,
-  afterText,
-  onRevert,
-  onRevertChange,
-}: {
-  entry: EditHistoryEntry;
-  now: number;
-  afterText: string;
-  onRevert: () => void;
-  onRevertChange: (op: 'add' | 'remove', text: string, context: string) => boolean;
-}) {
-  const canRevert = entry.before != null;
-  const [showDiff, setShowDiff] = useState(false);
-
-  // Compute the diff only when expanded — LCS is O(N*M) so we don't
-  // want to spin it on every panel re-render for entries the user
-  // hasn't asked to see. The result is memoised against the snapshot
-  // strings so toggling expanded keeps the same value.
-  const diff = useMemo(() => {
-    if (!showDiff) return null;
-    const before = extractText(entry.before).slice(0, DIFF_TRUNCATE_LIMIT);
-    const after = afterText.slice(0, DIFF_TRUNCATE_LIMIT);
-    return diffWords(before, after);
-  }, [showDiff, entry.before, afterText]);
-
-  // Stats (added/removed words) shown on the row at all times.
-  //
-  // PREVIOUSLY: setState was called inside `useMemo`, which is a
-  // React anti-pattern — under some renders it produced
-  // "Too many re-renders" (error #185) and crashed the whole editor
-  // (user-reported as "page becomes unresponsive"). useEffect is the
-  // correct hook for the side-effect of writing computed state.
-  const [stats, setStats] = useState<{ added: number; removed: number } | null>(null);
-  useEffect(() => {
-    if (!afterText && entry.before == null) {
-      setStats(null);
-      return;
-    }
-    const before = extractText(entry.before).slice(0, DIFF_TRUNCATE_LIMIT);
-    const after = afterText.slice(0, DIFF_TRUNCATE_LIMIT);
-    const segments = diffWords(before, after);
-    setStats(diffStats(segments));
-  }, [entry.before, afterText]);
-
-  return (
-    <li style={ENTRY_STYLE}>
-      <div style={ENTRY_HEAD_STYLE}>
-        <span style={AUTHOR_STYLE}>{entry.author}</span>
-        <span>·</span>
-        <Tooltip content={new Date(entry.time).toLocaleString()}>
-          <span tabIndex={0} style={{ outline: 'none' }}>
-            {relativeTime(entry.time, now)}
-          </span>
-        </Tooltip>
-        {entry.txCount > 1 && <span style={{ marginLeft: 'auto' }}>{entry.txCount} edits</span>}
-      </div>
-      <div style={SUMMARY_STYLE}>{entry.summary}</div>
-
-      {stats && (stats.added > 0 || stats.removed > 0) && (
-        <div style={STATS_PILL_STYLE} data-testid="version-history-stats">
-          {stats.added > 0 && <span style={STAT_ADD_STYLE}>+{stats.added}</span>}
-          {stats.added > 0 && stats.removed > 0 && <span>·</span>}
-          {stats.removed > 0 && <span style={STAT_REMOVE_STYLE}>-{stats.removed}</span>}
-          <span>word{stats.added + stats.removed === 1 ? '' : 's'}</span>
-        </div>
-      )}
-
-      <div style={ENTRY_ACTIONS_STYLE}>
-        <Tooltip content={canRevert ? 'Revert document to this point' : 'Snapshot unavailable'}>
-          <button
-            type="button"
-            onClick={onRevert}
-            disabled={!canRevert}
-            aria-label={`Revert to ${entry.summary}`}
-            style={REVERT_BUTTON_STYLE}
-          >
-            Revert to here
-          </button>
-        </Tooltip>
-        <button
-          type="button"
-          onClick={() => setShowDiff((v) => !v)}
-          style={SHOW_DIFF_BTN_STYLE}
-          aria-expanded={showDiff}
-          data-testid="version-history-toggle-diff"
-        >
-          {showDiff ? 'Hide changes' : 'Show changes'}
-        </button>
-      </div>
-
-      {showDiff && diff && (
-        <pre style={DIFF_BOX_STYLE} data-testid="version-history-diff">
-          {diff.map((seg, i) => {
-            if (seg.op === 'keep') return <span key={i}>{seg.text}</span>;
-            // Anchor context = last 30 chars of the preceding `keep`
-            // run. Disambiguates identical substrings — e.g. typing
-            // "hello" in two paragraphs reverts the right one.
-            const prevKept = (() => {
-              for (let j = i - 1; j >= 0; j--) {
-                if (diff[j]!.op === 'keep') return diff[j]!.text.slice(-30);
-                // A non-keep segment between us and the previous keep
-                // means there's no clean disambiguating prefix; bail
-                // and use empty context. Could be improved by chaining
-                // through adjacent changes, but the common case is
-                // single-keep gaps.
-                break;
-              }
-              return '';
-            })();
-            // `seg.op` is now narrowed to `'add' | 'remove'` because
-            // the `keep` branch returned `<span>` above.
-            const opForRevert: 'add' | 'remove' = seg.op;
-            const onRevertHunk = (): void => {
-              const ok = onRevertChange(opForRevert, seg.text, prevKept);
-              if (!ok) {
-                // Soft-fail — no toast plumbing into this leaf
-                // component; aria-live label updates so screen readers
-                // know. The Cmd+Z path still works for users who
-                // expected the previous behaviour.
-              }
-            };
-            if (seg.op === 'add') {
-              return (
-                <ins
-                  key={i}
-                  style={DIFF_ADD_STYLE}
-                  role="button"
-                  tabIndex={0}
-                  title="Revert this insertion"
-                  data-testid="version-history-diff-add"
-                  onClick={onRevertHunk}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      onRevertHunk();
-                    }
-                  }}
-                >
-                  {seg.text}
-                </ins>
-              );
-            }
-            return (
-              <del
-                key={i}
-                style={DIFF_REMOVE_STYLE}
-                role="button"
-                tabIndex={0}
-                title="Bring this text back"
-                data-testid="version-history-diff-remove"
-                onClick={onRevertHunk}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    onRevertHunk();
-                  }
-                }}
-              >
-                {seg.text}
-              </del>
-            );
-          })}
-        </pre>
-      )}
-    </li>
-  );
 }

--- a/docx-editor/packages/react/src/paged-editor/SmartChipMenu.tsx
+++ b/docx-editor/packages/react/src/paged-editor/SmartChipMenu.tsx
@@ -114,14 +114,14 @@ export function SmartChipMenu({
         left: caret.x * zoom,
         top: (caret.y + caret.height) * zoom + 4,
         minWidth: 200,
-        background: '#fff',
-        border: '1px solid #dadce0',
+        background: 'var(--doc-surface, #fff)',
+        border: '1px solid var(--doc-border-light, #dadce0)',
         borderRadius: 8,
-        boxShadow: '0 2px 10px rgba(0,0,0,0.18)',
+        boxShadow: 'var(--doc-shadow, 0 2px 10px rgba(0,0,0,0.18))',
         padding: '6px 0',
         zIndex: 220,
         fontSize: 13,
-        color: '#202124',
+        color: 'var(--doc-text-on-surface, #202124)',
       }}
     >
       {filtered.map((it, i) => (
@@ -145,7 +145,7 @@ export function SmartChipMenu({
             height: ROW_HEIGHT,
             padding: '0 14px',
             border: 'none',
-            background: i === active ? '#e8f0fe' : 'transparent',
+            background: i === active ? 'var(--doc-primary-light, #e8f0fe)' : 'transparent',
             color: 'inherit',
             font: 'inherit',
             textAlign: 'left',
@@ -159,14 +159,18 @@ export function SmartChipMenu({
               display: 'inline-flex',
               width: 18,
               height: 18,
-              color: '#5f6368',
+              color: 'var(--doc-text-subtle, #5f6368)',
               flexShrink: 0,
             }}
           >
             {it.icon}
           </span>
           <span style={{ flex: 1 }}>{it.label}</span>
-          {it.hint && <span style={{ color: '#80868b', fontSize: 12 }}>{it.hint}</span>}
+          {it.hint && (
+            <span style={{ color: 'var(--doc-text-subtle, #80868b)', fontSize: 12 }}>
+              {it.hint}
+            </span>
+          )}
         </button>
       ))}
     </div>

--- a/docx-editor/packages/react/src/version-history/store.ts
+++ b/docx-editor/packages/react/src/version-history/store.ts
@@ -54,6 +54,9 @@ export interface VersionSnapshot {
   /** Source format at capture, for round-trip on later "Save as" from
    *  a preview. Currently always `'docx'`; here as a forward hook. */
   sourceFormat: string | null;
+  /** Display name of who captured this version (the local editor). Absent
+   *  on older records and server-backed entries. */
+  author?: string;
   /** Full ProseMirror doc JSON — `view.state.doc.toJSON()` output.
    *  Undefined for server-backed entries (their bytes are fetched on
    *  restore, not held in the list). */

--- a/docx-editor/packages/react/src/version-history/useVersionHistoryCapture.ts
+++ b/docx-editor/packages/react/src/version-history/useVersionHistoryCapture.ts
@@ -49,6 +49,9 @@ export interface UseVersionHistoryCaptureOptions {
   /** Optional source format passed through onto the snapshot record
    *  (`'docx'` today; here for forward compatibility). */
   sourceFormat?: string | null;
+  /** Display name of the local editor, stamped onto each captured
+   *  snapshot so the timeline can show who made the changes. */
+  author?: string | null;
 }
 
 export interface UseVersionHistoryCaptureReturn {
@@ -56,6 +59,9 @@ export interface UseVersionHistoryCaptureReturn {
    *  Returns the new snapshot id, or `null` if the view / docId
    *  isn't ready. */
   saveNamedVersion: (name: string) => Promise<number | null>;
+  /** Capture an automatic snapshot on an explicit save. No-op (returns
+   *  `null`) when nothing changed since the last capture. */
+  captureOnSave: () => Promise<number | null>;
 }
 
 /** Imperative escape hatch outside React — the File menu can wire
@@ -76,6 +82,7 @@ export function useVersionHistoryCapture(
     enabled = true,
     idleIntervalMs = DEFAULT_IDLE_INTERVAL_MS,
     sourceFormat = null,
+    author = null,
   } = options;
 
   // Ensure the live feed exists before any subscriber mounts.
@@ -87,9 +94,10 @@ export function useVersionHistoryCapture(
   const optsRef = useRef<{
     docId: string | null;
     sourceFormat: string | null;
+    author: string | null;
     view: EditorView | null;
-  }>({ docId, sourceFormat, view });
-  optsRef.current = { docId, sourceFormat, view };
+  }>({ docId, sourceFormat, author, view });
+  optsRef.current = { docId, sourceFormat, author, view };
 
   // Module-scope dirty flag — set by the observe plugin, read by the
   // interval. A ref so re-renders don't reset it.
@@ -97,7 +105,12 @@ export function useVersionHistoryCapture(
 
   const doCapture = useRef(
     async (kind: 'auto' | 'manual', name: string): Promise<number | null> => {
-      const { view: liveView, docId: liveDocId, sourceFormat: liveFmt } = optsRef.current;
+      const {
+        view: liveView,
+        docId: liveDocId,
+        sourceFormat: liveFmt,
+        author: liveAuthor,
+      } = optsRef.current;
       if (!liveView || !liveDocId) return null;
       try {
         const data = liveView.state.doc.toJSON();
@@ -107,6 +120,7 @@ export function useVersionHistoryCapture(
           name,
           savedAt: Date.now(),
           sourceFormat: liveFmt,
+          author: liveAuthor ?? undefined,
           data,
         });
         return id;
@@ -189,6 +203,18 @@ export function useVersionHistoryCapture(
   return {
     saveNamedVersion: (name: string) =>
       doCapture.current('manual', name.trim() || 'Untitled version'),
+    // Capture an automatic snapshot on an explicit user save (Ctrl+S /
+    // File → Save), matching Google Docs' checkpoint-on-save. Gated on the
+    // dirty flag so repeated saves with no edits don't pile up identical
+    // versions; resets dirty so the idle interval won't immediately re-capture.
+    captureOnSave: async (): Promise<number | null> => {
+      if (!dirtyRef.current) return null;
+      const liveDocId = optsRef.current.docId;
+      if (!liveDocId) return null;
+      const id = await doCapture.current('auto', deriveAutoLabel(liveDocId));
+      if (id != null) dirtyRef.current = false;
+      return id;
+    },
   };
 }
 


### PR DESCRIPTION
Re-lands two follow-up commits that were orphaned when #167 and #171 squash-merged before the follow-ups were pushed (the squash captured only each branch's first commit). Both pieces were verified locally but never reached `main`.

**1. Version-history rework (Google-Docs model)** — the substance intended for #171:
- One auto-saved timeline; the separate "Activity"/recent-edits tab is removed.
- A version is captured on explicit save (Ctrl+S / File → Save), not just the idle interval (deduped on dirty).
- Each snapshot is stamped with its author; auto entries read as "Auto-saved" with the time; the panel states versions save automatically.
- Up/down change navigation in the in-canvas preview (steps between `.docx-insertion`/`.docx-deletion` clusters) — composed correctly with the #169 viewport-pinned portal.
- Dead recent-edits code (ActivityTab, EditHistoryEntryRow) removed; e2e specs updated; new `vh-change-nav` spec.

**2. Smart-chip dark-mode tokens** — the `@` menu hardcoded white; now uses the popover design tokens.

Verified on this branch: typecheck clean, version-history + change-nav + smart-chip + panel-state specs pass (change-nav scrolls correctly through the portal).