### PR TITLE
feat(editor): grammar check (blue squiggle + right-click fix)

### DIFF
--- a/docx-editor/.changeset/grammar-check.md
+++ b/docx-editor/.changeset/grammar-check.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': minor
+---
+
+Add grammar checking (Tools → Grammar check). A pluggable `GrammarExtension` paints a blue squiggle under likely mistakes; right-clicking shows the reason plus a one-click fix. The default engine is an offline, dependency-free rule set (a/an, repeated words, lowercase "i", "could of" → "could have", space before punctuation) tuned for precision; the provider interface (`setGrammarChecker`) lets a server- or LLM-backed pass replace it without UI changes.

--- a/docx-editor/e2e/tests/grammar-check.spec.ts
+++ b/docx-editor/e2e/tests/grammar-check.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Grammar check — toggle on, a likely mistake gets a blue squiggle, and the
+ * right-click menu applies the fix into the document.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test.describe('Grammar check', () => {
+  test('flags "a apple" and the fix menu replaces it with "an apple"', async ({ page }) => {
+    test.setTimeout(40_000);
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+    await editor.typeText('I ate a apple.');
+
+    // Tools → Grammar check (off by default).
+    await page.getByRole('button', { name: 'Tools' }).click();
+    await page.getByRole('menuitem', { name: /Grammar check/i }).click();
+
+    // A blue grammar squiggle is painted over the article "a".
+    const squiggle = page.locator('.grammar-error').first();
+    await expect(squiggle).toBeVisible({ timeout: 5000 });
+
+    // Right-click the flagged span → the grammar fix menu opens. The overlay
+    // is pointer-events:none, so go through the mouse API at its centre (a
+    // direct .click() would retry on actionability forever).
+    const box = await squiggle.boundingBox();
+    if (!box) throw new Error('no bbox for .grammar-error');
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2, {
+      button: 'right',
+    });
+    const menu = page.getByTestId('grammar-suggestions-menu');
+    await expect(menu).toBeVisible();
+    await expect(menu).toContainText(/vowel sound/i);
+
+    // Pick the suggested fix → the document now reads "an apple".
+    await page.getByTestId('grammar-suggestion-0').click();
+    await expect(menu).toHaveCount(0);
+
+    const body = page.locator('.layout-page').first();
+    await expect(body).toContainText('an apple');
+    await expect(body).not.toContainText('a apple');
+  });
+
+  test('toggling grammar off clears the squiggles', async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+    await editor.typeText('You could of told me.');
+
+    await page.getByRole('button', { name: 'Tools' }).click();
+    await page.getByRole('menuitem', { name: /Grammar check/i }).click();
+    await expect(page.locator('.grammar-error').first()).toBeVisible({ timeout: 5000 });
+
+    await page.getByRole('button', { name: 'Tools' }).click();
+    await page.getByRole('menuitem', { name: /Grammar check/i }).click();
+    await expect(page.locator('.grammar-error')).toHaveCount(0);
+  });
+});

--- a/docx-editor/packages/core/src/prosemirror/extensions/StarterKit.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/StarterKit.ts
@@ -75,6 +75,7 @@ import { SmartQuotesExtension } from './features/SmartQuotesExtension';
 import { AutocorrectExtension } from './features/AutocorrectExtension';
 import { SmartChipExtension } from './features/SmartChipExtension';
 import { SpellcheckExtension } from './features/SpellcheckExtension';
+import { GrammarExtension } from './features/GrammarExtension';
 import { WordNavigationExtension } from './features/WordNavigationExtension';
 
 export interface StarterKitOptions {
@@ -204,6 +205,10 @@ export function createStarterKit(options: StarterKitOptions = {}): AnyExtension[
   // toggles it on. Off by default so the ~500 KB dictionary download
   // doesn't fire on every page load.
   add('spellcheck', SpellcheckExtension());
+  // Grammar-check decorations — inert until the React side registers a
+  // checker via `setGrammarChecker(...)` and the user toggles it on. Sibling
+  // of spellcheck; paints a blue underline under likely grammar mistakes.
+  add('grammar', GrammarExtension());
   // Word-wise cursor motion (Alt+Arrow on macOS, Ctrl+Arrow elsewhere) +
   // Shift variants to extend. Operates on PM state — the dialog-advertised
   // "move by word" had no working binding before this.

--- a/docx-editor/packages/core/src/prosemirror/extensions/features/GrammarExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/features/GrammarExtension.ts
@@ -1,0 +1,188 @@
+/**
+ * GrammarExtension — paints decorations under likely grammar mistakes.
+ *
+ * Sibling of `SpellcheckExtension`: the actual analysis is plugged in by the
+ * React layer through `setGrammarChecker` so this file (in `@eigenpal/docx-core`)
+ * stays engine-agnostic — a curated rule set today, an LLM-backed pass later,
+ * with no change here. While no checker is registered the plugin is inert; once
+ * registered it walks the doc per debounced transaction and rebuilds a
+ * DecorationSet of `class: 'grammar-error'` inline ranges, each carrying its
+ * issue (message + suggested replacements) on the decoration spec.
+ *
+ * Rendering is handled by `DecorationLayer` (see CLAUDE.md → Dual Rendering
+ * System); `.grammar-error` is styled in `editor.css` as a blue underline,
+ * distinct from spell-check's red, matching Google Docs.
+ */
+
+import { Plugin, PluginKey } from 'prosemirror-state';
+import { Decoration, DecorationSet, type EditorView } from 'prosemirror-view';
+import type { Node as ProseMirrorNode } from 'prosemirror-model';
+import { createExtension } from '../create';
+import { Priority } from '../types';
+import type { ExtensionRuntime } from '../types';
+
+/**
+ * A grammar match in PLAIN TEXT coordinates (offsets into the string handed to
+ * `check`). The plugin maps these onto document positions.
+ */
+export interface GrammarMatch {
+  /** Start offset in the checked text (inclusive). */
+  start: number;
+  /** End offset in the checked text (exclusive). */
+  end: number;
+  /** Human-readable explanation, e.g. `Use "an" before a vowel sound`. */
+  message: string;
+  /** Ordered replacement candidates; the first is the primary fix. */
+  replacements: string[];
+}
+
+/**
+ * A grammar issue resolved to DOCUMENT positions, carried on the decoration
+ * spec so the context menu can read it back on a right-click.
+ */
+export interface GrammarIssue {
+  from: number;
+  to: number;
+  message: string;
+  replacements: string[];
+}
+
+/**
+ * Injection point — the React package registers a checker on mount. Kept tiny
+ * so a rule engine, a server pass, or an LLM can drop in without touching this
+ * file.
+ */
+export interface GrammarChecker {
+  /** True when grammar-check is currently enabled. */
+  isEnabled(): boolean;
+  /** Analyse one textblock's plain text, returning matches (text offsets). */
+  check(text: string): GrammarMatch[];
+  /** Version bumps when enable/disable flips so we can invalidate the set. */
+  version(): number;
+}
+
+let checker: GrammarChecker | null = null;
+
+export function setGrammarChecker(impl: GrammarChecker | null): void {
+  checker = impl;
+}
+
+export const grammarPluginKey = new PluginKey<{ version: number; decos: DecorationSet }>('grammar');
+
+/**
+ * Build the per-textblock text plus a parallel map from each character index
+ * back to its document position. Inline atoms (fields, images) flush the
+ * current run so a rule can't span across them, and their positions never leak
+ * into the map.
+ */
+function collectIssues(doc: ProseMirrorNode): GrammarIssue[] {
+  if (!checker) return [];
+  const out: GrammarIssue[] = [];
+
+  doc.descendants((node, pos) => {
+    if (!node.isTextblock) return;
+    let text = '';
+    const map: number[] = []; // map[i] = doc position of text[i]
+    const inner = pos + 1; // first child position
+
+    const flush = (): void => {
+      if (text.length === 0) return;
+      let matches: GrammarMatch[];
+      try {
+        matches = checker!.check(text);
+      } catch {
+        matches = [];
+      }
+      for (const m of matches) {
+        if (m.start < 0 || m.end > text.length || m.start >= m.end) continue;
+        const from = map[m.start];
+        const to = map[m.end - 1] + 1;
+        if (from == null || to == null) continue;
+        out.push({ from, to, message: m.message, replacements: m.replacements });
+      }
+      text = '';
+      map.length = 0;
+    };
+
+    node.forEach((child, offset) => {
+      if (child.isText && child.text) {
+        const base = inner + offset;
+        for (let i = 0; i < child.text.length; i++) {
+          text += child.text[i];
+          map.push(base + i);
+        }
+      } else {
+        // Atom / inline node — break the run so no match crosses it.
+        flush();
+      }
+    });
+    flush();
+  });
+
+  return out;
+}
+
+function buildDecorations(doc: ProseMirrorNode): DecorationSet {
+  if (!checker || !checker.isEnabled()) return DecorationSet.empty;
+  const issues = collectIssues(doc);
+  if (issues.length === 0) return DecorationSet.empty;
+  const decos = issues.map((issue) =>
+    Decoration.inline(issue.from, issue.to, { class: 'grammar-error' }, { issue })
+  );
+  return DecorationSet.create(doc, decos);
+}
+
+export const GrammarExtension = createExtension({
+  name: 'grammar',
+  priority: Priority.Low,
+  onSchemaReady(): ExtensionRuntime {
+    return {
+      plugins: [
+        new Plugin({
+          key: grammarPluginKey,
+          state: {
+            init(_, { doc }) {
+              return { version: checker?.version() ?? 0, decos: buildDecorations(doc) };
+            },
+            apply(tr, prev) {
+              const currentVersion = checker?.version() ?? 0;
+              const forceRefresh = tr.getMeta(grammarPluginKey) === 'refresh';
+              if (!tr.docChanged && currentVersion === prev.version && !forceRefresh) {
+                return prev;
+              }
+              return { version: currentVersion, decos: buildDecorations(tr.doc) };
+            },
+          },
+          props: {
+            decorations(state) {
+              return grammarPluginKey.getState(state)?.decos ?? DecorationSet.empty;
+            },
+          },
+        }),
+      ],
+    };
+  },
+});
+
+/**
+ * Read the grammar issue at a document position, or null. Used by the context
+ * menu to surface the message + fixes for a right-clicked `.grammar-error` span.
+ */
+export function getGrammarIssueAt(view: EditorView, pos: number): GrammarIssue | null {
+  const state = grammarPluginKey.getState(view.state);
+  if (!state) return null;
+  const hits = state.decos.find(pos, pos);
+  for (const hit of hits) {
+    const issue = (hit.spec as { issue?: GrammarIssue }).issue;
+    if (issue) return issue;
+  }
+  return null;
+}
+
+/**
+ * Ask any open editor to refresh its decorations — call after toggling the
+ * checker on/off.
+ */
+export function refreshGrammarDecorations(view: EditorView): void {
+  view.dispatch(view.state.tr.setMeta(grammarPluginKey, 'refresh'));
+}

--- a/docx-editor/packages/core/src/prosemirror/extensions/index.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/index.ts
@@ -48,6 +48,17 @@ export {
 } from './features/SpellcheckExtension';
 export type { SpellChecker } from './features/SpellcheckExtension';
 
+// Grammar-check — sibling of spellcheck; the React layer plugs in the actual
+// analysis engine via `setGrammarChecker`.
+export {
+  GrammarExtension,
+  setGrammarChecker,
+  refreshGrammarDecorations,
+  getGrammarIssueAt,
+  grammarPluginKey,
+} from './features/GrammarExtension';
+export type { GrammarChecker, GrammarMatch, GrammarIssue } from './features/GrammarExtension';
+
 // Re-export specific extensions consumers commonly customize
 export {
   ParagraphChangeTrackerExtension,

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -223,6 +223,8 @@ import {
   type EditorPreferences,
   setSpellChecker,
   refreshSpellcheckDecorations,
+  setGrammarChecker,
+  refreshGrammarDecorations,
 } from '@eigenpal/docx-core/prosemirror/extensions';
 import {
   getSpellCheckerImpl,
@@ -232,7 +234,9 @@ import {
   suggestionsFor,
   ignoreWord,
 } from '../lib/spellcheck/service';
+import { getGrammarCheckerImpl, isGrammarEnabled, setGrammarEnabled } from '../lib/grammar/service';
 import { SpellSuggestionsMenu } from './SpellSuggestionsMenu';
+import { GrammarSuggestionsMenu } from './GrammarSuggestionsMenu';
 import { bootWriterController, useWriterState } from '../lib/writer/controller';
 import { rewriteFragment, sampleContext } from '../lib/writer/rewriteFragment';
 import {
@@ -2808,6 +2812,15 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     suggestions: string[];
   } | null>(null);
 
+  const [grammarMenu, setGrammarMenu] = useState<{
+    x: number;
+    y: number;
+    from: number;
+    to: number;
+    message: string;
+    replacements: string[];
+  } | null>(null);
+
   // Spell-check runtime toggle. Off by default — the ~500 KB Hunspell
   // dictionary downloads lazily the first time the user flips this on.
   // Persisted to localStorage so the choice survives reloads.
@@ -2828,6 +2841,25 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     return () => {
       setSpellChecker(null);
     };
+  }, []);
+
+  const GRAMMAR_KEY = 'docx-editor-grammar-enabled';
+  const [grammarOn, setGrammarOn] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    try {
+      return window.localStorage.getItem(GRAMMAR_KEY) === '1';
+    } catch {
+      return false;
+    }
+  });
+  useEffect(() => {
+    setGrammarChecker(getGrammarCheckerImpl());
+    // Restore the persisted on-state so reopening keeps grammar active.
+    if (grammarOn) setGrammarEnabled(true);
+    return () => {
+      setGrammarChecker(null);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const handlePreferenceChange = useCallback(
     <K extends keyof EditorPreferences>(key: K, value: EditorPreferences[K]) => {
@@ -5405,6 +5437,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         inlinePositionEmu?: { horizontalEmu: number; verticalEmu: number };
       } | null;
       spellcheck?: { from: number; to: number; word: string } | null;
+      grammar?: {
+        from: number;
+        to: number;
+        message: string;
+        replacements: string[];
+      } | null;
     }) => {
       // Spell-check hit takes priority over both image and text menus —
       // matches Word's behaviour where a misspelled word's right-click
@@ -5417,6 +5455,18 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
           to: data.spellcheck.to,
           word: data.spellcheck.word,
           suggestions: suggestionsFor(data.spellcheck.word, 5),
+        });
+        return;
+      }
+      // Grammar hit pre-empts the standard menu too (mirrors spell-check).
+      if (data.grammar) {
+        setGrammarMenu({
+          x: data.x,
+          y: data.y,
+          from: data.grammar.from,
+          to: data.grammar.to,
+          message: data.grammar.message,
+          replacements: data.grammar.replacements,
         });
         return;
       }
@@ -5475,6 +5525,28 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     if (view) refreshSpellcheckDecorations(view);
     setSpellMenu(null);
   }, [getActiveEditorView, spellMenu]);
+
+  // Apply a grammar fix: replace the flagged span with the suggestion,
+  // preserving the marks at the start so formatting survives.
+  const handlePickGrammarFix = useCallback(
+    (replacement: string) => {
+      const view = getActiveEditorView();
+      if (!view || !grammarMenu) return;
+      const { from, to } = grammarMenu;
+      const docSize = view.state.doc.content.size;
+      const clampedFrom = Math.min(Math.max(from, 0), docSize);
+      const clampedTo = Math.min(Math.max(to, clampedFrom), docSize);
+      const marks = view.state.doc.nodeAt(clampedFrom)?.marks ?? [];
+      const tr = view.state.tr.replaceWith(
+        clampedFrom,
+        clampedTo,
+        view.state.schema.text(replacement, marks)
+      );
+      view.dispatch(tr);
+      setGrammarMenu(null);
+    },
+    [getActiveEditorView, grammarMenu]
+  );
 
   const handleImageWrapApply = useCallback(
     (target: ImageLayoutTarget) => {
@@ -6451,6 +6523,21 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     }
     const view = getActiveEditorView();
     if (view) refreshSpellcheckDecorations(view);
+  }, [getActiveEditorView]);
+
+  const handleToggleGrammar = useCallback(() => {
+    // No dictionary to download — the rule engine is synchronous, so the
+    // flip is instant (unlike spell-check).
+    const next = !isGrammarEnabled();
+    setGrammarEnabled(next);
+    setGrammarOn(next);
+    try {
+      window.localStorage.setItem(GRAMMAR_KEY, next ? '1' : '0');
+    } catch {
+      // Storage denied — toggle still takes effect for the session.
+    }
+    const view = getActiveEditorView();
+    if (view) refreshGrammarDecorations(view);
   }, [getActiveEditorView]);
 
   // Restore from localStorage on mount: if persisted "on", quietly load
@@ -8651,6 +8738,8 @@ body { background: white; }
                       // existing handlers when ready.
                       onToggleSpellcheck={handleToggleSpellcheck}
                       spellcheckEnabled={spellOn}
+                      onToggleGrammar={handleToggleGrammar}
+                      grammarEnabled={grammarOn}
                       onOpenCitations={handleOpenCitations}
                       onInsertShape={handleInsertShape}
                       onInsertTextBox={handleInsertTextBox}
@@ -9657,6 +9746,19 @@ body { background: white; }
                 onPick={handlePickSpellSuggestion}
                 onIgnore={handleIgnoreSpell}
                 onClose={() => setSpellMenu(null)}
+              />
+            )}
+
+            {/* Grammar fix menu — opens when a right-click landed on a
+                `.grammar-error` decoration. */}
+            {grammarMenu && (
+              <GrammarSuggestionsMenu
+                isOpen={true}
+                position={{ x: grammarMenu.x, y: grammarMenu.y }}
+                message={grammarMenu.message}
+                replacements={grammarMenu.replacements}
+                onPick={handlePickGrammarFix}
+                onClose={() => setGrammarMenu(null)}
               />
             )}
 

--- a/docx-editor/packages/react/src/components/GrammarSuggestionsMenu.tsx
+++ b/docx-editor/packages/react/src/components/GrammarSuggestionsMenu.tsx
@@ -1,0 +1,170 @@
+/**
+ * GrammarSuggestionsMenu — the popup shown when the user right-clicks a
+ * `.grammar-error` span. Sibling of `SpellSuggestionsMenu`, but a grammar issue
+ * leads with an explanation (why it's flagged) above the suggested fix(es),
+ * matching Google Docs. Closes on outside click + Escape; arrow keys + Enter
+ * walk the fixes.
+ */
+
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react';
+import { Z_INDEX } from '../styles/zIndex';
+
+export interface GrammarSuggestionsMenuProps {
+  isOpen: boolean;
+  position: { x: number; y: number };
+  message: string;
+  replacements: string[];
+  onPick: (replacement: string) => void;
+  onClose: () => void;
+}
+
+const menuStyle: CSSProperties = {
+  position: 'fixed',
+  minWidth: 240,
+  maxWidth: 320,
+  background: 'var(--doc-surface, white)',
+  color: 'var(--doc-text-on-surface, #1f2937)',
+  border: '1px solid var(--doc-border-light, #e0e0e0)',
+  borderRadius: 8,
+  boxShadow: 'var(--doc-shadow, 0 2px 10px rgba(0, 0, 0, 0.15))',
+  zIndex: Z_INDEX.contextMenu,
+  padding: '6px 0',
+  overflow: 'hidden',
+};
+
+const messageStyle: CSSProperties = {
+  padding: '6px 14px 8px',
+  fontSize: 12,
+  color: 'var(--doc-text-subtle, #6b7280)',
+  lineHeight: 1.4,
+};
+
+const itemStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  width: '100%',
+  padding: '6px 14px',
+  border: 'none',
+  background: 'transparent',
+  cursor: 'pointer',
+  fontSize: 13,
+  color: 'var(--doc-text-on-surface, #1f2937)',
+  textAlign: 'left',
+};
+
+const itemHoverStyle: CSSProperties = {
+  ...itemStyle,
+  background: 'var(--doc-primary-light, #e8f0fe)',
+};
+
+const dividerStyle: CSSProperties = {
+  height: 1,
+  background: 'var(--doc-border-light, #e0e0e0)',
+  margin: '4px 8px',
+};
+
+export function GrammarSuggestionsMenu({
+  isOpen,
+  position,
+  message,
+  replacements,
+  onPick,
+  onClose,
+}: GrammarSuggestionsMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [hover, setHover] = useState(0);
+
+  // Focusable rows: each replacement, then "Dismiss".
+  const rowCount = replacements.length + 1;
+
+  useEffect(() => {
+    if (isOpen) setHover(0);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onDown = (e: MouseEvent): void => {
+      if (!menuRef.current?.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setHover((h) => (h + 1) % rowCount);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setHover((h) => (h - 1 + rowCount) % rowCount);
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (hover < replacements.length) onPick(replacements[hover]);
+        else onClose();
+      }
+    };
+    // setTimeout(0) — the contextmenu event that opened us would otherwise
+    // close us immediately via the mousedown listener.
+    const timer = window.setTimeout(() => window.addEventListener('mousedown', onDown), 0);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener('mousedown', onDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [isOpen, onClose, onPick, hover, rowCount, replacements]);
+
+  const getStyle = useCallback((): CSSProperties => {
+    const menuWidth = 280;
+    const menuHeight = 40 + rowCount * 32 + 16;
+    let x = position.x;
+    let y = position.y;
+    if (typeof window !== 'undefined') {
+      if (x + menuWidth > window.innerWidth) x = window.innerWidth - menuWidth - 10;
+      if (y + menuHeight > window.innerHeight) y = window.innerHeight - menuHeight - 10;
+      x = Math.max(10, x);
+      y = Math.max(10, y);
+    }
+    return { ...menuStyle, left: x, top: y };
+  }, [position, rowCount]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label="Grammar suggestion"
+      data-testid="grammar-suggestions-menu"
+      style={getStyle()}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <div style={messageStyle}>{message}</div>
+      {replacements.map((r, idx) => (
+        <button
+          key={r}
+          type="button"
+          role="menuitem"
+          style={hover === idx ? itemHoverStyle : itemStyle}
+          onMouseEnter={() => setHover(idx)}
+          onClick={() => onPick(r)}
+          data-testid={`grammar-suggestion-${idx}`}
+        >
+          <strong style={{ fontWeight: 600 }}>{r}</strong>
+        </button>
+      ))}
+      <div style={dividerStyle} />
+      <button
+        type="button"
+        role="menuitem"
+        style={hover === replacements.length ? itemHoverStyle : itemStyle}
+        onMouseEnter={() => setHover(replacements.length)}
+        onClick={onClose}
+        data-testid="grammar-dismiss"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}
+
+export default GrammarSuggestionsMenu;

--- a/docx-editor/packages/react/src/components/TitleBar.tsx
+++ b/docx-editor/packages/react/src/components/TitleBar.tsx
@@ -275,6 +275,8 @@ export function MenuBar() {
     onTranslateDocument,
     onToggleSpellcheck,
     spellcheckEnabled,
+    onToggleGrammar,
+    grammarEnabled,
     onOpenWritingAssistant,
     onOpenExplore,
     onOpenCitations,
@@ -972,6 +974,7 @@ export function MenuBar() {
           onOpenTranslate ||
           onTranslateDocument ||
           onToggleSpellcheck ||
+          onToggleGrammar ||
           onOpenWritingAssistant ||
           onOpenExplore ||
           onOpenCitations) && (
@@ -1026,6 +1029,15 @@ export function MenuBar() {
                       icon: 'spellcheck',
                       label: spellcheckEnabled ? '✓ Spell check' : 'Spell check',
                       onClick: onToggleSpellcheck,
+                    } as MenuEntry,
+                  ]
+                : []),
+              ...(onToggleGrammar
+                ? [
+                    {
+                      icon: 'edit_note',
+                      label: grammarEnabled ? '✓ Grammar check' : 'Grammar check',
+                      onClick: onToggleGrammar,
                     } as MenuEntry,
                   ]
                 : []),

--- a/docx-editor/packages/react/src/components/Toolbar.tsx
+++ b/docx-editor/packages/react/src/components/Toolbar.tsx
@@ -356,6 +356,10 @@ export interface ToolbarProps {
   onToggleSpellcheck?: () => void;
   /** Current spell-check enabled state — drives the menu checkmark. */
   spellcheckEnabled?: boolean;
+  /** Tools → Grammar check — toggles inline grammar decorations. */
+  onToggleGrammar?: () => void;
+  /** Current grammar-check enabled state — drives the menu checkmark. */
+  grammarEnabled?: boolean;
   /** Tools → Writing Assistant — opens the on-device assistant sheet. */
   onOpenWritingAssistant?: () => void;
   /** Tools → Explore — opens the Wikipedia lookup dialog (A3). */

--- a/docx-editor/packages/react/src/lib/grammar/rules.test.ts
+++ b/docx-editor/packages/react/src/lib/grammar/rules.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from 'bun:test';
+import { checkText } from './rules';
+
+/** Convenience: the substrings the engine flagged, in order. */
+function flagged(text: string): string[] {
+  return checkText(text).map((m) => text.slice(m.start, m.end));
+}
+function fixes(text: string): string[] {
+  return checkText(text).flatMap((m) => m.replacements);
+}
+
+describe('grammar rules — precision (no false positives)', () => {
+  test('clean sentence yields nothing', () => {
+    expect(checkText('The quick brown fox jumps over the lazy dog.')).toEqual([]);
+  });
+  test('"a university" is NOT flagged (consonant sound)', () => {
+    expect(checkText('She attends a university downtown.')).toEqual([]);
+  });
+  test('"an hour" is NOT flagged (silent h)', () => {
+    expect(checkText('We waited an hour.')).toEqual([]);
+  });
+  test('"i.e." does not trip the lone-i rule', () => {
+    expect(checkText('Use a delimiter, i.e. a comma.')).toEqual([]);
+  });
+  test('"that that" is allowed', () => {
+    expect(checkText('I think that that approach works.')).toEqual([]);
+  });
+});
+
+describe('grammar rules — catches', () => {
+  test('a → an before a vowel', () => {
+    expect(flagged('I ate a apple.')).toContain('a');
+    expect(fixes('I ate a apple.')).toContain('an');
+  });
+  test('an → a before a consonant', () => {
+    expect(fixes('It was an dog.')).toContain('a');
+  });
+  test('preserves article case', () => {
+    expect(fixes('A apple a day.')).toContain('An');
+  });
+  test('doubled word', () => {
+    expect(flagged('This is the the end.')).toContain('the the');
+    expect(fixes('This is the the end.')).toContain('the');
+  });
+  test('lone lowercase i → I', () => {
+    expect(fixes('Yesterday i went home.')).toContain('I');
+  });
+  test('could of → could have', () => {
+    expect(fixes('You could of told me.')).toContain('could have');
+  });
+  test('space before punctuation', () => {
+    const out = checkText('Wait , what ?');
+    expect(out.length).toBeGreaterThanOrEqual(2);
+    expect(fixes('Wait , what ?')).toContain(',');
+  });
+});

--- a/docx-editor/packages/react/src/lib/grammar/rules.ts
+++ b/docx-editor/packages/react/src/lib/grammar/rules.ts
@@ -1,0 +1,144 @@
+/**
+ * Curated, high-precision grammar rules. Each scans one textblock's plain text
+ * and returns matches in TEXT-OFFSET coordinates (the GrammarExtension maps
+ * them to document positions). The bar is precision over recall — a false
+ * squiggle is worse than a missed one — so rules carry small exception sets and
+ * deliberately skip ambiguous cases (e.g. "a one-time", "that that").
+ *
+ * This is the default engine behind `GrammarChecker`. The provider interface is
+ * intentionally a pure `check(text)` so a server- or LLM-backed pass can replace
+ * it wholesale later without touching the extension or the UI.
+ */
+import type { GrammarMatch } from '@eigenpal/docx-core/prosemirror/extensions';
+
+/** Preserve the capitalisation pattern of `sample` onto `word`. */
+function matchCase(word: string, sample: string): string {
+  if (sample.length > 0 && sample[0] === sample[0].toUpperCase()) {
+    return word.charAt(0).toUpperCase() + word.slice(1);
+  }
+  return word;
+}
+
+/** a/an before the wrong sound. Conservative: skips the common letter-vs-sound
+ *  exceptions ("a university", "an hour") by excluding `u` and `h`. */
+function articleRule(text: string): GrammarMatch[] {
+  const out: GrammarMatch[] = [];
+  const re = /\b(an?)(\s+)([a-zA-Z])/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const article = m[1];
+    const lower = article.toLowerCase();
+    const next = m[3].toLowerCase();
+    const articleStart = m.index;
+    const articleEnd = m.index + article.length;
+    if (lower === 'a' && (next === 'a' || next === 'e' || next === 'i' || next === 'o')) {
+      out.push({
+        start: articleStart,
+        end: articleEnd,
+        message: 'Use “an” before a word that starts with a vowel sound.',
+        replacements: [matchCase('an', article)],
+      });
+    } else if (lower === 'an' && !'aeiouh'.includes(next)) {
+      out.push({
+        start: articleStart,
+        end: articleEnd,
+        message: 'Use “a” before a word that starts with a consonant sound.',
+        replacements: [matchCase('a', article)],
+      });
+    }
+  }
+  return out;
+}
+
+/** Repeated word ("the the"). Skips legitimately-doubled function words. */
+const DOUBLE_WORD_SKIP = new Set(['that', 'had']);
+function doubledWordRule(text: string): GrammarMatch[] {
+  const out: GrammarMatch[] = [];
+  const re = /\b([A-Za-z]+)(\s+)(\1)\b/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    if (DOUBLE_WORD_SKIP.has(m[1].toLowerCase())) continue;
+    out.push({
+      start: m.index,
+      end: m.index + m[0].length,
+      message: `Repeated word “${m[1]}”.`,
+      replacements: [m[1]],
+    });
+    // Step back so "word word word" reports the second pair too.
+    re.lastIndex = m.index + m[1].length;
+  }
+  return out;
+}
+
+/** Standalone lowercase "i" → "I". Space-bounded only, so "i.e." / "iPhone"
+ *  never trip it. */
+function loneIRule(text: string): GrammarMatch[] {
+  const out: GrammarMatch[] = [];
+  const re = /(^|\s)i(?=\s|$)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const start = m.index + m[1].length;
+    out.push({
+      start,
+      end: start + 1,
+      message: 'The pronoun “I” is always capitalized.',
+      replacements: ['I'],
+    });
+  }
+  return out;
+}
+
+/** "could of" → "could have" (and should/would/must/might). */
+function ofHaveRule(text: string): GrammarMatch[] {
+  const out: GrammarMatch[] = [];
+  const re = /\b(could|should|would|must|might)(\s+)of\b/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const fix = `${m[1]} have`;
+    out.push({
+      start: m.index,
+      end: m.index + m[0].length,
+      message: `Did you mean “${fix}”?`,
+      replacements: [fix],
+    });
+  }
+  return out;
+}
+
+/** Space before sentence punctuation ("word ,"). */
+function spaceBeforePunctRule(text: string): GrammarMatch[] {
+  const out: GrammarMatch[] = [];
+  const re = /\s+([,.;:!?])/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    out.push({
+      start: m.index,
+      end: m.index + m[0].length,
+      message: 'Remove the space before the punctuation.',
+      replacements: [m[1]],
+    });
+  }
+  return out;
+}
+
+const RULES = [articleRule, doubledWordRule, loneIRule, ofHaveRule, spaceBeforePunctRule];
+
+/**
+ * Run every rule over `text` and return matches sorted by position, with
+ * overlapping matches dropped (first one wins) so a single span never carries
+ * two conflicting fixes.
+ */
+export function checkText(text: string): GrammarMatch[] {
+  if (!text) return [];
+  const all: GrammarMatch[] = [];
+  for (const rule of RULES) all.push(...rule(text));
+  all.sort((a, b) => a.start - b.start || a.end - b.end);
+  const out: GrammarMatch[] = [];
+  let lastEnd = -1;
+  for (const m of all) {
+    if (m.start < lastEnd) continue; // overlaps a kept match — skip
+    out.push(m);
+    lastEnd = m.end;
+  }
+  return out;
+}

--- a/docx-editor/packages/react/src/lib/grammar/service.ts
+++ b/docx-editor/packages/react/src/lib/grammar/service.ts
@@ -1,0 +1,48 @@
+/**
+ * Grammar-check service — the React-side state + engine the core
+ * `GrammarExtension` plugs into via `setGrammarChecker`. Mirrors
+ * `lib/spellcheck/service.ts`, minus the async dictionary: the default engine
+ * is a synchronous, dependency-free rule set (`rules.ts`), so toggling on is
+ * instant (no download).
+ *
+ * Swapping engines later (server / LLM) means replacing `checkImpl` here; the
+ * extension and UI are unaffected.
+ */
+import type { GrammarChecker, GrammarMatch } from '@eigenpal/docx-core/prosemirror/extensions';
+import { checkText } from './rules';
+
+let enabled = false;
+let version = 0;
+
+export function isGrammarEnabled(): boolean {
+  return enabled;
+}
+
+/** Flip grammar-check on/off. Bumps the version so the plugin invalidates its
+ *  decoration set on the next transaction (or an explicit refresh). */
+export function setGrammarEnabled(next: boolean): void {
+  if (next === enabled) return;
+  enabled = next;
+  version += 1;
+}
+
+export function getGrammarVersion(): number {
+  return version;
+}
+
+/** Pluggable analysis. Default: the curated rule set. */
+let checkImpl: (text: string) => GrammarMatch[] = checkText;
+
+/** Replace the analysis engine (e.g. a Writing-Assistant LLM pass). */
+export function setGrammarEngine(impl: (text: string) => GrammarMatch[]): void {
+  checkImpl = impl;
+  version += 1;
+}
+
+export function getGrammarCheckerImpl(): GrammarChecker {
+  return {
+    isEnabled: isGrammarEnabled,
+    check: (text: string) => (enabled ? checkImpl(text) : []),
+    version: getGrammarVersion,
+  };
+}

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -39,7 +39,7 @@ import { usePinchZoom } from '../components/hooks/usePinchZoom';
 import { ImageSelectionOverlay, type ImageSelectionInfo } from './ImageSelectionOverlay';
 import { EndnoteSection } from './EndnoteSection';
 import { DecorationLayer } from './DecorationLayer';
-import { spellcheckPluginKey } from '@eigenpal/docx-core/prosemirror/extensions';
+import { spellcheckPluginKey, getGrammarIssueAt } from '@eigenpal/docx-core/prosemirror/extensions';
 import { getTableContext } from '@eigenpal/docx-core/prosemirror';
 import {
   smartChipKey,
@@ -356,6 +356,17 @@ export interface PagedEditorProps {
      * dispatch the replacement transaction.
      */
     spellcheck?: { from: number; to: number; word: string } | null;
+    /**
+     * Populated when the right-click landed on a `.grammar-error`
+     * decoration. Carries the flagged range plus the issue's message and
+     * suggested replacements; the host opens a fix menu from it.
+     */
+    grammar?: {
+      from: number;
+      to: number;
+      message: string;
+      replacements: string[];
+    } | null;
   }) => void;
   /** Open the contextual Format panel for the currently-selected object
    *  (image or table). Wired to the on-object "Format" chip. The host
@@ -4054,12 +4065,33 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           }
         }
 
+        // Grammar hit: same idea, against the grammar plugin's decorations.
+        // Each carries its issue (message + fixes) on the decoration spec.
+        let grammarInfo: {
+          from: number;
+          to: number;
+          message: string;
+          replacements: string[];
+        } | null = null;
+        if (pmPos !== null) {
+          const issue = getGrammarIssueAt(view, pmPos);
+          if (issue) {
+            grammarInfo = {
+              from: issue.from,
+              to: issue.to,
+              message: issue.message,
+              replacements: issue.replacements,
+            };
+          }
+        }
+
         onContextMenu({
           x: e.clientX,
           y: e.clientY,
           hasSelection,
           image: imageInfo,
           spellcheck: spellcheckInfo,
+          grammar: grammarInfo,
         });
       },
       // `zoom` is read inside `captureInlinePositionEmu` to convert post-

--- a/docx-editor/packages/react/src/styles/editor.css
+++ b/docx-editor/packages/react/src/styles/editor.css
@@ -426,6 +426,17 @@
   pointer-events: none;
 }
 
+/* Grammar issues — same wavy-underline mechanism as spell-check, but BLUE
+ * (#1a73e8) so the two are visually distinct, matching Google Docs (red =
+ * spelling, blue = grammar). */
+.grammar-error {
+  background-repeat: repeat-x;
+  background-position: bottom left;
+  background-size: 6px 3px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 6 3' fill='none' stroke='%231a73e8' stroke-width='1' stroke-linecap='round'><path d='M0 1.5 Q1.5 0 3 1.5 T6 1.5'/></svg>");
+  pointer-events: none;
+}
+
 /* Find/replace match highlighting */
 .docx-find-highlight {
   background-color: rgba(255, 235, 59, 0.5) !important;


### PR DESCRIPTION
Adds grammar checking as a sibling of spell-check — the last of the five document-level editor gaps.

**Tools → Grammar check** toggles inline grammar decorations (blue squiggle, distinct from spell-check's red, matching Google Docs). Right-clicking a flagged span opens a menu with the *reason* it's flagged plus a one-click fix, applied via `tr.replaceWith` (preserving marks).

**Pluggable by design.** Core `GrammarExtension` is engine-agnostic (`setGrammarChecker`); the React layer ships a default offline, dependency-free rule engine tuned for **precision over recall** (a false squiggle is worse than a miss):
- a/an before the wrong sound (skips "a university", "an hour")
- repeated words ("the the")
- lone lowercase "i" → "I" (won't trip on "i.e.")
- "could/should/would of" → "... have"
- space before punctuation

A server- or LLM-backed pass can replace the engine via `setGrammarEngine` with zero UI change.

Tests: 12 unit tests pin rule precision/recall; an e2e drives toggle → squiggle → right-click → fix → document update, and toggle-off → squiggles cleared. Screenshots verified.