### PR TITLE
fix(smart-chip): anchor the @ menu to the caret at any zoom

### DIFF
--- a/docx-editor/.changeset/smart-chip-zoom-fix.md
+++ b/docx-editor/.changeset/smart-chip-zoom-fix.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix the smart-chip "@" menu drifting away from the caret above 100% zoom. It multiplied the already zoom-transformed caret coordinates by the zoom factor again; it now anchors to the caret at any zoom.

--- a/docx-editor/e2e/tests/smart-chip-zoom.spec.ts
+++ b/docx-editor/e2e/tests/smart-chip-zoom.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression: the smart-chip "@" menu must anchor to the caret at any zoom.
+ * It used to multiply the (already zoom-transformed) caret coords by the zoom
+ * factor again, so above 100% the menu drifted down-right, away from the caret.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test.describe('Smart chip — caret anchoring at zoom', () => {
+  test('menu stays under the caret at 121% zoom', async ({ page }) => {
+    test.setTimeout(40_000);
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+    await editor.typeText('Meeting on ');
+
+    // Two "Zoom in" steps → 1.1 × 1.1 = 121%.
+    for (let i = 0; i < 2; i++) {
+      await page.getByRole('button', { name: /^View$/ }).click();
+      await page.getByRole('menuitem', { name: /Zoom in/i }).click();
+    }
+    await page.waitForTimeout(150);
+
+    await editor.focus();
+    await editor.typeText('@');
+    const menu = page.getByTestId('smart-chip-menu');
+    await expect(menu).toBeVisible({ timeout: 4000 });
+    await page.waitForTimeout(150);
+
+    const caretBox = await page.getByTestId('caret').first().boundingBox();
+    const menuBox = await menu.boundingBox();
+    expect(caretBox).not.toBeNull();
+    expect(menuBox).not.toBeNull();
+    if (!caretBox || !menuBox) return;
+
+    // Menu's left edge sits at the caret (small margin), and just below it —
+    // not double-scaled away. (Pre-fix the gap was > 100px.)
+    expect(Math.abs(menuBox.x - caretBox.x)).toBeLessThan(40);
+    expect(menuBox.y).toBeGreaterThan(caretBox.y);
+    expect(menuBox.y - (caretBox.y + caretBox.height)).toBeLessThan(40);
+  });
+});

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -4721,7 +4721,6 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               trigger={smartChip}
               caret={caretPosition}
               isFocused={isFocused}
-              zoom={zoom}
               items={smartChipItems}
             />
           )}

--- a/docx-editor/packages/react/src/paged-editor/SmartChipMenu.tsx
+++ b/docx-editor/packages/react/src/paged-editor/SmartChipMenu.tsx
@@ -29,12 +29,12 @@ export interface SmartChipMenuItem {
 interface SmartChipMenuProps {
   /** Active trigger, or null when no `@query` is open. */
   trigger: SmartChipTrigger | null;
-  /** Caret position in overlay space; the menu anchors just below it. */
+  /** Caret position in the overlay's pre-zoom coordinate space; the menu
+   *  anchors just below it. The overlay container applies the zoom transform,
+   *  so these coords are used raw (multiplying by zoom would double-scale). */
   caret: CaretPosition | null;
   /** Whether the editor body is focused (menu hides otherwise). */
   isFocused: boolean;
-  /** Current zoom — caret coords are pre-zoom, the overlay is scaled. */
-  zoom: number;
   /** The full menu (filtered by the trigger query before render). */
   items: SmartChipMenuItem[];
 }
@@ -45,7 +45,6 @@ export function SmartChipMenu({
   trigger,
   caret,
   isFocused,
-  zoom,
   items,
 }: SmartChipMenuProps): React.ReactElement | null {
   const [active, setActive] = useState(0);
@@ -111,8 +110,8 @@ export function SmartChipMenu({
       }}
       style={{
         position: 'absolute',
-        left: caret.x * zoom,
-        top: (caret.y + caret.height) * zoom + 4,
+        left: caret.x,
+        top: caret.y + caret.height + 4,
         minWidth: 200,
         background: 'var(--doc-surface, #fff)',
         border: '1px solid var(--doc-border-light, #dadce0)',


### PR DESCRIPTION
The smart-chip `@` menu drifted down-right of the caret above 100% zoom. It's rendered inside the zoom-transformed overlay (where caret coords are pre-zoom), but it multiplied `caret.x`/`caret.y` by the zoom factor again — double-scaling. Now it uses the raw caret coords like `SelectionOverlay` and the table chip, and the unused `zoom` prop is removed.

Regression test asserts the menu's left edge tracks the caret box (gap < 40px) at 121% zoom; pre-fix the gap was > 100px.