### PR TITLE
test(grammar): scope squiggle locator to visible overlay (de-flake)

### DIFF
--- a/docx-editor/e2e/tests/grammar-check.spec.ts
+++ b/docx-editor/e2e/tests/grammar-check.spec.ts
@@ -19,8 +19,10 @@ test.describe('Grammar check', () => {
     await page.getByRole('button', { name: 'Tools' }).click();
     await page.getByRole('menuitem', { name: /Grammar check/i }).click();
 
-    // A blue grammar squiggle is painted over the article "a".
-    const squiggle = page.locator('.grammar-error').first();
+    // A blue grammar squiggle is painted over the article "a". Scope to the
+    // VISIBLE pages — the hidden ProseMirror (left:-9999px) also renders the
+    // decoration, and an unscoped `.first()` can match that off-screen copy.
+    const squiggle = page.locator('.paged-editor__decoration-overlay .grammar-error').first();
     await expect(squiggle).toBeVisible({ timeout: 5000 });
 
     // Right-click the flagged span → the grammar fix menu opens. The overlay
@@ -54,10 +56,39 @@ test.describe('Grammar check', () => {
 
     await page.getByRole('button', { name: 'Tools' }).click();
     await page.getByRole('menuitem', { name: /Grammar check/i }).click();
-    await expect(page.locator('.grammar-error').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.paged-editor__decoration-overlay .grammar-error').first()).toBeVisible({
+      timeout: 5000,
+    });
 
     await page.getByRole('button', { name: 'Tools' }).click();
     await page.getByRole('menuitem', { name: /Grammar check/i }).click();
     await expect(page.locator('.grammar-error')).toHaveCount(0);
+  });
+
+  test('grammar works inside a table cell (right-click fix, not the table menu)', async ({
+    page,
+  }) => {
+    test.setTimeout(40_000);
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+    await editor.insertTable(2, 2);
+    await page.locator('.layout-table-cell').first().click();
+    await page.waitForTimeout(150);
+    await editor.typeText('we ate a apple');
+
+    await page.getByRole('button', { name: 'Tools' }).click();
+    await page.getByRole('menuitem', { name: /Grammar check/i }).click();
+
+    const squiggle = page.locator('.paged-editor__decoration-overlay .grammar-error').first();
+    await expect(squiggle).toBeVisible({ timeout: 5000 });
+    const box = await squiggle.boundingBox();
+    if (!box) throw new Error('no bbox for grammar squiggle in cell');
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2, { button: 'right' });
+
+    // The grammar fix menu opens (not the table context menu).
+    await expect(page.getByTestId('grammar-suggestions-menu')).toBeVisible();
   });
 });


### PR DESCRIPTION
While exercising grammar in edge contexts I found `grammar-check.spec.ts` was flaky: it matched `.grammar-error` unscoped, which can resolve to the decoration ProseMirror renders in the *hidden* editor (`left:-9999px`) rather than the painted squiggle. A right-click there lands off-screen, so the fix menu never opens — the test passes or fails depending on hidden-vs-visible DOM order (it happened to pass in CI on #178, fails locally).

Fix: scope the locator to `.paged-editor__decoration-overlay` (the visible paint), and add a table-cell case confirming the right-click fix works in cells too (it does).

No product code changed — the grammar feature is correct; only the test was non-deterministic. Test-only, so no changeset.