### PR TITLE
perf(paraId): skip the whole-doc uniqueness scan during plain typing

### DIFF
--- a/docx-editor/.changeset/paraid-typing-fastpath.md
+++ b/docx-editor/.changeset/paraid-typing-fastpath.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Stop re-scanning the whole document for paraId uniqueness on every keystroke. The allocator now only does its O(paragraphs) scan on the first edit and on structural edits (Enter, paste, doc load) — plain typing can't add or duplicate a paragraph, so it skips the walk. On a 2,500-paragraph document this cut per-keystroke transaction cost from ~7ms to ~0.1ms, removing typing lag in large documents (independent of spell/grammar).

--- a/docx-editor/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.test.ts
@@ -40,10 +40,15 @@ const schema = new Schema({
   },
 });
 
-const ext = ParaIdAllocatorExtension();
 const manager = new ExtensionManager([]);
-const runtime = ext.onSchemaReady({ schema, manager });
-const plugin = runtime.plugins![0];
+
+// A FRESH plugin per state — each models an independent editor session. The
+// allocator does one full scan on the first doc-changing transaction (catching
+// load-time gaps), then only re-scans on structural edits; sharing a single
+// instance across tests would leak that "did initial scan" state between them.
+function freshPlugin() {
+  return ParaIdAllocatorExtension().onSchemaReady({ schema, manager }).plugins![0];
+}
 
 function createDoc(paras: Array<{ text: string; paraId?: string | null }>) {
   return schema.node(
@@ -56,7 +61,7 @@ function createDoc(paras: Array<{ text: string; paraId?: string | null }>) {
 }
 
 function createState(paras: Array<{ text: string; paraId?: string | null }>) {
-  return EditorState.create({ doc: createDoc(paras), plugins: [plugin] });
+  return EditorState.create({ doc: createDoc(paras), plugins: [freshPlugin()] });
 }
 
 function paraIds(state: EditorState): (string | null)[] {
@@ -172,6 +177,30 @@ describe('ParaIdAllocatorExtension', () => {
       expect(ids).toHaveLength(3);
       expect(new Set(ids).size).toBe(3);
       expect(ids.every((id) => typeof id === 'string')).toBe(true);
+    });
+  });
+
+  describe('typing fast-path (skips the O(paragraphs) re-scan)', () => {
+    test('plain typing after the initial scan appends no allocator transaction', () => {
+      let state = createState([{ text: 'X', paraId: 'A' }]);
+      // First doc-changing tx does the initial scan.
+      state = state.apply(state.tr.insertText('Y', 2));
+      // Subsequent plain typing must NOT append a second allocator tx — that
+      // whole-doc walk is what made large documents lag per keystroke.
+      const { transactions } = state.applyTransaction(state.tr.insertText('Z', 3));
+      expect(transactions).toHaveLength(1); // just the insert, no appended scan
+    });
+
+    test('a structural edit after the initial scan still re-scans and dedups', () => {
+      let state = createState([{ text: 'HelloWorld', paraId: 'ORIG' }]);
+      // Initial scan via a plain edit.
+      state = state.apply(state.tr.insertText('!', 11));
+      // Now split (Enter) — a structural edit must still allocate a fresh id
+      // for the second half rather than leaving a duplicate.
+      state = state.apply(state.tr.split(6));
+      const ids = paraIds(state);
+      expect(ids).toHaveLength(2);
+      expect(new Set(ids).size).toBe(2);
     });
   });
 });

--- a/docx-editor/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/features/ParaIdAllocatorExtension.ts
@@ -8,19 +8,56 @@
  */
 
 import { Plugin, PluginKey } from 'prosemirror-state';
+import type { Transaction } from 'prosemirror-state';
 import { createExtension } from '../create';
 import type { ExtensionRuntime } from '../types';
 import { generateHexId } from '../../../utils/hexId';
 
 export const paraIdAllocatorKey = new PluginKey('paraIdAllocator');
 
+/**
+ * Could any of these transactions have ADDED or SPLIT a paragraph? Plain text
+ * edits (typing, deleting within a paragraph) never can, so the O(paragraphs)
+ * uniqueness scan can be skipped for them — it otherwise costs ~7ms PER
+ * KEYSTROKE on a 2,500-paragraph document. A step adds/splits a paragraph only
+ * when its replacement slice opens a block boundary (Enter split, backspace
+ * merge) or carries block-level content (paste, programmatic insert, doc load).
+ */
+function mayAddOrSplitParagraph(transactions: readonly Transaction[]): boolean {
+  for (const tr of transactions) {
+    for (const step of tr.steps) {
+      const slice = (step as { slice?: { openStart: number; openEnd: number; content: unknown } })
+        .slice;
+      if (!slice) continue; // mark / attr steps — no structural change
+      if (slice.openStart > 0 || slice.openEnd > 0) return true;
+      let hasBlock = false;
+      (slice.content as { forEach: (cb: (n: { isBlock: boolean }) => void) => void }).forEach(
+        (n) => {
+          if (n.isBlock) hasBlock = true;
+        }
+      );
+      if (hasBlock) return true;
+    }
+  }
+  return false;
+}
+
 function createParaIdAllocatorPlugin(): Plugin {
+  // Force one full scan up front (the initial document may carry paragraphs
+  // that loaded without a paraId); after that, only re-scan on structural edits.
+  let didInitialScan = false;
   return new Plugin({
     key: paraIdAllocatorKey,
     appendTransaction(transactions, _oldState, newState) {
       // Skip selection-only / mark-only transactions — they can't have
       // created or duplicated a paragraph.
       if (!transactions.some((t) => t.docChanged)) return null;
+
+      // Fast path: typing within a paragraph can't create or duplicate one, so
+      // skip the whole-document scan. The first doc-changing transaction always
+      // scans (catches load-time gaps); structural edits always scan.
+      if (didInitialScan && !mayAddOrSplitParagraph(transactions)) return null;
+      didInitialScan = true;
 
       const seen = new Set<string>();
       const updates: { pos: number; attrs: Record<string, unknown> }[] = [];


### PR DESCRIPTION
Profiling the per-keystroke `state.apply()` on the 2,458-paragraph `issue-68-large` fixture (removing each plugin in turn) pinned the dominant cost: **`paraIdAllocator` — 6.83ms of 6.91ms total.** Its `appendTransaction` walked every paragraph on every `docChanged` to detect missing/duplicate paraIds — even when you're just typing a character.

Typing within a paragraph can't add or split one, so that whole-document scan is wasted. Now it runs only when it can matter:
- the **first** doc-changing transaction (catches paragraphs that loaded without a paraId), and
- **structural** edits — detected by a step whose replacement slice opens a block boundary (Enter split, backspace merge) or carries block-level content (paste, programmatic insert, doc load).

Plain typing drops from **~7ms to ~0.1ms per apply** (~57×) on the large doc. This helps every large document, independent of spell/grammar.

Unit tests updated to model real editor sessions (fresh plugin per state → first edit scans) with two new tests pinning the fast-path (typing appends no allocator tx; a structural edit after the initial scan still dedups). Paste and paragraph-op e2e pass.