### PR TITLE
fix(ci): green main — smart-chip Escape bug + version-history e2e timeouts

### DIFF
--- a/docx-editor/.changeset/smart-chip-escape-dismiss.md
+++ b/docx-editor/.changeset/smart-chip-escape-dismiss.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix Escape not dismissing the smart-chip "@" menu. The handler updated state with a no-op (`setActive(i => i)`), which React bails out of, so the menu stayed open; it now tracks the dismissed trigger in state so Escape reliably closes it.

--- a/docx-editor/e2e/tests/palette-comments-history.spec.ts
+++ b/docx-editor/e2e/tests/palette-comments-history.spec.ts
@@ -43,7 +43,10 @@ test.describe('Command palette — rail toggles', () => {
     const mod = await modifierKey(page);
     await page.keyboard.press(`${mod}+Shift+p`);
     await page.getByTestId('command-palette-input').fill('version history');
-    await expect(page.locator('[data-cp-index="0"]')).toContainText('Show version history');
+    // Two commands match now — the File-menu "Version history" (discoverability)
+    // and the View "Show version history" toggle. Either as the top hit is fine;
+    // both open the panel, which is what we assert below.
+    await expect(page.locator('[data-cp-index="0"]')).toContainText(/version history/i);
     await page.keyboard.press('Enter');
 
     await expect(page.getByTestId('rail-history')).toHaveAttribute('aria-pressed', 'true');

--- a/docx-editor/e2e/tests/version-preview-pinned.spec.ts
+++ b/docx-editor/e2e/tests/version-preview-pinned.spec.ts
@@ -17,9 +17,13 @@ test.describe('Version preview — pinned banner', () => {
     await editor.newDocument();
     await editor.focus();
 
-    // Enough content that the preview scrolls.
-    for (let i = 0; i < 14; i++) {
-      await editor.typeText(`Paragraph ${i} with filler text long enough to scroll. `);
+    // Enough content that the preview scrolls. Each line is >100 chars so the
+    // helper inserts it in one InputEvent (the per-char path is far too slow
+    // under CI load and times the test out).
+    for (let i = 0; i < 9; i++) {
+      await editor.typeText(
+        `Paragraph ${i} with a good deal of filler text that is comfortably long so the document height grows well past the viewport and scrolls. `
+      );
       await editor.pressEnter();
     }
     await page.waitForTimeout(2200);

--- a/docx-editor/e2e/tests/vh-change-nav.spec.ts
+++ b/docx-editor/e2e/tests/vh-change-nav.spec.ts
@@ -4,8 +4,14 @@ test('preview change navigation scrolls between changes', async ({ page }) => {
   test.setTimeout(70000);
   const editor = new EditorPage(page);
   await editor.goto(); await editor.waitForReady(); await editor.newDocument(); await editor.focus();
-  // Build a tall doc.
-  for (let i = 0; i < 20; i++) { await editor.typeText(`Original paragraph ${i} of the document body. `); await editor.pressEnter(); }
+  // Build a tall doc. Each line is >100 chars so the helper inserts it in one
+  // InputEvent — the per-char path is far too slow under CI load (timeout).
+  for (let i = 0; i < 12; i++) {
+    await editor.typeText(
+      `Original paragraph ${i} of the document body with extra filler text so each line is comfortably long and the document grows tall. `
+    );
+    await editor.pressEnter();
+  }
   await page.waitForTimeout(2200);
   await page.getByRole('button', { name: 'Version history' }).click();
   await page.waitForSelector('[data-testid="version-history-panel"]');
@@ -15,8 +21,8 @@ test('preview change navigation scrolls between changes', async ({ page }) => {
   await editor.focus();
   await editor.selectText('Original paragraph 1 ');
   await editor.typeText('EDITED-TOP paragraph one ');
-  await editor.selectText('Original paragraph 18 ');
-  await editor.typeText('EDITED-BOTTOM paragraph eighteen ');
+  await editor.selectText('Original paragraph 10 ');
+  await editor.typeText('EDITED-BOTTOM paragraph ten ');
   await editor.saveNamedVersion('v2');
   await page.waitForFunction(() => document.querySelectorAll('[data-testid="version-history-version-row"]').length >= 2);
   // Preview the latest (v2) with show changes.

--- a/docx-editor/packages/react/src/paged-editor/SmartChipMenu.tsx
+++ b/docx-editor/packages/react/src/paged-editor/SmartChipMenu.tsx
@@ -7,7 +7,7 @@
  * Positioned in the same overlay-relative space as the caret (see
  * `CaretPosition`), so it tracks the cursor as the user keeps typing.
  */
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { CaretPosition } from '@eigenpal/docx-core/layout-bridge';
 import type { SmartChipTrigger } from '@eigenpal/docx-core/prosemirror';
 
@@ -49,8 +49,10 @@ export function SmartChipMenu({
 }: SmartChipMenuProps): React.ReactElement | null {
   const [active, setActive] = useState(0);
   // Suppress the menu for a trigger the user dismissed with Escape, until the
-  // trigger position changes (i.e. they moved on or re-typed `@`).
-  const dismissedFromRef = useRef<number | null>(null);
+  // trigger position changes (i.e. they moved on or re-typed `@`). State (not a
+  // ref) so dismissing actually re-renders — `setActive(i => i)` would bail out
+  // of React's update (same value) and leave the menu open.
+  const [dismissedFrom, setDismissedFrom] = useState<number | null>(null);
 
   const filtered = useMemo(() => {
     if (!trigger) return [];
@@ -64,7 +66,7 @@ export function SmartChipMenu({
     setActive(0);
   }, [trigger?.query, filtered.length]);
 
-  const dismissed = trigger != null && dismissedFromRef.current === trigger.from;
+  const dismissed = trigger != null && dismissedFrom === trigger.from;
   const open = isFocused && trigger != null && caret != null && filtered.length > 0 && !dismissed;
 
   // Keyboard: the hidden ProseMirror holds focus, so intercept navigation keys
@@ -87,9 +89,7 @@ export function SmartChipMenu({
       } else if (e.key === 'Escape') {
         e.preventDefault();
         e.stopPropagation();
-        dismissedFromRef.current = trigger?.from ?? null;
-        // Force a re-render so `dismissed` recomputes and the menu hides.
-        setActive((i) => i);
+        setDismissedFrom(trigger?.from ?? null);
       }
     };
     window.addEventListener('keydown', onKeyDown, true);


### PR DESCRIPTION
CI on main went red. Four genuine failures (all retries), now fixed:

1. **smart-chip-date "Escape dismisses the menu"** — a real product bug. `SmartChipMenu`'s Escape handler set state with `setActive(i => i)` to force a re-render that hides the menu, but React bails out of same-value updates, so the menu stayed open. Now the dismissed trigger is tracked in state → Escape reliably closes it.
2. **version-preview-pinned** & **vh-change-nav** — e2e timeouts (60-70s). They typed 14-20 short paragraphs char-by-char (the per-char path); under CI load that blew the timeout. Switched to >100-char lines (the helper's single-InputEvent insert path) and fewer paragraphs — locally ~6-8s now.
3. **palette-comments-history "version history"** — #164 added a File-menu "Version history" command, so it now co-exists with the View "Show version history" toggle and can be the top palette hit. Relaxed the text assertion to match either; both open the panel (the real assertion).

Verified all four pass locally; typecheck + lint clean.