### PR TITLE
perf(layout): skip redundant page-shell style writes during typing

### DIFF
--- a/docx-editor/.changeset/layout-skip-redundant-pagestyles.md
+++ b/docx-editor/.changeset/layout-skip-redundant-pagestyles.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Cut redundant page-shell style writes on every keystroke in large documents. Typing earlier in a document shifts every later page's content positions, which flagged all pages as "changed" and re-applied geometry styles to each (~5ms per keystroke on a 300-page doc). The incremental renderer now re-applies a page's size styles only when the size actually changed, and rewrites its page-number attribute only when it moved.

--- a/docx-editor/packages/core/src/layout-painter/renderPage.ts
+++ b/docx-editor/packages/core/src/layout-painter/renderPage.ts
@@ -2051,9 +2051,18 @@ export function renderPages(
       const shell = prev.element;
       const data = prevDataMap.get(shell);
 
+      // A fingerprint change usually means content SHIFTED (typing earlier in
+      // the doc bumps every later fragment's pmStart/pmEnd) rather than the
+      // page geometry changing. Capture the old size before overwriting so the
+      // shell-style write below can be skipped when the size is unchanged —
+      // otherwise editing near the top re-applies styles to every page (~300
+      // redundant style writes ≈ 5ms per keystroke on a large document).
+      const oldPage = data?.page;
+      const newPage = pages[i];
+
       // Update data map entry
       if (data) {
-        data.page = pages[i];
+        data.page = newPage;
 
         if (data.rendered) {
           // Surgically replace only the content area, preserving header/footer
@@ -2065,9 +2074,18 @@ export function renderPages(
       // Update fingerprint
       prev.fingerprint = newFp;
 
-      // Update page styles in case size changed
-      applyPageStyles(shell, pages[i].size.w, pages[i].size.h, options);
-      shell.dataset.pageNumber = String(pages[i].number);
+      // Re-apply shell geometry only when the page size actually changed (the
+      // page background uses a CSS var, so dark-mode / paper changes re-resolve
+      // without a rewrite). Page number is likewise only written when it moved.
+      const sizeChanged =
+        !oldPage || oldPage.size.w !== newPage.size.w || oldPage.size.h !== newPage.size.h;
+      if (sizeChanged) {
+        applyPageStyles(shell, newPage.size.w, newPage.size.h, options);
+      }
+      const newNumber = String(newPage.number);
+      if (shell.dataset.pageNumber !== newNumber) {
+        shell.dataset.pageNumber = newNumber;
+      }
     }
 
     // Handle new pages (document grew)


### PR DESCRIPTION
Final step of the per-keystroke profiling thread — this one is in the **layout pipeline** (the apply path was fixed in #184/#185).

Profiling `renderPages` on the 2,458-paragraph (313-page) fixture: the incremental update loop ran `applyPageStyles` + a `dataset.pageNumber` write for **all 313 pages** on every keystroke (`changed=313, repop=5, style=313` — measured), because typing earlier in the doc shifts every later fragment's `pmStart/pmEnd` so every page's fingerprint changes. Only ~5 pages are actually rendered and **none changed size**, so those ~308 `applyPageStyles` calls (~5ms) were pure waste.

Fix: capture the page's previous size and re-apply geometry styles only when the size actually changed; rewrite the page-number attribute only when it moved. The page background uses a CSS var, so dark-mode / paper changes re-resolve without a rewrite.

**Fidelity is the risk here, so verified carefully:** all load-time rendering tests pass (generic-rendering, section-pagination with page-size changes, demo-docx, textbox), plus a new incremental-edit check confirms page dimensions stay correct through edits and that new pages (313→317 when content is added) get the right geometry.