### PR TITLE
fix(table): Delete on a cell selection clears contents, keeps the table

### DIFF
--- a/docx-editor/.changeset/table-cell-delete-clears.md
+++ b/docx-editor/.changeset/table-cell-delete-clears.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Delete/Backspace over a multi-cell table selection now clears the selected cells' contents and keeps the table, matching Word and Google Docs. Previously selecting the whole table and pressing Delete removed the entire table.

--- a/docx-editor/e2e/tests/table-cell-delete-clears.spec.ts
+++ b/docx-editor/e2e/tests/table-cell-delete-clears.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+/**
+ * Delete/Backspace over a multi-cell selection clears the selected cells'
+ * contents and keeps the table — matching Word and Google Docs. Selecting the
+ * whole table and pressing Delete previously removed the entire table, which
+ * surprised users who selected all cells just to clear them. Deleting the table
+ * is an explicit right-click / menu action (covered by table-delete.spec.ts).
+ */
+test('full-table selection + Delete clears contents and keeps the table', async ({ page }) => {
+  test.setTimeout(60000);
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.newDocument();
+  await editor.focus();
+  await editor.insertTable(2, 2);
+  await page.waitForTimeout(300);
+
+  const cells = page.locator('.layout-table-cell');
+  for (let i = 0; i < 4; i++) {
+    await cells.nth(i).click();
+    await page.waitForTimeout(50);
+    await editor.typeText('C' + i);
+  }
+
+  // Drag across all four cells to build a CellSelection.
+  const r0 = await cells.nth(0).boundingBox();
+  const r3 = await cells.nth(3).boundingBox();
+  await page.mouse.move(r0!.x + r0!.width / 2, r0!.y + r0!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(r3!.x + r3!.width / 2, r3!.y + r3!.height / 2, { steps: 8 });
+  await page.mouse.up();
+  await page.waitForTimeout(180);
+
+  await page.keyboard.press('Delete');
+  await page.waitForTimeout(250);
+
+  // Table survives; all cells cleared.
+  expect(await page.locator('.layout-table').count()).toBe(1);
+  expect(await cells.count()).toBe(4);
+  expect((await cells.allInnerTexts()).every((t) => t.trim() === '')).toBe(true);
+});
+
+test('partial cell selection + Backspace clears only the selected cells', async ({ page }) => {
+  test.setTimeout(60000);
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+  await editor.newDocument();
+  await editor.focus();
+  await editor.insertTable(2, 2);
+  await page.waitForTimeout(300);
+
+  const cells = page.locator('.layout-table-cell');
+  for (let i = 0; i < 4; i++) {
+    await cells.nth(i).click();
+    await page.waitForTimeout(50);
+    await editor.typeText('D' + i);
+  }
+
+  // Select the top row (cells 0 and 1).
+  const a0 = await cells.nth(0).boundingBox();
+  const a1 = await cells.nth(1).boundingBox();
+  await page.mouse.move(a0!.x + a0!.width / 2, a0!.y + a0!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(a1!.x + a1!.width / 2, a1!.y + a1!.height / 2, { steps: 6 });
+  await page.mouse.up();
+  await page.waitForTimeout(150);
+
+  await page.keyboard.press('Backspace');
+  await page.waitForTimeout(220);
+
+  const texts = (await cells.allInnerTexts()).map((t) => t.trim());
+  expect(await cells.count()).toBe(4);
+  expect(texts[0]).toBe('');
+  expect(texts[1]).toBe('');
+  expect(texts[2]).toContain('D2');
+  expect(texts[3]).toContain('D3');
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -418,6 +418,7 @@ import {
   findNextChange,
   findPreviousChange,
 } from '@eigenpal/docx-core/prosemirror/commands';
+import { deleteCellSelection } from 'prosemirror-tables';
 import { collectHeadings } from '@eigenpal/docx-core/utils';
 import {
   getChangedParagraphIds,
@@ -3463,30 +3464,20 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       // Delete selected table from layout selection (non-ProseMirror selection)
       if (!cmdOrCtrl && !e.shiftKey && !e.altKey) {
         if (e.key === 'Delete' || e.key === 'Backspace') {
-          // If full table is selected via ProseMirror CellSelection, delete it.
+          // Multi-cell (CellSelection) delete: clear the selected cells'
+          // contents and keep the table, matching Word and Google Docs. Even
+          // selecting the whole table just empties it — deleting the table is
+          // an explicit menu/right-click action, not what Delete does. (This
+          // previously called deleteTable on a full-table selection, which
+          // surprised users who selected all cells just to clear them.)
           const view = pagedEditorRef.current?.getView();
           if (view) {
             const sel = view.state.selection as { $anchorCell?: unknown; forEachCell?: unknown };
             const isCellSel = '$anchorCell' in sel && typeof sel.forEachCell === 'function';
             if (isCellSel) {
-              const context = getTableContext(view.state);
-              if (context.isInTable && context.table) {
-                let totalCells = 0;
-                context.table.descendants((node) => {
-                  if (node.type.name === 'tableCell' || node.type.name === 'tableHeader') {
-                    totalCells += 1;
-                  }
-                });
-                let selectedCells = 0;
-                (sel as { forEachCell: (fn: () => void) => void }).forEachCell(() => {
-                  selectedCells += 1;
-                });
-                if (totalCells > 0 && selectedCells >= totalCells) {
-                  e.preventDefault();
-                  pmDeleteTable(view.state, view.dispatch);
-                  return;
-                }
-              }
+              e.preventDefault();
+              deleteCellSelection(view.state, view.dispatch);
+              return;
             }
           }
 


### PR DESCRIPTION
Selecting cells in a table and pressing Delete/Backspace now clears those cells' contents instead of deleting the whole table — matching Word and Google Docs. Selecting every cell just empties the table; removing the table is the explicit right-click / menu action.

The whole-table deletion came from a document-level keydown handler in DocxEditor that called deleteTable on a full-table CellSelection; it now calls the table library's deleteCellSelection (which refills each cell with an empty paragraph). Partial cell selections were already cleared correctly and are unaffected.