### PR TITLE
docs: finish Go-backend-removal hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,6 @@ The editor under [`docx-editor/`](./docx-editor/) is a fork of [eigenpal/docx-ed
 
 ## 📄 License
 
-Apache-2.0 for this repository — the Go gateway, Dockerfile, docker-compose, CI workflows, and project docs. See [`LICENSE`](./LICENSE) and [`NOTICE`](./NOTICE).
+Apache-2.0 for this repository — the Dockerfile, docker-compose, CI workflows, and project docs. The collab server is the `collab/` submodule (CasualOffice/collab, Apache-2.0). See [`LICENSE`](./LICENSE) and [`NOTICE`](./NOTICE).
 
 The editor under [`docx-editor/`](./docx-editor/) is based on [eigenpal/docx-editor](https://github.com/eigenpal/docx-editor) and remains under its original **MIT** terms — see [`docx-editor/LICENSE`](./docx-editor/LICENSE). Apache-2.0 + MIT are compatible; the combined work is distributed under Apache-2.0 with MIT attribution preserved.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,7 +27,7 @@ System design for Casual Editor. For deployment notes, see [`DEPLOYMENT.md`](./D
 │  └────────────────────────────────┬──────────────────────────────────────┘  │
 │                                   │ y-prosemirror.ySyncPlugin                │
 │  ┌────────────────────────────────▼──────────────────────────────────────┐  │
-│  │  Yjs Y.Doc + y-websocket provider → wss://host/doc/<docId>?p=<pw>    │  │
+│  │  Yjs Y.Doc + HocuspocusProvider → wss://host/yjs (room in handshake)  │  │
 │  │  Awareness — selection, cursors, presence                             │  │
 │  └──────────────────────────────┬─────────────────────────────────────────┘ │
 │                                 │                                            │
@@ -37,43 +37,48 @@ System design for Casual Editor. For deployment notes, see [`DEPLOYMENT.md`](./D
 │  │  ProseMirror → fromProseDoc → Document → serialize XML → rezip         │ │
 │  └────────────────────────────────────────────────────────────────────────┘ │
 └──────────────────────────────────┬───────────────────────────────────────────┘
-                                   │ WebSocket  /doc/:docId
-                                   │ HTTP       /api/docs
+                                   │ WebSocket  /yjs (Hocuspocus)
+                                   │ HTTP       /api/rooms, /auth, /files, /wopi
                                    ▼
-┌─── LEGACY Go gateway (backend/) — superseded by the Node CasualOffice/collab ─┐
+┌─── Node collab server (CasualOffice/collab, the ./collab submodule) ──────────┐
 │                                                                              │
 │  REST + static                                                               │
 │  ├─ GET  /                            editor SPA bundle                      │
-│  ├─ GET  /d/:docId                    same SPA; doc context                  │
-│  ├─ POST /api/docs                    upload .docx → {docId}                 │
-│  ├─ GET  /api/docs/:id/download       download latest snapshot               │
+│  ├─ POST /api/rooms                   mint a share-link room → {roomId}      │
+│  ├─ POST /api/rooms/:id/seed          seed a room with starting .docx bytes  │
+│  ├─ GET  /api/rooms/:id/seed          fetch seed bytes (joiners)            │
+│  ├─ /auth/* /files/* /wopi/*          Mode 3 (personal) + Mode 2 (WOPI)      │
 │  └─ GET  /health                      {ok, ts, rooms}                        │
 │                                                                              │
-│  y-websocket gateway (WS /doc/:docId)                                        │
-│  ├─ Per-docId in-memory Y.Doc room                                           │
-│  ├─ Password gate: SHA-256 + constant-time compare, close 4401 on fail       │
+│  Hocuspocus WS broker (/yjs)                                                 │
+│  ├─ One authoritative Y.Doc per room (room name in the handshake)            │
+│  ├─ Share-token gate via onAuthenticate → resolveJoinRole                    │
 │  ├─ Awareness fan-out — cursors, presence                                    │
-│  └─ Room GC: dropped when last client of a room disconnects                  │
+│  └─ Snapshot / version on room drain; room GC when last client leaves        │
 │                                                                              │
-│  Host integration (internal/host/)                                           │
-│  ├─ inline — in-memory bytes, drained on container restart (v0)              │
-│  ├─ wopi   — GetFile / PutFile against a WOPI host (v1)                      │
-│  └─ jwtapi — lighter REST host integration (v1)                              │
+│  Persistence                                                                 │
+│  ├─ Y.Doc room state — CASUAL_STORAGE: memory / local / redis                │
+│  └─ File bytes (host integration) — memory / local / s3 / postgres           │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
+
+> The legacy in-repo **Go** y-websocket gateway (`backend/`, paths `/doc/:docId`
+> + `/api/docs`) was **removed 2026-06-28** — see
+> [docs/internal/23](./internal/23-collab-server-migration.md).
 
 ---
 
 ## Stateless invariant
 
-The gateway has **no database** and **no on-disk update log**.
+The collab server holds **one authoritative `Y.Doc` per live room** and no
+product database.
 
-- The only live state is the in-memory `Y.Doc` for an active room.
-- When the last client of a room disconnects, the Y.Doc is flushed via the host integration (`PutFile` or equivalent) and dropped.
-- On process restart, clients reconnect and the session re-seeds from the host via `GetFile`.
+- Room Y.Doc state is persisted via `CASUAL_STORAGE` (in-memory by default; `local` / `redis` to survive restarts); file bytes via the host integration.
+- When the last client of a room disconnects, the room drains — a snapshot is taken and the in-memory Y.Doc dropped.
+- On reconnect, a fresh peer syncs from the server's Y.Doc (or re-seeds from the host).
 
-This shifts durability entirely to the host. The gateway is a pure realtime orchestrator — horizontally scalable behind a sticky-by-room load balancer with no shared state.
+Durability is delegated to the configured storage + host backends, keeping the server horizontally scalable behind a sticky-by-room load balancer.
 
 ---
 
@@ -123,12 +128,13 @@ docx-editor/packages/
         ├── hooks/                 # selection sync, sidebar items, etc.
         └── i18n/                  # locale loader + en.json
 
-backend/
-├── cmd/gateway/                   # entry point
-└── internal/
-    ├── host/                      # host.Integration interface + impls
-    ├── room/                      # per-docId in-memory Y.Doc room manager
-    └── yws/                       # y-websocket protocol helpers
+collab/                            # Node collab server (CasualOffice/collab submodule)
+└── src/
+    ├── index.ts                  # Fastify app: static SPA + REST + /yjs WS
+    ├── yjs.ts                    # Hocuspocus broker, onAuthenticate gate
+    ├── rooms.ts                  # in-memory Y.Doc room registry + GC
+    ├── auth/ files/ wopi.ts      # /auth, /files, /api/rooms, /wopi surfaces
+    └── host/                     # file-byte backends: memory / local / s3 / postgres
 ```
 
 ---
@@ -140,9 +146,9 @@ backend/
 | Editor model     | OOXML-preserving ProseMirror schema           | Round-trip fidelity matters more than schema purity                                          |
 | Layout           | Custom layout-painter, separate from `toDOM`  | Word-style pagination, headers/footers, section breaks                                       |
 | CRDT             | Yjs + `y-prosemirror`                         | Documented integration, mature, fast convergence                                             |
-| Transport        | y-websocket protocol                          | Standard for Yjs over WS — works with Hocuspocus, custom servers, etc.                       |
-| Backend language | Go                                            | IO-bound workload, mature WS ecosystem                                                       |
-| Backend state    | None on disk; in-memory Y.Doc per active room | Stateless = trivial to scale + restart cleanly                                               |
-| Persistence      | Delegated to host integration                 | inline / WOPI / JWT-API — keeps the gateway storage-agnostic                                 |
+| Transport        | Hocuspocus (`@hocuspocus/provider`)           | Maintained Yjs WS server/client; room name in the handshake                                  |
+| Backend language | Node / TypeScript                             | Shared CasualOffice/collab server (docs + sheets); one codebase to run                       |
+| Backend state    | One authoritative Y.Doc per active room       | `CASUAL_STORAGE` (memory / local / redis) for room state; scale behind sticky-by-room LB      |
+| Persistence      | Storage + host backends                       | Room state via `CASUAL_STORAGE`; file bytes via memory / local / s3 / postgres               |
 | Editor toolchain | Bun                                           | Fast install, fast test, native TS                                                           |
-| Test runner      | Playwright (Chromium)                         | 836 e2e tests on the editor, plus `go test -race ./...` on the backend; both gate every push |
+| Test runner      | Playwright (Chromium)                         | e2e on the editor; the collab server has its own Node test suite in `CasualOffice/collab`     |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -8,13 +8,15 @@ If you're new to the project, start with §[Quickstart](#quickstart).
 For production hosting (TLS, reverse proxy, scale), jump to
 §[Production hosting](#production-hosting).
 
-> **Backend note.** Where this guide describes the **Go** gateway / `backend/`
-> image, that is the legacy in-repo gateway, now **superseded** by the shared
-> **Node/TypeScript** `@casualoffice/collab` server (Hocuspocus + Yjs on Fastify).
-> The deployment shapes still apply; the collab service is run from the separate
-> `@casualoffice/collab` repo. See
-> [internal/23-collab-server-migration](internal/23-collab-server-migration.md)
-> and [`ARCHITECTURE.md`](ARCHITECTURE.md).
+> **Superseded — read [`../deploy/README.md`](../deploy/README.md) for the current deploy.**
+> The in-repo **Go** gateway under `backend/` was **removed 2026-06-28**. The bundled
+> Docker image now runs the Node `@casualoffice/collab` server (the `./collab` submodule),
+> which serves the SPA + REST (`/api/rooms`, `/auth`, `/files`, `/wopi`) + WS (`/yjs`) on
+> one `:8080` origin. The three deployment *shapes* below still apply, but any `GATEWAY_*` /
+> `STATIC_DIR` / `VITE_BACKEND` / `go run` specifics are **historical** — use `PORT` /
+> `CASUAL_STORAGE` / `CASUAL_FILE_EXT` / `CASUAL_PERSONAL_MODE` and
+> `VITE_COLLAB_BACKEND=ws://localhost:1234/yjs` (see [`../.env.example`](../.env.example),
+> the README config table, and [internal/23](internal/23-collab-server-migration.md)).
 
 ---
 
@@ -37,7 +39,7 @@ open http://localhost:8080
 # → they open it, you both edit live
 ```
 
-That image carries the editor SPA + Go gateway in one container. No
+That image carries the editor SPA + the Node collab server in one container. No
 database, no Redis, no sidecars. Everything works out of the box on
 the host you run it on.
 

--- a/docs/internal/00-overview.md
+++ b/docs/internal/00-overview.md
@@ -7,8 +7,8 @@ A real-time collaborative `.docx` editor service. Browser-side: a fork of `eigen
 > **Backend note (current).** Real-time sync/presence/snapshots are owned by the Node
 > `@casualoffice/collab` server (Hocuspocus + Yjs on Fastify); the editor connects via
 > `HocuspocusProvider` (`packages/react/src/collab/useCollab.ts`). A legacy in-repo **Go**
-> y-websocket gateway under `backend/` predates this and is **superseded** — it still builds
-> in CI but new sync/persistence work goes to the collab server, not `backend/`. The
+> y-websocket gateway under `backend/` predated this and was **removed 2026-06-28** — all
+> sync / persistence / REST work lives in the collab server. The
 > "Architecture (committed)", "Decisions (locked, 2026-05-16)", "Resolved questions", and the
 > Go-specific milestone rows **below are a historical record of that legacy gateway**. For the
 > current backend see [23-collab-server-migration](23-collab-server-migration.md) and

--- a/docs/internal/12-env-vars.md
+++ b/docs/internal/12-env-vars.md
@@ -1,11 +1,16 @@
 # 12 — Backend env vars
 
-Consolidated reference for every env var the `backend/` reads at
-startup, with defaults and mode dependencies. Source of truth is the
-code; this doc exists so an operator doesn't have to grep `os.Getenv`
-to know what's tunable.
+> **Legacy / historical.** This documents the env vars of the in-repo
+> **Go** gateway under `backend/`, which was **removed 2026-06-28** (see
+> [23-collab-server-migration](./23-collab-server-migration.md)). The
+> collab server (the `./collab` submodule) now owns the REST surface and
+> reads its own vars — `PORT`, `CASUAL_STORAGE`, `CASUAL_FILE_EXT`,
+> `CASUAL_PERSONAL_MODE`, `CASUAL_WOPI_*`; see `.env.example`, the README
+> config table, and the collab repo's README. Kept for historical
+> reference to the retired Go gateway.
 
-When a new env var ships, add a row to the right table.
+Consolidated reference for every env var the `backend/` Go gateway read
+at startup, with defaults and mode dependencies.
 
 ---
 

--- a/docs/internal/27-production-grade-tracker.md
+++ b/docs/internal/27-production-grade-tracker.md
@@ -36,11 +36,11 @@ The forward backend is the shared Node/TypeScript `@casualoffice/collab` server:
 - Used by Docs, Sheets, and future Slides.
 - Stores opaque file bytes and Yjs updates; editor-specific serialization remains in the product clients unless a dedicated headless serializer is introduced.
 
-The legacy Go gateway remains transitional:
+The legacy Go gateway (`backend/`) was **removed 2026-06-28** (see [23-collab-server-migration](./23-collab-server-migration.md)):
 
-- It can continue serving SPA, upload/download, and historical compatibility during migration.
-- It must not receive new realtime collaboration or snapshot architecture work.
-- Public docs must stop presenting the legacy Go y-websocket path as the primary production architecture.
+- The collab server now serves the SPA, the REST surface (`/api/rooms`, `/auth`, `/files`, `/wopi`), and the WS broker (`/yjs`) from one origin.
+- All realtime / snapshot / REST work lives in the collab server.
+- Public docs (README, deploy, `.env.example`, CLAUDE.md, NOTICE) no longer reference the Go gateway.
 
 ---
 
@@ -70,7 +70,7 @@ No production-grade release until all gates below are green.
 | ID   | Task                                                                             | Acceptance gate                                                                                                                            | Status                                                                                                                  |
 | ---- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
 | P0.1 | Update README architecture claims from Go/y-websocket to Node/Hocuspocus collab. | README stack table, collaboration section, Docker section, and API surface no longer contradict `deploy/README.md`.                        | Todo                                                                                                                    |
-| P0.2 | Mark legacy Go realtime gateway as transitional everywhere.                      | `docs/ARCHITECTURE.md`, `00-overview.md`, deployment docs, and Docker comments consistently describe current vs legacy responsibilities.   | Partial — `00-overview.md` and deploy docs are current; README/Docker comments still drift.                             |
+| P0.2 | Mark legacy Go realtime gateway as transitional everywhere.                      | `docs/ARCHITECTURE.md`, `00-overview.md`, deployment docs, and Docker comments consistently describe current vs legacy responsibilities.   | Done — the Go gateway was removed 2026-06-28 (#195); README, deploy, `.env.example`, CLAUDE.md, NOTICE, Docker all collab-only. |
 | P0.3 | Define the official production topology.                                         | One canonical diagram: `gateway/static + collab + persistent storage + reverse proxy`; single-container legacy path labeled dev/demo only. | Covered — `deploy/README.md`, `deploy/docker-compose.prod.yml`, and `deploy/Caddyfile` define gateway + collab + proxy. |
 | P0.4 | Add a decision record for “one shared collab server across Docs/Sheets/Slides.”  | Decision states why: shared protocol, fewer servers, common auth/share semantics, common operator story.                                   | Partial — `23-collab-server-migration.md` covers Docs/Sheets; formal suite-wide ADR still useful.                       |
 | P0.5 | Create a release checklist template.                                             | Every release must attach gate status: fidelity, collab, a11y, UX, security, deploy, rollback.                                             | Todo                                                                                                                    |


### PR DESCRIPTION
Follow-up to #195 — updates the docs that still presented the removed Go gateway as the current backend.

- **ARCHITECTURE.md** — system diagram, repo tree, and decisions table now describe the collab server (HocuspocusProvider → `/yjs`, `/api/rooms`, `CASUAL_STORAGE` + host backends) instead of the Go gateway.
- **DEPLOYMENT.md** — top banner marks the guide superseded and redirects to `deploy/README.md`; `GATEWAY_*`/`STATIC_DIR`/`VITE_BACKEND` flagged historical.
- **00-overview / 12-env-vars / 27-tracker** — removal banners + status updated (P0.2 → Done).
- **README** — license line drops the Go gateway.

Historical milestone records (M1, Phase C/D) are kept under their existing 'historical' banners — they document what was built, not current state.