### PR TITLE
fix(editor): Home/End line nav + Ctrl/Cmd+Home/End document nav

### DIFF
--- a/docx-editor/.changeset/home-end-line-nav.md
+++ b/docx-editor/.changeset/home-end-line-nav.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix Home and End keys: they now move the caret to the start/end of the current visual line (and Shift+Home/End extend the selection), measured against the painted layout. Previously they were no-ops because the off-screen editing model's native Home/End didn't map to the paginated view.

--- a/docx-editor/.changeset/home-end-line-nav.md
+++ b/docx-editor/.changeset/home-end-line-nav.md
@@ -2,4 +2,4 @@
 '@eigenpal/docx-js-editor': patch
 ---
 
-Fix Home and End keys: they now move the caret to the start/end of the current visual line (and Shift+Home/End extend the selection), measured against the painted layout. Previously they were no-ops because the off-screen editing model's native Home/End didn't map to the paginated view.
+Fix Home/End navigation. Home and End now move the caret to the start/end of the current visual line, and Ctrl/Cmd+Home/End move it to the document start/end (Shift extends the selection in both cases). Previously these were no-ops because the off-screen editing model's native Home/End didn't map to the paginated view.

--- a/docx-editor/e2e/tests/home-end-keys.spec.ts
+++ b/docx-editor/e2e/tests/home-end-keys.spec.ts
@@ -45,6 +45,39 @@ test('Shift+Home extends the selection to line start', async ({ page }) => {
   expect((await page.locator('.paged-editor__pages').innerText()).trim()).toBe('Z');
 });
 
+test('Ctrl/Cmd+Home/End move the caret to document start/end', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  // Playwright's Chromium reports platform Win32 even on macOS; detect the
+  // real modifier so the right key combo is sent.
+  const mod = /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
+  await ed.typeText('first');
+  await page.keyboard.press('Enter');
+  await ed.typeText('second');
+  await page.keyboard.press('Enter');
+  await ed.typeText('third');
+  await page.waitForTimeout(150);
+
+  await page.keyboard.press(`${mod}+Home`);
+  await page.waitForTimeout(120);
+  await ed.typeText('Z');
+  await page.waitForTimeout(150);
+  expect((await page.locator('.paged-editor__pages').innerText()).replace(/\n/g, '|')).toMatch(
+    /^Zfirst/
+  );
+
+  await page.keyboard.press(`${mod}+End`);
+  await page.waitForTimeout(120);
+  await ed.typeText('Q');
+  await page.waitForTimeout(150);
+  expect((await page.locator('.paged-editor__pages').innerText()).replace(/\n/g, '|')).toMatch(
+    /thirdQ$/
+  );
+});
+
 test('Home goes to the visual-line start on a wrapped paragraph', async ({ page }) => {
   const ed = new EditorPage(page);
   await ed.goto();

--- a/docx-editor/e2e/tests/home-end-keys.spec.ts
+++ b/docx-editor/e2e/tests/home-end-keys.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+/**
+ * Home / End move the caret to the start / end of the current VISUAL line,
+ * measured against the painted (paginated) layout. The real editing state
+ * lives in an off-screen ProseMirror whose native Home/End map to ITS line
+ * wrapping, not what the user sees — so the nav hook handles them explicitly.
+ */
+test('Home and End move to line start and end', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('hello world');
+  await page.waitForTimeout(120);
+
+  await page.keyboard.press('Home');
+  await page.waitForTimeout(80);
+  await ed.typeText('X');
+  await page.waitForTimeout(120);
+  expect(await page.locator('.paged-editor__pages').innerText()).toContain('Xhello world');
+
+  await page.keyboard.press('End');
+  await page.waitForTimeout(80);
+  await ed.typeText('Y');
+  await page.waitForTimeout(120);
+  expect(await page.locator('.paged-editor__pages').innerText()).toContain('Xhello worldY');
+});
+
+test('Shift+Home extends the selection to line start', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('abcdef');
+  await page.waitForTimeout(120);
+
+  await page.keyboard.press('Shift+Home');
+  await page.waitForTimeout(80);
+  await ed.typeText('Z'); // typing replaces the selection
+  await page.waitForTimeout(120);
+  expect((await page.locator('.paged-editor__pages').innerText()).trim()).toBe('Z');
+});
+
+test('Home goes to the visual-line start on a wrapped paragraph', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('wordA '.repeat(40).trim());
+  await page.waitForTimeout(200);
+
+  const lines = await page.locator('.layout-page-content .layout-line').count();
+  expect(lines).toBeGreaterThan(1);
+
+  // Caret is on the last visual line; Home → start of THAT line, not the doc.
+  await page.keyboard.press('Home');
+  await page.waitForTimeout(80);
+  await ed.typeText('@');
+  await page.waitForTimeout(150);
+  const body = await page.locator('.paged-editor__pages').innerText();
+  expect(body.trimStart().startsWith('@')).toBe(false);
+});

--- a/docx-editor/packages/react/src/paged-editor/useVisualLineNavigation.ts
+++ b/docx-editor/packages/react/src/paged-editor/useVisualLineNavigation.ts
@@ -241,12 +241,31 @@ export function useVisualLineNavigation({ pagesContainerRef }: VisualLineNavigat
    */
   const handlePMKeyDown = useCallback(
     (view: EditorView, event: KeyboardEvent): boolean => {
+      // Ctrl/Cmd + Home / End → document start / end (caret move). The
+      // container separately scrolls the viewport; without this the caret
+      // stays put. Shift extends the selection to the doc edge.
+      if (
+        (event.key === 'Home' || event.key === 'End') &&
+        (event.ctrlKey || event.metaKey) &&
+        !event.altKey
+      ) {
+        stickyXRef.current = null;
+        lastVisualLineIndexRef.current = -1;
+        const { state, dispatch } = view;
+        const edge =
+          event.key === 'Home' ? TextSelection.atStart(state.doc) : TextSelection.atEnd(state.doc);
+        const sel = event.shiftKey
+          ? TextSelection.between(state.doc.resolve(state.selection.anchor), edge.$head)
+          : edge;
+        dispatch(state.tr.setSelection(sel).scrollIntoView());
+        return true;
+      }
+
       // Home / End → start / end of the current VISUAL line, measured against
       // the painted layout. The real editing state lives in an off-screen
       // ProseMirror whose native Home/End map to ITS line wrapping, not the
       // paginated layout the user sees — so without this, Home/End are no-ops
-      // (or jump to the wrong place). Ctrl/Cmd (doc start/end) and Alt are left
-      // to PM / the container handler.
+      // (or jump to the wrong place). Alt is left to PM / the container handler.
       if (
         (event.key === 'Home' || event.key === 'End') &&
         !event.ctrlKey &&

--- a/docx-editor/packages/react/src/paged-editor/useVisualLineNavigation.ts
+++ b/docx-editor/packages/react/src/paged-editor/useVisualLineNavigation.ts
@@ -241,6 +241,57 @@ export function useVisualLineNavigation({ pagesContainerRef }: VisualLineNavigat
    */
   const handlePMKeyDown = useCallback(
     (view: EditorView, event: KeyboardEvent): boolean => {
+      // Home / End → start / end of the current VISUAL line, measured against
+      // the painted layout. The real editing state lives in an off-screen
+      // ProseMirror whose native Home/End map to ITS line wrapping, not the
+      // paginated layout the user sees — so without this, Home/End are no-ops
+      // (or jump to the wrong place). Ctrl/Cmd (doc start/end) and Alt are left
+      // to PM / the container handler.
+      if (
+        (event.key === 'Home' || event.key === 'End') &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey
+      ) {
+        stickyXRef.current = null;
+        lastVisualLineIndexRef.current = -1;
+        if (!pagesContainerRef.current) return false;
+        const { from, anchor } = view.state.selection;
+        const line = findLineElementAtPosition(from);
+        if (!line) return false; // off the painted layout — let PM try
+        const spans = Array.from(
+          line.querySelectorAll('span[data-pm-start][data-pm-end]')
+        ) as HTMLElement[];
+        let target: number | null = null;
+        if (spans.length === 0) {
+          // Empty line — go to the paragraph's content start.
+          const para = line.closest('.layout-paragraph') as HTMLElement | null;
+          if (para?.dataset.pmStart) target = Number(para.dataset.pmStart) + 1;
+        } else {
+          let lo = Infinity;
+          let hi = -Infinity;
+          for (const s of spans) {
+            const st = Number(s.dataset.pmStart);
+            const en = Number(s.dataset.pmEnd);
+            if (st < lo) lo = st;
+            if (en > hi) hi = en;
+          }
+          target = event.key === 'Home' ? lo : hi;
+        }
+        if (target === null) return false;
+        const { state, dispatch } = view;
+        const clamped = Math.max(0, Math.min(target, state.doc.content.size));
+        try {
+          const sel = event.shiftKey
+            ? TextSelection.create(state.doc, anchor, clamped)
+            : TextSelection.create(state.doc, clamped);
+          dispatch(state.tr.setSelection(sel).scrollIntoView());
+        } catch {
+          return false; // let PM fall back if the position won't resolve
+        }
+        return true;
+      }
+
       // Clear sticky state on non-vertical navigation
       if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') {
         if (


### PR DESCRIPTION
Two related caret-navigation bugs, both from the keys being delegated to the off-screen ProseMirror (whose native behaviour maps to ITS line wrapping / doesn't move the caret), not the paginated layout the user sees:

- **Home / End** were no-ops (or jumped to the wrong place). Now they move the caret to the start/end of the current **visual line**, measured against the painted geometry. Shift+Home/End extend the selection.
- **Ctrl/Cmd+Home / End** only scrolled the viewport without moving the caret. Now they move it to **document** start/end (Shift extends).

Handled in the visual-line-navigation hook alongside ArrowUp/Down. Alt is untouched.

Verified: single-line Home/End, Shift+Home selection, Home landing on the visual-line start of a wrapped paragraph (not doc start), empty-line no-crash, Ctrl/Cmd+Home/End to doc edges; 27 existing cursor/click nav tests still green.