### PR TITLE
fix(find-replace): Replace/Replace All actually apply

### DIFF
--- a/docx-editor/.changeset/find-replace-apply.md
+++ b/docx-editor/.changeset/find-replace-apply.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix Find & Replace: Replace and Replace All now actually change the document (and are undoable as one step). Previously the replacement was routed through the post-transaction change-notification path and never re-seeded the editor, so clicking Replace did nothing.

--- a/docx-editor/e2e/tests/find-replace-apply.spec.ts
+++ b/docx-editor/e2e/tests/find-replace-apply.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+/**
+ * Replace / Replace All must actually change the document. They build a new
+ * Document via the Document-model `replaceText` command and push it into the
+ * live ProseMirror view as one undoable transaction — previously the change
+ * was routed through `handleDocumentChange`, which is the post-transaction
+ * echo and never re-seeded the editor, so Replace silently did nothing.
+ */
+async function openReplace(page: import('@playwright/test').Page) {
+  const mod = /Win/i.test(await page.evaluate(() => navigator.platform)) ? 'Control' : 'Meta';
+  await page.keyboard.press(`${mod}+h`);
+  await page.locator('[data-testid="find-replace-dialog"]').waitFor({ timeout: 3000 });
+  return mod;
+}
+
+test('Replace and Replace All change the document; undo restores it', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('foo boo zoo');
+  await page.waitForTimeout(200);
+
+  const mod = await openReplace(page);
+  const dlg = page.locator('[data-testid="find-replace-dialog"]');
+  await page.locator('[data-testid="find-input"]').fill('oo');
+  await page.locator('[data-testid="find-input"]').press('Enter');
+  await page.waitForTimeout(300);
+  await page.locator('#replace-text').fill('00');
+  await page.waitForTimeout(150);
+
+  await dlg.getByRole('button', { name: /^Replace$/ }).click();
+  await page.waitForTimeout(400);
+  expect((await page.locator('.paged-editor__pages').innerText()).replace(/\s+/g, ' ')).toContain(
+    'f00 boo zoo'
+  );
+
+  await dlg.getByRole('button', { name: /^Replace All$/ }).click();
+  await page.waitForTimeout(400);
+  expect((await page.locator('.paged-editor__pages').innerText()).replace(/\s+/g, ' ').trim()).toBe(
+    'f00 b00 z00'
+  );
+
+  // The Replace All is a single undoable step.
+  await ed.focus();
+  await page.keyboard.press(`${mod}+z`);
+  await page.waitForTimeout(300);
+  expect((await page.locator('.paged-editor__pages').innerText()).replace(/\s+/g, ' ')).toContain(
+    'f00 boo zoo'
+  );
+});
+
+test('Replace preserves surrounding formatting', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('KEEP');
+  await page.waitForTimeout(80);
+  const mod = /Win/i.test(await page.evaluate(() => navigator.platform)) ? 'Control' : 'Meta';
+  await page.keyboard.press(`${mod}+a`);
+  await page.keyboard.press(`${mod}+b`); // bold "KEEP"
+  await page.waitForTimeout(100);
+  await page.keyboard.press('End');
+  await ed.typeText(' replaceme end');
+  await page.waitForTimeout(150);
+
+  await openReplace(page);
+  const dlg = page.locator('[data-testid="find-replace-dialog"]');
+  await page.locator('[data-testid="find-input"]').fill('replaceme');
+  await page.locator('[data-testid="find-input"]').press('Enter');
+  await page.waitForTimeout(250);
+  await page.locator('#replace-text').fill('DONE');
+  await page.waitForTimeout(120);
+  await dlg.getByRole('button', { name: /^Replace All$/ }).click();
+  await page.waitForTimeout(400);
+
+  expect((await page.locator('.paged-editor__pages').innerText()).replace(/\s+/g, ' ')).toContain(
+    'KEEP DONE end'
+  );
+  const keepWeight = await page.evaluate(() => {
+    const span = [...document.querySelectorAll('.paged-editor__pages span')].find((s) =>
+      s.textContent?.includes('KEEP')
+    );
+    return span ? getComputedStyle(span).fontWeight : '';
+  });
+  expect(['bold', '700']).toContain(keepWeight);
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -299,7 +299,11 @@ import {
 } from '@eigenpal/docx-core/prosemirror/plugins';
 
 // Conversion (for HF inline editor save + version-history preview)
-import { proseDocToBlocks, fromProseDoc } from '@eigenpal/docx-core/prosemirror/conversion';
+import {
+  proseDocToBlocks,
+  fromProseDoc,
+  toProseDoc,
+} from '@eigenpal/docx-core/prosemirror/conversion';
 import { buildVersionDiffDoc } from '../version-history/versionDiff';
 import {
   setStrictCoEditing,
@@ -7387,6 +7391,23 @@ body { background: white; }
   }, [findReplace]);
 
   // Handle replace current match
+  // Push a Document produced by a Document-model command (e.g. find/replace's
+  // `replaceText`) into the live ProseMirror view as a single undoable
+  // transaction. We can't just call `handleDocumentChange(newDoc)`: that path
+  // assumes the change already happened in PM (it's the post-transaction echo),
+  // and the HiddenProseMirror re-seed guard keys on document *metadata*, so a
+  // pure content edit pushed that way never reaches the editor. Dispatching the
+  // rebuilt content here makes the change real, keeps undo as one step, and the
+  // normal onTransaction → handleDocumentChange echo handles history/dirty.
+  const applyDocumentToPm = useCallback((newDoc: Document): boolean => {
+    const view = pagedEditorRef.current?.getView();
+    if (!view) return false;
+    const pmDoc = toProseDoc(newDoc, { styles: newDoc.package?.styles });
+    const tr = view.state.tr.replaceWith(0, view.state.doc.content.size, pmDoc.content);
+    view.dispatch(tr.scrollIntoView());
+    return true;
+  }, []);
+
   const handleReplace = useCallback(
     (replaceText: string): boolean => {
       const document = getFindDocument();
@@ -7414,14 +7435,13 @@ body { background: white; }
           text: replaceText,
         });
 
-        handleDocumentChange(newDoc);
-        return true;
+        return applyDocumentToPm(newDoc);
       } catch (error) {
         console.error('Replace failed:', error);
         return false;
       }
     },
-    [getFindDocument, handleDocumentChange]
+    [getFindDocument, applyDocumentToPm]
   );
 
   // Handle replace all matches
@@ -7466,13 +7486,13 @@ body { background: white; }
         }
       }
 
-      handleDocumentChange(doc);
+      applyDocumentToPm(doc);
       findResultRef.current = null;
       findReplace.setMatches([], 0);
 
       return matches.length;
     },
-    [getFindDocument, handleDocumentChange, findReplace]
+    [getFindDocument, applyDocumentToPm, findReplace]
   );
 
   // Expose ref methods


### PR DESCRIPTION
Find & Replace's **Replace** and **Replace All** silently did nothing — find worked (matches highlighted, navigable) but clicking Replace never changed the text.

Root cause: the replace handlers built a new `Document` via the Document-model `replaceText` command and routed it through `handleDocumentChange`. But that function is the *post-transaction echo* (called after PM already changed during normal typing) — it pushes to history and mirrors PM state, but never re-seeds the ProseMirror view. The HiddenProseMirror re-seed guard keys on document *metadata* (created/modified/title), which a content edit doesn't change, so the replacement never reached the editor.

Fix: push the rebuilt Document into the live PM view as a single `replaceWith` transaction (`applyDocumentToPm`). The change is real, undoable as one step, and the normal onTransaction → handleDocumentChange echo still handles history/dirty.

Verified: single Replace, Replace All, undo restores in one step, and surrounding formatting (bold) is preserved; existing find-replace specs still pass.