### PR TITLE
fix(find-replace): search & replace inside table cells (PM-native)

### DIFF
--- a/docx-editor/.changeset/find-replace-pm-native.md
+++ b/docx-editor/.changeset/find-replace-pm-native.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Find & Replace now searches and replaces inside table cells. The search is ProseMirror-native (it walks the document, including cells) instead of the old Document-model search that skipped tables; replacements are targeted, undoable transactions, and Find navigation selects each match.

--- a/docx-editor/e2e/tests/find-replace-tables.spec.ts
+++ b/docx-editor/e2e/tests/find-replace-tables.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+/**
+ * Find & Replace is PM-native (walks the ProseMirror doc), so it searches and
+ * replaces inside table cells — the old Document-model search skipped tables.
+ */
+async function modKey(page: import('@playwright/test').Page) {
+  return /Win/i.test(await page.evaluate(() => navigator.platform)) ? 'Control' : 'Meta';
+}
+
+test('find counts matches in body and table cells; Replace All replaces all', async ({ page }) => {
+  test.setTimeout(60000);
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('before TARGET');
+  await page.keyboard.press('Enter');
+  await ed.insertTable(2, 2);
+  await page.waitForTimeout(300);
+
+  const cells = page.locator('.layout-table-cell');
+  await cells.nth(0).click();
+  await ed.typeText('TARGET in cell');
+  await cells.nth(3).click();
+  await ed.typeText('another TARGET here');
+  await page.waitForTimeout(200);
+
+  const mod = await modKey(page);
+  await page.keyboard.press(`${mod}+h`);
+  const dlg = page.locator('[data-testid="find-replace-dialog"]');
+  await dlg.waitFor({ timeout: 3000 });
+  await page.locator('[data-testid="find-input"]').fill('TARGET');
+  await page.locator('[data-testid="find-input"]').press('Enter');
+  await page.waitForTimeout(300);
+
+  // 1 in the body paragraph + 1 in each of two cells = 3.
+  expect((await dlg.innerText()).match(/of (\d+) matches/)?.[1]).toBe('3');
+
+  await page.locator('#replace-text').fill('FOUND');
+  await page.waitForTimeout(120);
+  await dlg.getByRole('button', { name: /^Replace All$/ }).click();
+  await page.waitForTimeout(400);
+
+  const body = (await page.locator('.paged-editor__pages').innerText()).replace(/\s+/g, ' ');
+  expect(body).not.toContain('TARGET');
+  expect((await cells.allInnerTexts()).join('|')).toContain('FOUND');
+});
+
+test('case and whole-word options narrow the match set', async ({ page }) => {
+  test.setTimeout(60000);
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('Cat cat CATatonic cats');
+  await page.waitForTimeout(200);
+
+  const mod = await modKey(page);
+  await page.keyboard.press(`${mod}+f`);
+  const dlg = page.locator('[data-testid="find-replace-dialog"]');
+  await dlg.waitFor({ timeout: 3000 });
+  const fi = page.locator('[data-testid="find-input"]');
+  await fi.fill('cat');
+  await fi.press('Enter');
+  await page.waitForTimeout(300);
+  expect((await dlg.innerText()).match(/of (\d+) matches/)?.[1]).toBe('4');
+
+  await dlg.getByText(/Match case/i).click();
+  await page.waitForTimeout(300);
+  expect((await dlg.innerText()).match(/of (\d+) matches/)?.[1]).toBe('2');
+
+  await dlg.getByText(/Whole words/i).click();
+  await page.waitForTimeout(300);
+  expect((await dlg.innerText()).match(/of (\d+) matches/)?.[1]).toBe('1');
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -97,8 +97,7 @@ import { type PrintOptions } from './ui/PrintPreview';
 // reached for a value that had become undefined.
 import { useFindReplace } from './dialogs/useFindReplace';
 import {
-  findInDocument,
-  scrollToMatch,
+  findInPmDoc,
   type FindMatch,
   type FindOptions,
   type FindResult,
@@ -282,7 +281,6 @@ import { findBodyPmAnchors } from '@eigenpal/docx-core/layout-bridge';
 import { type DocxInput } from '@eigenpal/docx-core/utils';
 import { onFontsLoaded, loadDocumentFonts } from '@eigenpal/docx-core/utils';
 import { resolveColorToHex } from '@eigenpal/docx-core/utils';
-import { executeCommand } from '@eigenpal/docx-core/agent';
 import { useTableSelection } from '../hooks/useTableSelection';
 import { useDocumentHistory } from '../hooks/useHistory';
 import {
@@ -299,11 +297,7 @@ import {
 } from '@eigenpal/docx-core/prosemirror/plugins';
 
 // Conversion (for HF inline editor save + version-history preview)
-import {
-  proseDocToBlocks,
-  fromProseDoc,
-  toProseDoc,
-} from '@eigenpal/docx-core/prosemirror/conversion';
+import { proseDocToBlocks, fromProseDoc } from '@eigenpal/docx-core/prosemirror/conversion';
 import { buildVersionDiffDoc } from '../version-history/versionDiff';
 import {
   setStrictCoEditing,
@@ -7322,38 +7316,57 @@ body { background: white; }
 
   // Store the current find result for navigation
   const findResultRef = useRef<FindResult | null>(null);
-  const getFindDocument = useCallback(
-    () => pagedEditorRef.current?.getDocument() ?? history.state,
-    [history.state]
-  );
+  // Last executed query — lets Replace re-run the search after an edit shifts
+  // positions, so "N of M" and the next current match stay correct.
+  const lastFindQueryRef = useRef<{ searchText: string; options: FindOptions } | null>(null);
 
-  // Handle find operation
+  // Select a PM-position match in the editor and scroll its painted span into
+  // view. The hidden PM's own scrollIntoView is suppressed (the paginated layer
+  // owns scroll), so we scroll the painted DOM directly. Works in table cells.
+  const navigateToMatch = useCallback((match: FindMatch | null): void => {
+    if (!match || match.pmFrom == null || match.pmTo == null) return;
+    const view = pagedEditorRef.current?.getView();
+    if (!view) return;
+    const size = view.state.doc.content.size;
+    const from = Math.max(0, Math.min(match.pmFrom, size));
+    const to = Math.max(from, Math.min(match.pmTo, size));
+    try {
+      view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, from, to)));
+    } catch {
+      return;
+    }
+    const container = containerRef.current;
+    if (!container) return;
+    for (const el of Array.from(
+      container.querySelectorAll<HTMLElement>('.paged-editor__pages [data-pm-start]')
+    )) {
+      const s = Number(el.dataset.pmStart);
+      const e = Number(el.dataset.pmEnd);
+      if (from >= s && from <= e) {
+        el.scrollIntoView({ block: 'center' });
+        return;
+      }
+    }
+  }, []);
+
+  // Handle find operation (PM-native — searches table cells too)
   const handleFind = useCallback(
     (searchText: string, options: FindOptions): FindResult | null => {
-      const document = getFindDocument();
-      if (!document || !searchText.trim()) {
+      const view = pagedEditorRef.current?.getView();
+      if (!view || !searchText.trim()) {
         findResultRef.current = null;
+        lastFindQueryRef.current = null;
         return null;
       }
-
-      const matches = findInDocument(document, searchText, options);
-      const result: FindResult = {
-        matches,
-        totalCount: matches.length,
-        currentIndex: 0,
-      };
-
+      lastFindQueryRef.current = { searchText, options };
+      const matches = findInPmDoc(view.state.doc, searchText, options);
+      const result: FindResult = { matches, totalCount: matches.length, currentIndex: 0 };
       findResultRef.current = result;
       findReplace.setMatches(matches, 0);
-
-      // Scroll to first match
-      if (matches.length > 0 && containerRef.current) {
-        scrollToMatch(containerRef.current, matches[0]);
-      }
-
+      if (matches.length > 0) navigateToMatch(matches[0]);
       return result;
     },
-    [getFindDocument, findReplace]
+    [findReplace, navigateToMatch]
   );
 
   // Handle find next
@@ -7361,138 +7374,79 @@ body { background: white; }
     if (!findResultRef.current || findResultRef.current.matches.length === 0) {
       return null;
     }
-
     const newIndex = findReplace.goToNextMatch();
     const match = findResultRef.current.matches[newIndex];
-
-    // Scroll to the match
-    if (match && containerRef.current) {
-      scrollToMatch(containerRef.current, match);
-    }
-
+    navigateToMatch(match);
     return match || null;
-  }, [findReplace]);
+  }, [findReplace, navigateToMatch]);
 
   // Handle find previous
   const handleFindPrevious = useCallback((): FindMatch | null => {
     if (!findResultRef.current || findResultRef.current.matches.length === 0) {
       return null;
     }
-
     const newIndex = findReplace.goToPreviousMatch();
     const match = findResultRef.current.matches[newIndex];
-
-    // Scroll to the match
-    if (match && containerRef.current) {
-      scrollToMatch(containerRef.current, match);
-    }
-
+    navigateToMatch(match);
     return match || null;
-  }, [findReplace]);
+  }, [findReplace, navigateToMatch]);
 
-  // Handle replace current match
-  // Push a Document produced by a Document-model command (e.g. find/replace's
-  // `replaceText`) into the live ProseMirror view as a single undoable
-  // transaction. We can't just call `handleDocumentChange(newDoc)`: that path
-  // assumes the change already happened in PM (it's the post-transaction echo),
-  // and the HiddenProseMirror re-seed guard keys on document *metadata*, so a
-  // pure content edit pushed that way never reaches the editor. Dispatching the
-  // rebuilt content here makes the change real, keeps undo as one step, and the
-  // normal onTransaction → handleDocumentChange echo handles history/dirty.
-  const applyDocumentToPm = useCallback((newDoc: Document): boolean => {
-    const view = pagedEditorRef.current?.getView();
-    if (!view) return false;
-    const pmDoc = toProseDoc(newDoc, { styles: newDoc.package?.styles });
-    const tr = view.state.tr.replaceWith(0, view.state.doc.content.size, pmDoc.content);
-    view.dispatch(tr.scrollIntoView());
-    return true;
-  }, []);
-
+  // Replace the current match with a targeted PM transaction (works in table
+  // cells; one undoable step), then re-run the search so positions / "N of M"
+  // stay correct and the next match becomes current.
   const handleReplace = useCallback(
     (replaceText: string): boolean => {
-      const document = getFindDocument();
-      if (!document || !findResultRef.current || findResultRef.current.matches.length === 0) {
-        return false;
-      }
-
-      const currentMatch = findResultRef.current.matches[findResultRef.current.currentIndex];
-      if (!currentMatch) return false;
-
-      // Execute replace command
+      const res = findResultRef.current;
+      if (!res || res.matches.length === 0) return false;
+      const match = res.matches[res.currentIndex] ?? res.matches[0];
+      if (!match || match.pmFrom == null || match.pmTo == null) return false;
+      const view = pagedEditorRef.current?.getView();
+      if (!view) return false;
+      const size = view.state.doc.content.size;
+      const from = Math.max(0, Math.min(match.pmFrom, size));
+      const to = Math.max(from, Math.min(match.pmTo, size));
       try {
-        const newDoc = executeCommand(document, {
-          type: 'replaceText',
-          range: {
-            start: {
-              paragraphIndex: currentMatch.paragraphIndex,
-              offset: currentMatch.startOffset,
-            },
-            end: {
-              paragraphIndex: currentMatch.paragraphIndex,
-              offset: currentMatch.endOffset,
-            },
-          },
-          text: replaceText,
-        });
-
-        return applyDocumentToPm(newDoc);
+        view.dispatch(view.state.tr.insertText(replaceText, from, to).scrollIntoView());
       } catch (error) {
         console.error('Replace failed:', error);
         return false;
       }
+      const q = lastFindQueryRef.current;
+      const nextView = pagedEditorRef.current?.getView();
+      const matches = q && nextView ? findInPmDoc(nextView.state.doc, q.searchText, q.options) : [];
+      findResultRef.current = { matches, totalCount: matches.length, currentIndex: 0 };
+      findReplace.setMatches(matches, 0);
+      if (matches.length > 0) navigateToMatch(matches[0]);
+      return true;
     },
-    [getFindDocument, applyDocumentToPm]
+    [findReplace, navigateToMatch]
   );
 
-  // Handle replace all matches
+  // Replace every match in one undoable transaction. Apply end → start so each
+  // edit doesn't shift the positions of matches still to be processed. Covers
+  // table cells.
   const handleReplaceAll = useCallback(
     (searchText: string, replaceText: string, options: FindOptions): number => {
-      const document = getFindDocument();
-      if (!document || !searchText.trim()) {
-        return 0;
-      }
-
-      // Find all matches first
-      const matches = findInDocument(document, searchText, options);
+      const view = pagedEditorRef.current?.getView();
+      if (!view || !searchText.trim()) return 0;
+      const matches = findInPmDoc(view.state.doc, searchText, options).filter(
+        (m) => m.pmFrom != null && m.pmTo != null
+      );
       if (matches.length === 0) return 0;
-
-      // Replace from end to start to maintain correct indices
-      let doc = document;
-      const sortedMatches = [...matches].sort((a, b) => {
-        if (a.paragraphIndex !== b.paragraphIndex) {
-          return b.paragraphIndex - a.paragraphIndex;
-        }
-        return b.startOffset - a.startOffset;
-      });
-
-      for (const match of sortedMatches) {
-        try {
-          doc = executeCommand(doc, {
-            type: 'replaceText',
-            range: {
-              start: {
-                paragraphIndex: match.paragraphIndex,
-                offset: match.startOffset,
-              },
-              end: {
-                paragraphIndex: match.paragraphIndex,
-                offset: match.endOffset,
-              },
-            },
-            text: replaceText,
-          });
-        } catch (error) {
-          console.error('Replace failed for match:', match, error);
-        }
+      const sorted = [...matches].sort((a, b) => (b.pmFrom as number) - (a.pmFrom as number));
+      const tr = view.state.tr;
+      const size = view.state.doc.content.size;
+      for (const m of sorted) {
+        const from = Math.max(0, Math.min(m.pmFrom as number, size));
+        const to = Math.max(from, Math.min(m.pmTo as number, size));
+        tr.insertText(replaceText, from, to);
       }
-
-      applyDocumentToPm(doc);
+      view.dispatch(tr.scrollIntoView());
       findResultRef.current = null;
       findReplace.setMatches([], 0);
-
       return matches.length;
     },
-    [getFindDocument, applyDocumentToPm, findReplace]
+    [findReplace]
   );
 
   // Expose ref methods

--- a/docx-editor/packages/react/src/components/dialogs/findReplaceUtils.ts
+++ b/docx-editor/packages/react/src/components/dialogs/findReplaceUtils.ts
@@ -27,6 +27,24 @@ export interface FindMatch {
   endOffset: number;
   /** The matched text */
   text: string;
+  /**
+   * ProseMirror document positions of the match. Set by `findInPmDoc` (the
+   * PM-native search, which covers table cells). Navigation + replace prefer
+   * these; the paragraphIndex/offset fields above are the legacy Document-model
+   * coordinates (top-level paragraphs only) kept for back-compat.
+   */
+  pmFrom?: number;
+  pmTo?: number;
+}
+
+/** Minimal structural view of a ProseMirror node — avoids a hard dep here. */
+interface PmNodeLike {
+  isTextblock: boolean;
+  isText: boolean;
+  text?: string | null;
+  content: { size: number };
+  descendants(f: (node: PmNodeLike, pos: number) => boolean | void, ...rest: unknown[]): void;
+  forEach(f: (node: PmNodeLike, offset: number, index: number) => void): void;
 }
 
 /**
@@ -308,6 +326,58 @@ export function findInDocument(
       }
     }
   }
+
+  return matches;
+}
+
+/**
+ * PM-native search: walk the ProseMirror doc (including table cells, unlike
+ * `findInDocument` which only covers top-level paragraphs) and return matches as
+ * PM document positions. Reuses `findAllMatches` per textblock so case /
+ * whole-word / regex semantics match the Document-model search exactly.
+ */
+export function findInPmDoc(
+  doc: PmNodeLike,
+  searchText: string,
+  options: FindOptions
+): FindMatch[] {
+  if (!doc || !searchText) return [];
+  const matches: FindMatch[] = [];
+
+  doc.descendants((node, pos) => {
+    if (!node.isTextblock) return true; // recurse into tables / cells / etc.
+
+    // Build the block's plain text + a PM position for each text-offset
+    // boundary (pmAt[k] = PM pos just before text char k; the final entry is
+    // the position just after the last text char).
+    let text = '';
+    const pmAt: number[] = [];
+    let lastTextPmEnd = pos + 1; // empty block → content start
+    node.forEach((child, offset) => {
+      if (child.isText && child.text) {
+        const base = pos + 1 + offset;
+        for (let i = 0; i < child.text.length; i++) {
+          pmAt.push(base + i);
+          text += child.text.charAt(i);
+        }
+        lastTextPmEnd = base + child.text.length;
+      }
+    });
+    pmAt.push(lastTextPmEnd);
+
+    for (const m of findAllMatches(text, searchText, options)) {
+      matches.push({
+        paragraphIndex: -1,
+        contentIndex: -1,
+        startOffset: m.start,
+        endOffset: m.end,
+        text: text.slice(m.start, m.end),
+        pmFrom: pmAt[m.start],
+        pmTo: pmAt[m.end],
+      });
+    }
+    return false; // already consumed this textblock's inline content
+  });
 
   return matches;
 }


### PR DESCRIPTION
Find & Replace skipped table cells — `findInDocument` only walked top-level paragraphs ("Table paragraphs tracked separately - skip for now"). So text in a table was never found or replaced.

Reworked find to be **ProseMirror-native**: a new `findInPmDoc` walks the PM doc (cells included), reuses the existing `findAllMatches` string matcher (so case / whole-word / regex semantics are unchanged), and returns matches as PM document positions. The handlers now:
- **navigate** by selecting the match (PM selection) and scrolling its painted span into view — works in cells;
- **replace** with a targeted `tr.insertText` (one undoable step), and **replace all** in a single end→start transaction.

This also retires the whole-document rebuild added in the previous fix (#198) in favour of precise, cursor-preserving edits.

Verified: find/replace in body + table cells (3-of-3 match count, all replaced), case + whole-word options (4→2→1), single Replace + Replace All + undo + formatting preserved, and the existing find-replace-shortcuts / -scroll / -apply specs still pass.