### PR TITLE
feat(find-replace): highlight all matches (Google-Docs style)

### DIFF
--- a/docx-editor/.changeset/find-match-highlight.md
+++ b/docx-editor/.changeset/find-match-highlight.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Find & Replace now highlights every match in the document (and marks the current match distinctly), matching Google Docs. Highlights clear when the find bar closes.

--- a/docx-editor/e2e/tests/find-match-highlight.spec.ts
+++ b/docx-editor/e2e/tests/find-match-highlight.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+/**
+ * Find highlights every match over the visible pages (yellow) and marks the
+ * current one distinctly (orange), painted by DecorationLayer from the
+ * findHighlightPlugin's inline decorations. Closing find clears them.
+ */
+const OVERLAY = '.paged-editor__decoration-overlay';
+
+test('find highlights all matches, marks the current one, clears on close', async ({ page }) => {
+  test.setTimeout(60000);
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('apple banana apple cherry apple');
+  await page.waitForTimeout(200);
+
+  const mod = /Win/i.test(await page.evaluate(() => navigator.platform)) ? 'Control' : 'Meta';
+  await page.keyboard.press(`${mod}+f`);
+  await page.locator('[data-testid="find-replace-dialog"]').waitFor({ timeout: 3000 });
+  await page.locator('[data-testid="find-input"]').fill('apple');
+  await page.locator('[data-testid="find-input"]').press('Enter');
+  await page.waitForTimeout(500);
+
+  expect(await page.locator(`${OVERLAY} .find-match`).count()).toBeGreaterThanOrEqual(3);
+  expect(await page.locator(`${OVERLAY} .find-match-current`).count()).toBe(1);
+
+  // Navigating keeps exactly one current highlight.
+  await page.locator('[data-testid="find-input"]').press('Enter');
+  await page.waitForTimeout(400);
+  expect(await page.locator(`${OVERLAY} .find-match-current`).count()).toBe(1);
+
+  // Closing find clears all highlights.
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(400);
+  expect(await page.locator(`${OVERLAY} .find-match`).count()).toBe(0);
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -72,7 +72,8 @@ import { CommentMarginMarkers } from './CommentMarginMarkers';
 import { useCommentSidebarItems, type CommentCallbacks } from '../hooks/useCommentSidebarItems';
 import { useTrackedChanges } from '../hooks/useTrackedChanges';
 import type { EditorState as PMEditorState } from 'prosemirror-state';
-import { NodeSelection, Plugin } from 'prosemirror-state';
+import { NodeSelection, Plugin, PluginKey } from 'prosemirror-state';
+import { Decoration, DecorationSet } from 'prosemirror-view';
 import type { Mark as PMMark } from 'prosemirror-model';
 import { undo as pmUndo, redo as pmRedo } from 'prosemirror-history';
 import type { ReactSidebarItem } from '../plugin-api/types';
@@ -2157,9 +2158,52 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       }),
     []
   );
+  // Find & Replace match highlighting. The handlers publish the match ranges
+  // (PM positions) via a `findHighlightKey` meta; this plugin turns them into
+  // inline decorations, which DecorationLayer paints over the visible pages
+  // (the current match gets `find-match-current`). Purely visual — it never
+  // affects find/replace behavior. Decorations map through edits so they stay
+  // put until the next find re-runs.
+  const findHighlightKey = useMemo(() => new PluginKey('findHighlight'), []);
+  const findHighlightPlugin = useMemo(
+    () =>
+      new Plugin({
+        key: findHighlightKey,
+        state: {
+          init: () => DecorationSet.empty,
+          apply(tr, deco: DecorationSet) {
+            const meta = tr.getMeta(findHighlightKey) as
+              | { ranges: Array<{ from: number; to: number }>; current: number }
+              | undefined;
+            if (meta) {
+              if (!meta.ranges.length) return DecorationSet.empty;
+              const decos = meta.ranges.map((r, i) =>
+                Decoration.inline(r.from, r.to, {
+                  class: i === meta.current ? 'find-match find-match-current' : 'find-match',
+                })
+              );
+              return DecorationSet.create(tr.doc, decos);
+            }
+            return deco.map(tr.mapping, tr.doc);
+          },
+        },
+        props: {
+          decorations(state) {
+            return findHighlightKey.getState(state);
+          },
+        },
+      }),
+    [findHighlightKey]
+  );
+
   const allExternalPlugins = useMemo(
-    () => [suggestionPlugin, markdownHeadingPlugin, ...(externalPlugins ?? [])],
-    [suggestionPlugin, markdownHeadingPlugin, externalPlugins]
+    () => [
+      suggestionPlugin,
+      markdownHeadingPlugin,
+      findHighlightPlugin,
+      ...(externalPlugins ?? []),
+    ],
+    [suggestionPlugin, markdownHeadingPlugin, findHighlightPlugin, externalPlugins]
   );
 
   // Refs
@@ -7320,6 +7364,19 @@ body { background: white; }
   // positions, so "N of M" and the next current match stay correct.
   const lastFindQueryRef = useRef<{ searchText: string; options: FindOptions } | null>(null);
 
+  // Publish the find matches as highlight decorations (see findHighlightPlugin).
+  const setFindHighlights = useCallback(
+    (matches: FindMatch[], current: number) => {
+      const view = pagedEditorRef.current?.getView();
+      if (!view) return;
+      const ranges = matches
+        .filter((m) => m.pmFrom != null && m.pmTo != null)
+        .map((m) => ({ from: m.pmFrom as number, to: m.pmTo as number }));
+      view.dispatch(view.state.tr.setMeta(findHighlightKey, { ranges, current }));
+    },
+    [findHighlightKey]
+  );
+
   // Select a PM-position match in the editor and scroll its painted span into
   // view. The hidden PM's own scrollIntoView is suppressed (the paginated layer
   // owns scroll), so we scroll the painted DOM directly. Works in table cells.
@@ -7363,10 +7420,11 @@ body { background: white; }
       const result: FindResult = { matches, totalCount: matches.length, currentIndex: 0 };
       findResultRef.current = result;
       findReplace.setMatches(matches, 0);
+      setFindHighlights(matches, 0);
       if (matches.length > 0) navigateToMatch(matches[0]);
       return result;
     },
-    [findReplace, navigateToMatch]
+    [findReplace, navigateToMatch, setFindHighlights]
   );
 
   // Handle find next
@@ -7377,8 +7435,9 @@ body { background: white; }
     const newIndex = findReplace.goToNextMatch();
     const match = findResultRef.current.matches[newIndex];
     navigateToMatch(match);
+    setFindHighlights(findResultRef.current.matches, newIndex);
     return match || null;
-  }, [findReplace, navigateToMatch]);
+  }, [findReplace, navigateToMatch, setFindHighlights]);
 
   // Handle find previous
   const handleFindPrevious = useCallback((): FindMatch | null => {
@@ -7388,8 +7447,9 @@ body { background: white; }
     const newIndex = findReplace.goToPreviousMatch();
     const match = findResultRef.current.matches[newIndex];
     navigateToMatch(match);
+    setFindHighlights(findResultRef.current.matches, newIndex);
     return match || null;
-  }, [findReplace, navigateToMatch]);
+  }, [findReplace, navigateToMatch, setFindHighlights]);
 
   // Replace the current match with a targeted PM transaction (works in table
   // cells; one undoable step), then re-run the search so positions / "N of M"
@@ -7416,10 +7476,11 @@ body { background: white; }
       const matches = q && nextView ? findInPmDoc(nextView.state.doc, q.searchText, q.options) : [];
       findResultRef.current = { matches, totalCount: matches.length, currentIndex: 0 };
       findReplace.setMatches(matches, 0);
+      setFindHighlights(matches, 0);
       if (matches.length > 0) navigateToMatch(matches[0]);
       return true;
     },
-    [findReplace, navigateToMatch]
+    [findReplace, navigateToMatch, setFindHighlights]
   );
 
   // Replace every match in one undoable transaction. Apply end → start so each
@@ -7444,9 +7505,10 @@ body { background: white; }
       view.dispatch(tr.scrollIntoView());
       findResultRef.current = null;
       findReplace.setMatches([], 0);
+      setFindHighlights([], 0);
       return matches.length;
     },
-    [findReplace]
+    [findReplace, setFindHighlights]
   );
 
   // Expose ref methods
@@ -9953,7 +10015,10 @@ body { background: white; }
               {findReplace.state.isOpen && (
                 <FindReplaceDialog
                   isOpen={findReplace.state.isOpen}
-                  onClose={findReplace.close}
+                  onClose={() => {
+                    findReplace.close();
+                    setFindHighlights([], 0);
+                  }}
                   onFind={handleFind}
                   onFindNext={handleFindNext}
                   onFindPrevious={handleFindPrevious}

--- a/docx-editor/packages/react/src/styles/editor.css
+++ b/docx-editor/packages/react/src/styles/editor.css
@@ -454,6 +454,18 @@
   outline: 2px solid rgba(255, 152, 0, 0.8);
 }
 
+/* Find/replace match highlights painted by DecorationLayer over the visible
+   pages (findHighlightPlugin inline decorations). Each is an absolute overlay
+   rect above the text, so a translucent fill tints the matched run. */
+.find-match {
+  background-color: rgba(255, 235, 59, 0.45);
+  border-radius: 2px;
+}
+.find-match-current {
+  background-color: rgba(255, 152, 0, 0.55);
+  border-radius: 2px;
+}
+
 /* ============================================================================
  * AI ACTION PREVIEW HIGHLIGHTING
  * ============================================================================ */


### PR DESCRIPTION
Find & Replace previously only counted matches and scrolled to the current one — it didn't visually highlight anything. Now every match is highlighted over the visible pages (yellow), with the current match marked distinctly (orange), matching Google Docs.

Implementation: a small ProseMirror plugin (`findHighlightPlugin`) turns the match ranges (PM positions from #199's `findInPmDoc`) into inline decorations, which the existing `DecorationLayer` paints over the paginated layer — the same path grammar/spellcheck squiggles use. The find handlers publish ranges + current index via a plugin meta; highlights map through edits and clear when the find bar closes. Purely additive — it doesn't touch find/replace behavior.

Verified (Playwright + screenshot): all matches highlighted, exactly one current marker that moves on navigate, highlights clear on close; all existing find-replace specs (apply / tables / shortcuts / scroll) still pass.