### PR TITLE
feat(format-painter): double-click for persistent paint

### DIFF
--- a/docx-editor/.changeset/format-painter-persistent.md
+++ b/docx-editor/.changeset/format-painter-persistent.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Format painter now supports Google-Docs-style persistent mode: double-click the paint-format button to apply the copied formatting to multiple selections in a row (until Escape or another click). A single click stays one-shot.

--- a/docx-editor/e2e/tests/format-painter-persistent.spec.ts
+++ b/docx-editor/e2e/tests/format-painter-persistent.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+/**
+ * Format painter: a single click paints one target then disarms (one-shot); a
+ * double-click arms persistent mode (paint many targets until Esc / another
+ * click), matching Google Docs.
+ */
+const PAINT = '[aria-label="Paint format"]';
+
+async function weightOf(page: import('@playwright/test').Page, text: string) {
+  return page.evaluate((t) => {
+    const span = [...document.querySelectorAll('.paged-editor__pages span')].find(
+      (s) => s.textContent === t
+    );
+    return span ? getComputedStyle(span).fontWeight : '?';
+  }, text);
+}
+
+test('double-click paints multiple targets; Escape disarms', async ({ page }) => {
+  test.setTimeout(60000);
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('SRC one two');
+  await page.waitForTimeout(150);
+  const mod = /Win/i.test(await page.evaluate(() => navigator.platform)) ? 'Control' : 'Meta';
+  await ed.selectText('SRC');
+  await page.keyboard.press(`${mod}+b`);
+  await page.waitForTimeout(150);
+
+  await page.locator(PAINT).first().dblclick();
+  await page.waitForTimeout(200);
+
+  await ed.selectText('one');
+  await page.waitForTimeout(250);
+  await ed.selectText('two');
+  await page.waitForTimeout(250);
+  expect(await weightOf(page, 'one')).toBe('700');
+  expect(await weightOf(page, 'two')).toBe('700');
+
+  await page.keyboard.press('Escape');
+  await page.waitForTimeout(150);
+  expect(
+    (await page.locator(PAINT).first().getAttribute('class'))?.includes('doc-primary-light')
+  ).toBe(false);
+});
+
+test('single click paints one target then disarms', async ({ page }) => {
+  test.setTimeout(60000);
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('SRC aaa bbb');
+  await page.waitForTimeout(150);
+  const mod = /Win/i.test(await page.evaluate(() => navigator.platform)) ? 'Control' : 'Meta';
+  await ed.selectText('SRC');
+  await page.keyboard.press(`${mod}+b`);
+  await page.waitForTimeout(150);
+
+  await page.locator(PAINT).first().click();
+  await page.waitForTimeout(150);
+  await ed.selectText('aaa');
+  await page.waitForTimeout(250);
+  await ed.selectText('bbb');
+  await page.waitForTimeout(250);
+  expect(await weightOf(page, 'aaa')).toBe('700');
+  expect(await weightOf(page, 'bbb')).not.toBe('700');
+});

--- a/docx-editor/e2e/tests/format-painter-persistent.spec.ts
+++ b/docx-editor/e2e/tests/format-painter-persistent.spec.ts
@@ -26,7 +26,7 @@ test('double-click paints multiple targets; Escape disarms', async ({ page }) =>
   await ed.focus();
   await ed.typeText('SRC one two');
   await page.waitForTimeout(150);
-  const mod = /Win/i.test(await page.evaluate(() => navigator.platform)) ? 'Control' : 'Meta';
+  const mod = /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
   await ed.selectText('SRC');
   await page.keyboard.press(`${mod}+b`);
   await page.waitForTimeout(150);
@@ -57,7 +57,7 @@ test('single click paints one target then disarms', async ({ page }) => {
   await ed.focus();
   await ed.typeText('SRC aaa bbb');
   await page.waitForTimeout(150);
-  const mod = /Win/i.test(await page.evaluate(() => navigator.platform)) ? 'Control' : 'Meta';
+  const mod = /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
   await ed.selectText('SRC');
   await page.keyboard.press(`${mod}+b`);
   await page.waitForTimeout(150);

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -1748,6 +1748,10 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // toggles between idle/armed.
   const [paintFormatMarks, setPaintFormatMarks] = useState<readonly PMMark[] | null>(null);
   const paintFormatMarksRef = useRef<readonly PMMark[] | null>(null);
+  // Double-click arms persistent paint (apply to many selections); single click
+  // is one-shot. `lastPaintClickRef` is how the toggle handler tells them apart.
+  const paintFormatPersistentRef = useRef(false);
+  const lastPaintClickRef = useRef(0);
   useEffect(() => {
     paintFormatMarksRef.current = paintFormatMarks;
   }, [paintFormatMarks]);
@@ -3770,10 +3774,23 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // disarm. Otherwise capture the current cursor's mark set; the next
   // selection-change with a non-empty selection will apply them.
   const handleTogglePaintFormat = useCallback(() => {
+    const now = Date.now();
+    const isDoubleClick = now - lastPaintClickRef.current < 350;
+    lastPaintClickRef.current = now;
+
+    // Already armed: a double-click promotes to persistent mode (paint many
+    // selections until Esc or another click, matching Google Docs); a single
+    // click disarms.
     if (paintFormatMarksRef.current) {
+      if (isDoubleClick) {
+        paintFormatPersistentRef.current = true;
+        return; // keep the captured marks, stay armed
+      }
+      paintFormatPersistentRef.current = false;
       setPaintFormatMarks(null);
       return;
     }
+
     const view = pagedEditorRef.current?.getView();
     if (!view) return;
     const { selection, storedMarks } = view.state;
@@ -3787,6 +3804,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     } else {
       marks = selection.$from.marks();
     }
+    paintFormatPersistentRef.current = isDoubleClick;
     setPaintFormatMarks(marks);
   }, []);
 
@@ -3807,14 +3825,19 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       tr = tr.addMark(from, to, m);
     }
     view.dispatch(tr);
-    setPaintFormatMarks(null);
+    // One-shot paint disarms after a single application; persistent (double-
+    // click) mode stays armed until Esc or another click on the button.
+    if (!paintFormatPersistentRef.current) setPaintFormatMarks(null);
   }, []);
 
   // Cancel paint-format on Escape.
   useEffect(() => {
     if (!paintFormatMarks) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setPaintFormatMarks(null);
+      if (e.key === 'Escape') {
+        paintFormatPersistentRef.current = false;
+        setPaintFormatMarks(null);
+      }
     };
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);


### PR DESCRIPTION
The format painter was one-shot only. Now, matching Google Docs, **double-clicking** the paint-format button arms persistent mode — the copied formatting applies to each subsequent selection until you press Escape or click the button again. A **single click** stays one-shot (paint one target, then disarm).

Implemented entirely in the existing toggle handler (double-click detected by click timing — no shared-component changes): an `isDoubleClick` check sets a persistent ref; `applyPaintedMarks` only disarms when not persistent; Escape clears it.

Verified (Playwright): double-click paints two targets in a row and Escape disarms; single click paints only the first target.