### PR TITLE
fix(ci): test modifier detection on Linux + Tab-adds-row scenario

### DIFF
--- a/docx-editor/e2e/scenarios/tables.json
+++ b/docx-editor/e2e/scenarios/tables.json
@@ -219,8 +219,8 @@
       ]
     },
     {
-      "name": "Tab at last cell moves below table",
-      "description": "Pressing Tab in the last cell should move to the paragraph after the table",
+      "name": "Tab at last cell adds a new row",
+      "description": "Pressing Tab in the last cell adds a new row and moves into it (Word / Google Docs)",
       "tags": ["edge-case"],
       "steps": [
         { "action": "goto" },
@@ -231,9 +231,9 @@
         { "action": "clickTableCell", "args": { "tableIndex": 0, "row": 0, "col": 1 } },
         { "action": "typeText", "args": { "text": "Last" } },
         { "action": "pressTab" },
-        { "action": "typeText", "args": { "text": "Below table" } },
-        { "assert": "expectDocumentContains", "args": { "text": "Below table" } },
-        { "assert": "expectTableDimensions", "args": { "tableIndex": 0, "rows": 1, "cols": 2 } }
+        { "action": "typeText", "args": { "text": "NewRow" } },
+        { "assert": "expectDocumentContains", "args": { "text": "NewRow" } },
+        { "assert": "expectTableDimensions", "args": { "tableIndex": 0, "rows": 2, "cols": 2 } }
       ]
     },
     {

--- a/docx-editor/e2e/tests/find-match-highlight.spec.ts
+++ b/docx-editor/e2e/tests/find-match-highlight.spec.ts
@@ -18,7 +18,7 @@ test('find highlights all matches, marks the current one, clears on close', asyn
   await ed.typeText('apple banana apple cherry apple');
   await page.waitForTimeout(200);
 
-  const mod = /Win/i.test(await page.evaluate(() => navigator.platform)) ? 'Control' : 'Meta';
+  const mod = /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
   await page.keyboard.press(`${mod}+f`);
   await page.locator('[data-testid="find-replace-dialog"]').waitFor({ timeout: 3000 });
   await page.locator('[data-testid="find-input"]').fill('apple');

--- a/docx-editor/e2e/tests/find-replace-apply.spec.ts
+++ b/docx-editor/e2e/tests/find-replace-apply.spec.ts
@@ -9,7 +9,7 @@ import { EditorPage } from '../helpers/editor-page';
  * echo and never re-seeded the editor, so Replace silently did nothing.
  */
 async function openReplace(page: import('@playwright/test').Page) {
-  const mod = /Win/i.test(await page.evaluate(() => navigator.platform)) ? 'Control' : 'Meta';
+  const mod = /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
   await page.keyboard.press(`${mod}+h`);
   await page.locator('[data-testid="find-replace-dialog"]').waitFor({ timeout: 3000 });
   return mod;
@@ -61,7 +61,7 @@ test('Replace preserves surrounding formatting', async ({ page }) => {
   await ed.focus();
   await ed.typeText('KEEP');
   await page.waitForTimeout(80);
-  const mod = /Win/i.test(await page.evaluate(() => navigator.platform)) ? 'Control' : 'Meta';
+  const mod = /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
   await page.keyboard.press(`${mod}+a`);
   await page.keyboard.press(`${mod}+b`); // bold "KEEP"
   await page.waitForTimeout(100);

--- a/docx-editor/e2e/tests/find-replace-tables.spec.ts
+++ b/docx-editor/e2e/tests/find-replace-tables.spec.ts
@@ -6,7 +6,7 @@ import { EditorPage } from '../helpers/editor-page';
  * replaces inside table cells — the old Document-model search skipped tables.
  */
 async function modKey(page: import('@playwright/test').Page) {
-  return /Win/i.test(await page.evaluate(() => navigator.platform)) ? 'Control' : 'Meta';
+  return /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
 }
 
 test('find counts matches in body and table cells; Replace All replaces all', async ({ page }) => {


### PR DESCRIPTION
Fixes the two CI failures on main:

1. **Find/replace + highlight specs timed out on Linux.** They detected the keyboard modifier as `/Win/.test(navigator.platform) ? 'Control' : 'Meta'`, which gives **Meta on Linux CI** (`navigator.platform === 'Linux x86_64'`), so Ctrl+F/H never opened the find dialog and every assertion hit a 3s timeout. (Locally Playwright reports `Win32`, so it resolved to Control and passed — masking the bug.) Switched to `/Mac/ ? 'Meta' : 'Control'`, which resolves to Control everywhere in Playwright and matches the app + the existing `openFindReplace` helper.

2. **`scenario-driven` 'Tab at last cell' asserted the old behavior.** #190 made Tab in the last cell add a new row (Word/Google Docs) instead of exiting the table; the scenario still expected 1 row + cursor below. Updated it to expect the new row.

Verified locally: the three find specs + the updated scenario all pass.