### PR TITLE
feat(shortcuts): Google Docs Ctrl+Shift alignment shortcuts

### DIFF
--- a/docx-editor/.changeset/gdocs-alignment-shortcuts.md
+++ b/docx-editor/.changeset/gdocs-alignment-shortcuts.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Add Google Docs paragraph-alignment shortcuts: Ctrl+Shift+L / E / R / J (left / center / right / justify) now work alongside the existing Word-style Ctrl+L / E / R / J.

--- a/docx-editor/e2e/tests/alignment-shortcuts.spec.ts
+++ b/docx-editor/e2e/tests/alignment-shortcuts.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+/**
+ * Paragraph alignment keyboard shortcuts. The editor binds both Word's
+ * Ctrl+L/E/R/J and Google Docs' Ctrl+Shift+L/E/R/J so either muscle memory
+ * works. (Detect the modifier from navigator.platform — branch on MAC, never
+ * WIN; Playwright reports Win32/Linux, never Mac, so this is Control on CI.)
+ */
+async function mod(page: import('@playwright/test').Page) {
+  return /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
+}
+
+async function align(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const p = document.querySelector(
+      '.layout-page-content .layout-paragraph'
+    ) as HTMLElement | null;
+    return p ? getComputedStyle(p).textAlign : '?';
+  });
+}
+
+test('Google Docs Ctrl+Shift+L/E/R/J set alignment', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('align me');
+  await page.waitForTimeout(150);
+  const m = await mod(page);
+
+  await page.keyboard.press(`${m}+Shift+e`);
+  await page.waitForTimeout(200);
+  expect(await align(page)).toBe('center');
+
+  await page.keyboard.press(`${m}+Shift+r`);
+  await page.waitForTimeout(200);
+  expect(await align(page)).toBe('right');
+
+  await page.keyboard.press(`${m}+Shift+l`);
+  await page.waitForTimeout(200);
+  expect(['left', 'start']).toContain(await align(page));
+});
+
+test("Word's Ctrl+E/R/L still work", async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('align me');
+  await page.waitForTimeout(150);
+  const m = await mod(page);
+
+  await page.keyboard.press(`${m}+e`);
+  await page.waitForTimeout(200);
+  expect(await align(page)).toBe('center');
+
+  await page.keyboard.press(`${m}+r`);
+  await page.waitForTimeout(200);
+  expect(await align(page)).toBe('right');
+});

--- a/docx-editor/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/core/ParagraphExtension.ts
@@ -902,13 +902,18 @@ export const ParagraphExtension = createNodeExtension({
         },
       },
       keyboardShortcuts: {
-        // Word / Google Docs paragraph alignment shortcuts.
-        // Surfaced by AlignmentButtons in the toolbar; bound here so the
-        // shortcut works whether or not the dropdown is open.
+        // Paragraph alignment shortcuts, surfaced by AlignmentButtons in the
+        // toolbar; bound here so the shortcut works whether or not the dropdown
+        // is open. Word uses Ctrl+L/E/R/J; Google Docs uses Ctrl+Shift+L/E/R/J —
+        // bind both so either muscle memory works.
         'Mod-l': makeSetAlignment('left'),
         'Mod-e': makeSetAlignment('center'),
         'Mod-r': makeSetAlignment('right'),
         'Mod-j': makeSetAlignment('both'),
+        'Mod-Shift-l': makeSetAlignment('left'),
+        'Mod-Shift-e': makeSetAlignment('center'),
+        'Mod-Shift-r': makeSetAlignment('right'),
+        'Mod-Shift-j': makeSetAlignment('both'),
       },
     };
   },


### PR DESCRIPTION
The editor bound paragraph alignment to Word's Ctrl+L/E/R/J but not Google Docs' Ctrl+Shift+L/E/R/J — so a GDocs user pressing Ctrl+Shift+E got nothing. Added the Ctrl+Shift+ variants alongside the Word ones (both fire the same alignment commands).

Verified (Playwright, incl. a forced-Linux `navigator.platform` simulation so the modifier-on-CI bug can't recur): Ctrl+Shift+E/R/L set center/right/left, and Word's Ctrl+E/R still work.

**Known follow-up (separate):** Google Docs' Ctrl+]/Ctrl+[ don't indent a *non-list* paragraph here — `Mod-]`/`Mod-[` only adjust list level. I prototyped a paragraph-indent fallback but the indent didn't re-render (the painter positions paragraphs absolutely from `indentLeft`; setting it via a transaction didn't re-layout — likely the measure-cache doesn't key on `indentLeft`). Worth a focused fix.