### PR TITLE
feat(shortcuts): Ctrl+]/Ctrl+[ indent any paragraph (Google Docs)

### DIFF
--- a/docx-editor/.changeset/gdocs-indent-shortcut.md
+++ b/docx-editor/.changeset/gdocs-indent-shortcut.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Ctrl+] / Ctrl+[ now indent / outdent a plain paragraph (Google Docs), not just list items — they bump the list level inside a list and adjust the paragraph indent otherwise.

--- a/docx-editor/e2e/tests/indent-shortcuts.spec.ts
+++ b/docx-editor/e2e/tests/indent-shortcuts.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+/**
+ * Ctrl+] / Ctrl+[ (Google Docs) indent / outdent. Inside a list they bump the
+ * list level; on a plain paragraph they change the left indent. Indent shifts
+ * the painted TEXT right (the paragraph container stays full-width and
+ * absolutely positioned), so we measure the first run's screen x.
+ */
+async function mod(page: import('@playwright/test').Page) {
+  return /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
+}
+
+function textX(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const s = document.querySelector(
+      '.layout-page-content .layout-line span, .layout-page-content .layout-run'
+    ) as HTMLElement | null;
+    return s ? Math.round(s.getBoundingClientRect().x) : -1;
+  });
+}
+
+test('Ctrl+] indents and Ctrl+[ outdents a plain paragraph', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('indent me please');
+  await page.waitForTimeout(150);
+  const m = await mod(page);
+
+  const x0 = await textX(page);
+  await page.keyboard.press(`${m}+]`);
+  await page.waitForTimeout(300);
+  const x1 = await textX(page);
+  expect(x1).toBeGreaterThan(x0);
+
+  await page.keyboard.press(`${m}+]`);
+  await page.waitForTimeout(300);
+  const x2 = await textX(page);
+  expect(x2).toBeGreaterThan(x1);
+
+  await page.keyboard.press(`${m}+[`);
+  await page.waitForTimeout(300);
+  expect(await textX(page)).toBeLessThan(x2);
+});
+
+test('Ctrl+] still nests inside a list', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.applyBulletList();
+  await ed.typeText('a');
+  await page.keyboard.press('Enter');
+  await ed.typeText('b');
+  await page.waitForTimeout(150);
+
+  await page.keyboard.press(`${await mod(page)}+]`);
+  await page.waitForTimeout(300);
+  // Still a list (two markers) — Ctrl+] bumped the level, didn't unlist.
+  expect(await page.locator('.layout-list-marker').count()).toBe(2);
+});

--- a/docx-editor/packages/core/src/prosemirror/extensions/features/ListExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/features/ListExtension.ts
@@ -177,6 +177,35 @@ const decreaseListLevel: Command = (state, dispatch) => {
   return true;
 };
 
+// Indent / outdent plain paragraphs by half an inch — the fallback for
+// Mod-] / Mod-[ (Google Docs' Ctrl+] / Ctrl+[) when the selection isn't in a
+// list. Mirrors ParagraphExtension's makeIncreaseIndent. Returns false when
+// nothing changes so it composes after the list-level command in a chain.
+const PARAGRAPH_INDENT_STEP = 720; // 0.5"
+const indentParagraphs =
+  (delta: number): Command =>
+  (state, dispatch) => {
+    const { $from, $to } = state.selection;
+    const targets: Array<{ pos: number; attrs: Record<string, unknown>; next: number }> = [];
+    const seen = new Set<number>();
+    state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
+      if (node.type.name !== 'paragraph' || seen.has(pos)) return;
+      seen.add(pos);
+      const cur = (node.attrs.indentLeft as number) ?? 0;
+      const next = Math.max(0, cur + delta);
+      if (next === cur) return;
+      targets.push({ pos, attrs: node.attrs, next });
+    });
+    if (targets.length === 0) return false;
+    if (!dispatch) return true;
+    let tr = state.tr;
+    for (const { pos, attrs, next } of targets) {
+      tr = tr.setNodeMarkup(pos, undefined, { ...attrs, indentLeft: next || null });
+    }
+    dispatch(tr.scrollIntoView());
+    return true;
+  };
+
 const removeList: Command = (state, dispatch) => {
   const { $from, $to } = state.selection;
 
@@ -462,10 +491,10 @@ export const ListExtension = createExtension({
         // Google Docs list shortcuts
         'Mod-Shift-7': toggleNumberedList,
         'Mod-Shift-8': toggleBulletList,
-        // Indent / outdent for paragraphs (works inside or outside lists —
-        // increaseListLevel handles both via the existing list-aware path).
-        'Mod-]': increaseListLevel,
-        'Mod-[': decreaseListLevel,
+        // Indent / outdent: bump the list level inside a list, else indent the
+        // plain paragraph (Google Docs' Ctrl+] / Ctrl+[ work on any paragraph).
+        'Mod-]': chainCommands(increaseListLevel, indentParagraphs(PARAGRAPH_INDENT_STEP)),
+        'Mod-[': chainCommands(decreaseListLevel, indentParagraphs(-PARAGRAPH_INDENT_STEP)),
       },
     };
   },


### PR DESCRIPTION
Ctrl+] / Ctrl+[ only changed list level — on a plain paragraph they did nothing, but Google Docs indents/outdents any paragraph. Now `Mod-]`/`Mod-[` chain: bump the list level inside a list, else adjust the paragraph's left indent (mirrors the toolbar indent button + ParagraphExtension's makeIncreaseIndent).

This is the follow-up flagged in #203. (Note: paragraph indent shifts the painted *text*, not the absolutely-positioned paragraph container — an earlier measurement of the container's marginLeft wrongly suggested indent was broken; it works, verified by the text's screen x.)

Verified (Playwright, incl. forced-Linux sim): Ctrl+] indents and Ctrl+[ outdents a plain paragraph (text shifts 0.5"/click), and Ctrl+] still nests inside a list.