### PR TITLE
feat(shortcuts): Google Docs heading shortcuts (Ctrl+Alt+1/2/3)

### DIFF
--- a/docx-editor/.changeset/heading-shortcuts.md
+++ b/docx-editor/.changeset/heading-shortcuts.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Add Google Docs heading shortcuts: Ctrl/Cmd+Alt+1/2/3 apply Heading 1/2/3 and Ctrl/Cmd+Alt+0 reverts to Normal text.

--- a/docx-editor/e2e/tests/heading-shortcuts.spec.ts
+++ b/docx-editor/e2e/tests/heading-shortcuts.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+/**
+ * Google Docs heading shortcuts: Ctrl/Cmd+Alt+1/2/3 apply Heading 1/2/3,
+ * Ctrl/Cmd+Alt+0 reverts to Normal text. (Modifier detection branches on MAC —
+ * Playwright reports Win32/Linux, never Mac, so it's Control on CI.)
+ */
+async function mod(page: import('@playwright/test').Page) {
+  return /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
+}
+
+function fontPx(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const s = document.querySelector(
+      '.layout-page-content .layout-line span, .layout-page-content .layout-run'
+    ) as HTMLElement | null;
+    return s ? Math.round(parseFloat(getComputedStyle(s).fontSize)) : -1;
+  });
+}
+
+test('Ctrl+Alt+1/2/3 apply headings and Ctrl+Alt+0 reverts to Normal', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('My heading');
+  await page.waitForTimeout(150);
+  const m = await mod(page);
+
+  const base = await fontPx(page);
+
+  await page.keyboard.press(`${m}+Alt+1`);
+  await page.waitForTimeout(300);
+  const h1 = await fontPx(page);
+  expect(h1).toBeGreaterThan(base);
+
+  await page.keyboard.press(`${m}+Alt+2`);
+  await page.waitForTimeout(300);
+  const h2 = await fontPx(page);
+  expect(h2).toBeGreaterThan(base);
+  expect(h2).toBeLessThanOrEqual(h1);
+
+  await page.keyboard.press(`${m}+Alt+0`);
+  await page.waitForTimeout(300);
+  expect(await fontPx(page)).toBe(base);
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -3635,6 +3635,26 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         setShowCommandPalette(true);
       }
 
+      // Google Docs heading shortcuts: Ctrl/Cmd+Alt+1/2/3 → Heading 1/2/3,
+      // Ctrl/Cmd+Alt+0 → Normal text. Match on e.code (the physical digit key)
+      // so it works regardless of what Alt+digit produces on the layout.
+      if (cmdOrCtrl && e.altKey && !e.shiftKey) {
+        const styleId =
+          e.code === 'Digit1'
+            ? 'Heading1'
+            : e.code === 'Digit2'
+              ? 'Heading2'
+              : e.code === 'Digit3'
+                ? 'Heading3'
+                : e.code === 'Digit0'
+                  ? 'Normal'
+                  : null;
+        if (styleId && applyHeadingStyleRef.current) {
+          e.preventDefault();
+          applyHeadingStyleRef.current(styleId);
+        }
+      }
+
       // Mod+Shift+\ → toggle focus mode. iA Writer / Bear / Notion all
       // use a variant of this; backslash is chosen because it sits
       // alone on every layout (no conflict with format shortcuts) and


### PR DESCRIPTION
Adds the Google Docs heading shortcuts, which were missing: Ctrl/Cmd+Alt+1/2/3 apply Heading 1/2/3, and Ctrl/Cmd+Alt+0 reverts to Normal text. Wired into the existing document keydown handler (next to Ctrl+K / Ctrl+\), reusing the same applyHeadingStyle path as the markdown '# ' shortcut. Matches on e.code (physical digit key) so it's layout-robust.

Verified (Playwright, incl. forced-Linux sim): Ctrl+Alt+1 → larger H1 font, Ctrl+Alt+2 → H2 (between H1 and body), Ctrl+Alt+0 → back to the body size.