### PR TITLE
fix(editor): PageUp/PageDown scroll the viewport

### DIFF
--- a/docx-editor/.changeset/pageup-pagedown-scroll.md
+++ b/docx-editor/.changeset/pageup-pagedown-scroll.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix PageUp / PageDown: they now scroll the editor viewport by ~one page (Google Docs behavior). Previously they did nothing, because the keys were delegated to the off-screen ProseMirror, which scrolls its hidden area rather than the visible paginated pages.

--- a/docx-editor/e2e/tests/pageup-pagedown.spec.ts
+++ b/docx-editor/e2e/tests/pageup-pagedown.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+/**
+ * PageUp / PageDown scroll the visible viewport by ~one page (Google Docs —
+ * the caret stays). The off-screen ProseMirror's native paging scrolls its
+ * hidden area, not the paginated pages, so the nav hook handles it against the
+ * real scroll container.
+ */
+function maxScrollTop(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    let best = 0;
+    document.querySelectorAll<HTMLElement>('*').forEach((el) => {
+      if (el.scrollHeight - el.clientHeight > 50 && el.scrollTop > best) best = el.scrollTop;
+    });
+    return best;
+  });
+}
+
+test('PageDown scrolls down and PageUp scrolls back up', async ({ page }) => {
+  test.setTimeout(60000);
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  // Fill well past one viewport.
+  for (let i = 0; i < 70; i++) {
+    await ed.typeText('Line ' + i);
+    await page.keyboard.press('Enter');
+  }
+  await page.waitForTimeout(300);
+
+  const mod = /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
+  await page.keyboard.press(`${mod}+Home`);
+  await page.waitForTimeout(200);
+
+  const s0 = await maxScrollTop(page);
+  await page.keyboard.press('PageDown');
+  await page.waitForTimeout(300);
+  const s1 = await maxScrollTop(page);
+  expect(s1).toBeGreaterThan(s0);
+
+  await page.keyboard.press('PageDown');
+  await page.waitForTimeout(300);
+  const s2 = await maxScrollTop(page);
+  expect(s2).toBeGreaterThan(s1);
+
+  await page.keyboard.press('PageUp');
+  await page.waitForTimeout(300);
+  expect(await maxScrollTop(page)).toBeLessThan(s2);
+});

--- a/docx-editor/packages/react/src/paged-editor/useVisualLineNavigation.ts
+++ b/docx-editor/packages/react/src/paged-editor/useVisualLineNavigation.ts
@@ -241,6 +241,25 @@ export function useVisualLineNavigation({ pagesContainerRef }: VisualLineNavigat
    */
   const handlePMKeyDown = useCallback(
     (view: EditorView, event: KeyboardEvent): boolean => {
+      // PageUp / PageDown → scroll the visible viewport by ~one page, like
+      // Google Docs (the caret stays put). The off-screen ProseMirror's native
+      // paging scrolls ITS hidden area, not the paginated pages, so handle it
+      // here against the real scroll container.
+      if (
+        (event.key === 'PageUp' || event.key === 'PageDown') &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        !event.shiftKey
+      ) {
+        const container = pagesContainerRef.current;
+        const sc = container ? findVerticalScrollParent(container) : null;
+        if (!sc) return false;
+        const delta = sc.clientHeight * 0.9; // one viewport, with overlap
+        sc.scrollBy({ top: event.key === 'PageDown' ? delta : -delta });
+        return true;
+      }
+
       // Ctrl/Cmd + Home / End → document start / end (caret move). The
       // container separately scrolls the viewport; without this the caret
       // stays put. Shift extends the selection to the doc edge.


### PR DESCRIPTION
PageUp / PageDown did nothing — no scroll, no caret move. Like Home/End (#197), they were delegated to the off-screen ProseMirror, whose native paging scrolls its hidden off-screen area, not the visible paginated pages.

The visual-line-navigation hook now handles plain PageUp/PageDown by scrolling the real scroll container by ~0.9 of a viewport (Google Docs behavior — the caret stays put; Ctrl/Cmd and Shift variants are left alone).

Verified (Playwright): in a multi-page doc, PageDown increases scrollTop twice in a row and PageUp scrolls back up.