### PR TITLE
fix(editor): Shift+Click extends the selection

### DIFF
--- a/docx-editor/.changeset/shift-click-extend.md
+++ b/docx-editor/.changeset/shift-click-extend.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Fix Shift+Click: it now extends the selection from the existing anchor to the clicked point, instead of collapsing the selection to the click. A subsequent drag keeps extending from that anchor.

--- a/docx-editor/e2e/tests/shift-click-select.spec.ts
+++ b/docx-editor/e2e/tests/shift-click-select.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+/**
+ * Shift+Click extends the selection from the existing anchor to the clicked
+ * point (a fundamental selection gesture). Previously the painted-layer
+ * mousedown handler always collapsed the selection to the click, ignoring
+ * the Shift modifier.
+ */
+test('Shift+Click extends the selection to the click point', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('AAAA BBBB CCCC DDDD');
+  await page.waitForTimeout(200);
+
+  const span = page.locator('.layout-page-content span', { hasText: 'AAAA' }).first();
+  const box = await span.boundingBox();
+  if (!box) throw new Error('no span box');
+
+  // Place the cursor at the very start.
+  await page.mouse.click(box.x + 2, box.y + box.height / 2);
+  await page.waitForTimeout(120);
+
+  // Shift+Click partway through CCCC → selection from start to that point.
+  await page.keyboard.down('Shift');
+  await page.mouse.click(box.x + box.width * 0.62, box.y + box.height / 2);
+  await page.keyboard.up('Shift');
+  await page.waitForTimeout(150);
+
+  // Typing replaces the selection — the left chunk is gone.
+  await ed.typeText('X');
+  await page.waitForTimeout(150);
+  const body = (await page.locator('.paged-editor__pages').innerText()).trim();
+  expect(body.startsWith('X')).toBe(true);
+  expect(body).not.toContain('AAAA');
+  expect(body).toContain('DDDD');
+});
+
+test('a plain click still just places the cursor (no extend)', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('one two three');
+  await page.waitForTimeout(200);
+
+  const span = page.locator('.layout-page-content span', { hasText: 'one' }).first();
+  const box = await span.boundingBox();
+  if (!box) throw new Error('no span box');
+  // Click near the start, then type — inserts there, nothing replaced.
+  await page.mouse.click(box.x + 2, box.y + box.height / 2);
+  await page.waitForTimeout(120);
+  await ed.typeText('Z');
+  await page.waitForTimeout(150);
+  const body = (await page.locator('.paged-editor__pages').innerText()).trim();
+  expect(body).toContain('two three');
+  expect(body).toMatch(/Z/);
+});

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -3384,10 +3384,20 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
 
           // Start dragging
           isDraggingRef.current = true;
-          dragAnchorRef.current = pmPos;
 
-          // Set initial selection (collapsed)
-          hiddenPMRef.current.setSelection(pmPos);
+          if (e.shiftKey) {
+            // Shift+Click extends the existing selection to the click point —
+            // keep the current anchor, move the head. A subsequent drag keeps
+            // extending from that same anchor.
+            const view = hiddenPMRef.current.getView();
+            const anchor = view ? view.state.selection.anchor : pmPos;
+            dragAnchorRef.current = anchor;
+            hiddenPMRef.current.setSelection(anchor, pmPos);
+          } else {
+            dragAnchorRef.current = pmPos;
+            // Set initial selection (collapsed)
+            hiddenPMRef.current.setSelection(pmPos);
+          }
         } else {
           // Clicked outside content - move to end
           cellDragAnchorPosRef.current = null;


### PR DESCRIPTION
Shift+Click didn't extend the selection — the painted-layer mousedown handler always collapsed the selection to the click point, ignoring the Shift modifier. So Shift+Click (a fundamental selection gesture) just moved the cursor.

Now, when Shift is held, the handler keeps the current anchor and moves the head to the click point; a subsequent drag continues extending from that anchor.

Verified (Playwright): Shift+Click selects from the cursor to the click (typing replaces the chunk), a plain click still just places the cursor, and the 14 existing cursor/click positioning tests still pass.