### PR TITLE
fix(ci): retry bun install to survive transient npm tarball flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,14 @@ jobs:
           bun-version: '1.3.14'
 
       - name: Install
-        run: bun install --frozen-lockfile
+        # Retry to survive transient npm registry tarball flakes.
+        run: |
+          for i in 1 2 3; do
+            bun install --frozen-lockfile && exit 0
+            echo "::warning::bun install attempt $i failed; retrying in 10s"
+            sleep 10
+          done
+          exit 1
 
       - name: Format check
         run: bun run format:check
@@ -61,7 +68,14 @@ jobs:
           bun-version: '1.3.14'
 
       - name: Install
-        run: bun install --frozen-lockfile
+        # Retry to survive transient npm registry tarball flakes.
+        run: |
+          for i in 1 2 3; do
+            bun install --frozen-lockfile && exit 0
+            echo "::warning::bun install attempt $i failed; retrying in 10s"
+            sleep 10
+          done
+          exit 1
 
       - name: Typecheck
         run: bun run typecheck
@@ -102,7 +116,14 @@ jobs:
           bun-version: '1.3.14'
 
       - name: Install
-        run: bun install --frozen-lockfile
+        # Retry to survive transient npm registry tarball flakes.
+        run: |
+          for i in 1 2 3; do
+            bun install --frozen-lockfile && exit 0
+            echo "::warning::bun install attempt $i failed; retrying in 10s"
+            sleep 10
+          done
+          exit 1
 
       # Cache the Playwright browser binaries. The cache key embeds the
       # @playwright/test version pulled from node_modules so a Playwright

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -39,7 +39,15 @@ jobs:
           bun-version: '1.3.14'
 
       - name: Install
-        run: bun install --frozen-lockfile
+        # Retry to survive transient npm registry tarball flakes
+        # (e.g. sharp's optional platform binary failing to download).
+        run: |
+          for i in 1 2 3; do
+            bun install --frozen-lockfile && exit 0
+            echo "::warning::bun install attempt $i failed; retrying in 10s"
+            sleep 10
+          done
+          exit 1
 
       - name: Build core + react libs
         run: bun run build

--- a/.github/workflows/fidelity-compare.yml
+++ b/.github/workflows/fidelity-compare.yml
@@ -60,7 +60,14 @@ jobs:
           bun-version: '1.3.14'
 
       - name: Install editor deps
-        run: bun install --frozen-lockfile
+        # Retry to survive transient npm registry tarball flakes.
+        run: |
+          for i in 1 2 3; do
+            bun install --frozen-lockfile && exit 0
+            echo "::warning::bun install attempt $i failed; retrying in 10s"
+            sleep 10
+          done
+          exit 1
 
       - name: Install LibreOffice
         run: |

--- a/.github/workflows/visual-fidelity.yml
+++ b/.github/workflows/visual-fidelity.yml
@@ -58,7 +58,14 @@ jobs:
           bun-version: '1.3.14'
 
       - name: Install editor deps
-        run: bun install --frozen-lockfile
+        # Retry to survive transient npm registry tarball flakes.
+        run: |
+          for i in 1 2 3; do
+            bun install --frozen-lockfile && exit 0
+            echo "::warning::bun install attempt $i failed; retrying in 10s"
+            sleep 10
+          done
+          exit 1
 
       # The reference renderer shells out to LibreOffice (DOCX → PDF) and the
       # editor renderer drives headless Chromium; both apt installs hit the same


### PR DESCRIPTION
The Pages deploy for #205 failed because bun could not download sharp's optional platform binary (`@img/sharp-libvips-linux-x64`) from the npm registry, so `bun install --frozen-lockfile` exited 1 and failed the build — a transient infra flake, not a code issue.

Every install step (CI, deploy-demo, visual-fidelity, fidelity-compare) now retries up to 3 times with a short backoff, so one registry hiccup no longer breaks the build. Validated with actionlint.