### PR TITLE
fix(test): stop pageup-pagedown e2e timing out on CI

### DIFF
--- a/docx-editor/e2e/tests/pageup-pagedown.spec.ts
+++ b/docx-editor/e2e/tests/pageup-pagedown.spec.ts
@@ -24,14 +24,19 @@ test('PageDown scrolls down and PageUp scrolls back up', async ({ page }) => {
   await ed.waitForReady();
   await ed.newDocument();
   await ed.focus();
-  // Fill well past one viewport.
-  for (let i = 0; i < 70; i++) {
-    await ed.typeText('Line ' + i);
-    await page.keyboard.press('Enter');
+
+  const mod = /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
+  // Build a multi-page (scrollable) doc with page breaks rather than typing
+  // dozens of lines — char-by-char typing of a long doc is slow enough on CI
+  // to blow the test's keyboard-input budget. A handful of page breaks gives
+  // several pages with a few keystrokes.
+  await ed.typeText('Top');
+  for (let i = 0; i < 5; i++) {
+    await page.keyboard.press(`${mod}+Enter`); // page break
+    await ed.typeText('Page ' + (i + 2));
   }
   await page.waitForTimeout(300);
 
-  const mod = /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
   await page.keyboard.press(`${mod}+Home`);
   await page.waitForTimeout(200);
 


### PR DESCRIPTION
The PageDown/PageUp scroll test built a scrollable document by typing 70 lines one character at a time (~490 key events). On the slower CI runner — compounded by per-keystroke re-render cost that grows with document length — that exceeded the test's keyboard-input budget and the page was closed mid-type (60s timeout, failing shard 3 across all retries).

It now builds the same multi-page, scrollable doc with a handful of page breaks (`Mod+Enter`) — a few keystrokes instead of hundreds. Runs in ~5s locally; verified on a Linux-simulated platform so the Control modifier path is exercised too.