### PR TITLE
feat(pages): add Google Analytics tracking

### DIFF
--- a/docx-editor/examples/vite/index.html
+++ b/docx-editor/examples/vite/index.html
@@ -74,6 +74,15 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/favicon.svg" />
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1CDWFLK79M"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1CDWFLK79M');
+    </script>
+
     <!--
     JSON-LD: SoftwareApplication + Person + WebSite.
     Google's rich-results indexer + LLM crawlers (Perplexity, ChatGPT


### PR DESCRIPTION
Adds the G-1CDWFLK79M gtag.js snippet to the GitHub Pages demo (`docx-editor/examples/vite/index.html`). No changes to the editor or build — analytics only runs on the deployed static site.