### PR TITLE
test(odt-open): widen timeouts for the flaky WASM conversion

### DIFF
--- a/docx-editor/e2e/tests/odt-open.spec.ts
+++ b/docx-editor/e2e/tests/odt-open.spec.ts
@@ -25,6 +25,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ODT_FIXTURE = path.join(__dirname, '..', 'fixtures', 'casual-sample.odt');
 
 test('opens a .odt file from the Home picker and renders its text', async ({ page }) => {
+  // The 7 MB WASM converter dominates this test's wall-clock; give the whole
+  // test a budget wide enough that its slower-path load can't trip the default
+  // per-test timeout (the root of the odt-open flake).
+  test.setTimeout(120000);
   // Plain `/` lands on Home; `?e2e=1` would force the editor and skip the picker.
   await page.goto('/');
 
@@ -35,13 +39,17 @@ test('opens a .odt file from the Home picker and renders its text', async ({ pag
   await fileInput.setInputFiles(ODT_FIXTURE);
 
   // Editor mounts once the WASM converter returns DOCX bytes. The 7 MB WASM is
-  // lazy-loaded on first conversion, so allow a generous mount window.
-  await page.waitForSelector('[data-testid="docx-editor"]', { timeout: 45000 });
+  // lazy-loaded on first conversion and — when the dev server serves it without
+  // the application/wasm MIME — instantiation falls back to the slower
+  // non-streaming path, which on a loaded CI runner intermittently blew the old
+  // 45 s window (the long-standing odt-open flake). Widen the mount + text
+  // windows so WASM-load timing variance stops producing false failures.
+  await page.waitForSelector('[data-testid="docx-editor"]', { timeout: 90000 });
   await page.waitForFunction(() => document.fonts.ready);
 
   // The converted document's text must appear in the painted pages — this is
   // the real proof the .odt was decoded, not just accepted.
   const pages = page.locator('.paged-editor__pages');
-  await expect(pages).toContainText('Casual ODT Fixture Heading', { timeout: 15000 });
+  await expect(pages).toContainText('Casual ODT Fixture Heading', { timeout: 30000 });
   await expect(pages).toContainText('This paragraph proves ODT open works end to end');
 });


### PR DESCRIPTION
`odt-open` opens a .odt via the 7 MB WASM converter (lazy-loaded, and instantiated via the slower non-streaming path when the dev server serves the .wasm without the `application/wasm` MIME). On a loaded CI runner that intermittently exceeded the 45 s mount window and the default per-test timeout — the long-standing odt-open flake (passes most runs, fails some; it just failed twice on an unrelated compose-only PR).

Raises the per-test budget to 120 s, the editor-mount wait to 90 s, and the text assertion to 30 s. No product change — pure test robustness.

Note: verified it's not a regression — odt-open passed on the `b8503e5` CI run (which PR #228 branches off), and pinning `@schnsrw/core` back to 0.1.1 doesn't change the outcome, so this is timing variance, not a code break.