### PR TITLE
fix(sdk): revert @schnsrw/core to ^0.1.1 — 0.2.0 breaks the WASM converter

### DIFF
--- a/docx-editor/bun.lock
+++ b/docx-editor/bun.lock
@@ -113,7 +113,7 @@
         "@huggingface/transformers": "^4.2.0",
         "@mlc-ai/web-llm": "^0.2.84",
         "@radix-ui/react-select": "^2.2.6",
-        "@schnsrw/core": "^0.2.0",
+        "@schnsrw/core": "^0.1.1",
         "clsx": "^2.1.0",
         "dictionary-en": "^4.0.0",
         "katex": "^0.17.0",
@@ -665,7 +665,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
 
-    "@schnsrw/core": ["@schnsrw/core@0.2.0", "", {}, "sha512-1GH24OfE3KdIb87cuDNz0Ib1K6+yPOTPvkpD375LfmBmXuLGzBnOuEBHHVPLSqkXbqLR4LIe5yEXs11jd2TA0w=="],
+    "@schnsrw/core": ["@schnsrw/core@0.1.1", "", {}, "sha512-IP1ug4JRr/YV9wsqXB96xytO8jioAwW8I76JYXS/7ktWDo6JXFeUcqy/iwuLZ6dWdYYQOXV6Pit/yccbeRI1Dg=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "7.29.0", "@babel/runtime": "7.29.2", "@types/aria-query": "5.0.4", "aria-query": "5.3.0", "dom-accessibility-api": "0.5.16", "lz-string": "1.5.0", "picocolors": "1.1.1", "pretty-format": "27.5.1" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/docx-editor/packages/react/package.json
+++ b/docx-editor/packages/react/package.json
@@ -128,7 +128,7 @@
     "@huggingface/transformers": "^4.2.0",
     "@mlc-ai/web-llm": "^0.2.84",
     "@radix-ui/react-select": "^2.2.6",
-    "@schnsrw/core": "^0.2.0",
+    "@schnsrw/core": "^0.1.1",
     "clsx": "^2.1.0",
     "dictionary-en": "^4.0.0",
     "katex": "^0.17.0",


### PR DESCRIPTION
**Fixes the CI regression on `main`.** The `@schnsrw/core` bump to `^0.2.0` (74fccbb) broke the odt/md/txt WASM conversion.

CI archaeology is conclusive:
- `497670b` (before the bump) — **success**
- `74fccbb` (the bump) and every commit since — **failure** on shard 3 (`odt-open`)

The 0.2.0 WASM never returns, so the editor never mounts and the test times out. The bump was made on a false premise (that `^0.1.1` wouldn't resolve on npm) — 0.1.1 is published and `^0.1.1` resolves it fine, while 0.2.0 regresses the converter.

Reverts just the dependency (+ lockfile). The other 74fccbb changes (format-aware worker-URL rewrite for GH #4, VERSION/CSS-doc fixes) are unaffected and stay on main.

CI shard 3 should go green again with this.