### PR TITLE
fix(md): white-on-light text in dark mode (invisible source/preview)

### DIFF
--- a/docx-editor/e2e/tests/markdown-editor.spec.ts
+++ b/docx-editor/e2e/tests/markdown-editor.spec.ts
@@ -33,6 +33,29 @@ async function openMarkdown(page: import('@playwright/test').Page) {
   await page.waitForSelector('[data-testid="markdown-editor"]', { timeout: 30000 });
 }
 
+test('dark mode: source + preview text stays readable (no white-on-light)', async ({ page }) => {
+  // A prior docx-editor mount sets data-theme="dark" on <html>; the markdown
+  // editor must theme its panes consistently. Regression: the panes used the
+  // always-light page-paper token while text used the theme-swapping text
+  // token, producing white text on a near-white pane.
+  await page.addInitScript(() => document.documentElement.setAttribute('data-theme', 'dark'));
+  await page.goto('/');
+  await page.getByTestId('home-file-input').setInputFiles(MD_FIXTURE);
+  await page.waitForSelector('[data-testid="markdown-editor"]', { timeout: 30000 });
+
+  const lum = (rgb: string) => {
+    const m = rgb.match(/\d+/g)!.map(Number);
+    return (0.299 * m[0] + 0.587 * m[1] + 0.114 * m[2]) / 255;
+  };
+  const contrast = await page.evaluate(() => {
+    const src = document.querySelector('[data-testid="markdown-source"] .cm-content')!;
+    const pane = document.querySelector('[data-testid="markdown-source"] .cm-editor')!;
+    return { text: getComputedStyle(src).color, bg: getComputedStyle(pane).backgroundColor };
+  });
+  // Text and pane luminance must differ enough to be readable.
+  expect(Math.abs(lum(contrast.text) - lum(contrast.bg))).toBeGreaterThan(0.3);
+});
+
 test('opens .md in the source+preview editor with raw markdown and rendered preview', async ({
   page,
 }) => {

--- a/docx-editor/examples/vite/src/markdown/markdown-editor.css
+++ b/docx-editor/examples/vite/src/markdown/markdown-editor.css
@@ -21,8 +21,12 @@
      as one product. --doc-* is defined globally by editor.css (imported in
      styles.css); the hex fallbacks are the DS light values. */
   --md-chrome: var(--doc-chrome, #eef1f5);
-  --md-paper: var(--doc-page-paper, #ffffff);
-  --md-surface: var(--doc-page-paper, #ffffff);
+  /* Editing panes use --doc-SURFACE (theme-swapping panel bg), NOT
+     --doc-page-paper: the page-paper token stays light in dark mode (the
+     printed page is always white), so pairing it with --doc-text — which DOES
+     go light in dark mode — produced white text on a light pane. */
+  --md-paper: var(--doc-surface, #ffffff);
+  --md-surface: var(--doc-surface, #ffffff);
   --md-surface-2: var(--doc-chrome, #eef1f5);
   --md-surface-3: var(--doc-bg-hover, #e3e7ee);
   --md-border: var(--doc-border, #cdd3db);
@@ -38,8 +42,8 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --md-chrome: var(--doc-chrome, #2a2e35);
-    --md-paper: var(--doc-page-paper, #1b1e23);
-    --md-surface: var(--doc-page-paper, #1b1e23);
+    --md-paper: var(--doc-surface, #1b1e23);
+    --md-surface: var(--doc-surface, #1b1e23);
     --md-surface-2: var(--doc-chrome, #2a2e35);
     --md-surface-3: var(--doc-bg-hover, #14161a);
     --md-border: var(--doc-border, #424751);


### PR DESCRIPTION
**Regression from the chrome-alignment pass — critical, text was invisible.**

The editing panes mapped `--md-surface` → `--doc-page-paper`, which stays **light** in dark mode (the printed page is always white: `#fff` / `#ececec`). But `--md-text` → `--doc-text` **swaps to white** in dark mode. So once anything set `data-theme="dark"` on `<html>` (e.g. a prior docx-editor mount), the source + preview showed near-white text on a near-white pane — invisible.

- Point `--md-paper`/`--md-surface` at `--doc-surface` (the theme-swapping panel bg) so pane and text always come from the same theme state.
- Verified with computed values (dark: `#1b1e23` pane + `#e6e6e6` text) and a screenshot.
- New e2e: opens the md editor under `data-theme=dark` and asserts source text/pane luminance differ enough to be readable (would have caught this).