### PR TITLE
fix(md): theme-adaptive syntax highlighting (dark keys were unreadable)

### DIFF
--- a/docx-editor/bun.lock
+++ b/docx-editor/bun.lock
@@ -46,6 +46,7 @@
         "@codemirror/state": "^6.7.0",
         "@codemirror/view": "^6.43.2",
         "@hocuspocus/provider": "^2.15.0",
+        "@lezer/highlight": "^1.2.3",
         "@lezer/markdown": "^1.6.4",
         "codemirror": "^6.0.2",
         "dompurify": "^3.4.11",

--- a/docx-editor/e2e/tests/markdown-editor.spec.ts
+++ b/docx-editor/e2e/tests/markdown-editor.spec.ts
@@ -56,6 +56,28 @@ test('dark mode: source + preview text stays readable (no white-on-light)', asyn
   expect(Math.abs(lum(contrast.text) - lum(contrast.bg))).toBeGreaterThan(0.3);
 });
 
+test('dark mode: .yml syntax-highlight tokens stay readable', async ({ page }) => {
+  // The default CodeMirror highlight style bakes in light-mode token colors
+  // (dark-blue keys) that vanish on a dark pane. Our theme-adaptive style must
+  // win over basicSetup's and swap colors under data-theme="dark".
+  await page.addInitScript(() => document.documentElement.setAttribute('data-theme', 'dark'));
+  await page.goto('/');
+  await page.getByTestId('home-file-input').setInputFiles(YML_FIXTURE);
+  await page.waitForSelector('[data-testid="markdown-editor"]', { timeout: 30000 });
+
+  const lum = (rgb: string) => {
+    const m = rgb.match(/\d+/g)!.map(Number);
+    return (0.299 * m[0] + 0.587 * m[1] + 0.114 * m[2]) / 255;
+  };
+  const c = await page.evaluate(() => {
+    const lines = document.querySelectorAll('[data-testid="markdown-source"] .cm-line');
+    const key = lines[1]?.querySelector('span'); // a YAML key token
+    const pane = document.querySelector('[data-testid="markdown-source"] .cm-editor')!;
+    return { key: key ? getComputedStyle(key).color : '', bg: getComputedStyle(pane).backgroundColor };
+  });
+  expect(Math.abs(lum(c.key) - lum(c.bg))).toBeGreaterThan(0.3);
+});
+
 test('opens .md in the source+preview editor with raw markdown and rendered preview', async ({
   page,
 }) => {

--- a/docx-editor/examples/vite/package.json
+++ b/docx-editor/examples/vite/package.json
@@ -16,6 +16,7 @@
     "@codemirror/state": "^6.7.0",
     "@codemirror/view": "^6.43.2",
     "@hocuspocus/provider": "^2.15.0",
+    "@lezer/highlight": "^1.2.3",
     "@lezer/markdown": "^1.6.4",
     "codemirror": "^6.0.2",
     "dompurify": "^3.4.11",

--- a/docx-editor/examples/vite/src/markdown/MarkdownEditor.tsx
+++ b/docx-editor/examples/vite/src/markdown/MarkdownEditor.tsx
@@ -8,7 +8,8 @@ import { Compartment, EditorState, type Extension } from '@codemirror/state';
 import { markdown } from '@codemirror/lang-markdown';
 import { GFM } from '@lezer/markdown';
 import { yaml } from '@codemirror/lang-yaml';
-import { StreamLanguage, syntaxHighlighting, defaultHighlightStyle } from '@codemirror/language';
+import { StreamLanguage, syntaxHighlighting } from '@codemirror/language';
+import { themeHighlightStyle } from './syntaxTheme';
 import { properties } from '@codemirror/legacy-modes/mode/properties';
 import { toml } from '@codemirror/legacy-modes/mode/toml';
 import { yCollab } from 'y-codemirror.next';
@@ -489,7 +490,10 @@ export function MarkdownEditor({
           // Explicit highlight style so language tokens (YAML keys, markdown
           // syntax, TOML, config keys) are actually colored — basicSetup's
           // fallback doesn't reliably paint tokens on its own here.
-          syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+          // NOT { fallback: true } — basicSetup already registers
+          // defaultHighlightStyle; ours must win (added after → higher
+          // precedence) so the theme-adaptive token colors actually apply.
+          syntaxHighlighting(themeHighlightStyle),
           ...langExtensions,
           // Notebook mode (markdown only) — toggled via the compartment below.
           liveCompartmentRef.current.of(

--- a/docx-editor/examples/vite/src/markdown/markdown-editor.css
+++ b/docx-editor/examples/vite/src/markdown/markdown-editor.css
@@ -35,6 +35,33 @@
   --md-text-muted: var(--doc-text-subtle, #7a7f88);
   --md-accent: var(--doc-primary, #1a73e8);
   --md-accent-soft: var(--doc-primary-light, rgba(26, 115, 232, 0.14));
+
+  /* Syntax-highlight token colors (light) — legible on the light pane. */
+  --md-hl-keyword: #0550ae;
+  --md-hl-property: #0b7285;
+  --md-hl-string: #0a7d33;
+  --md-hl-atom: #8250df;
+  --md-hl-comment: #6a737d;
+  --md-hl-variable: #1f2328;
+  --md-hl-type: #953800;
+  --md-hl-punct: #57606a;
+  --md-hl-meta: #795548;
+}
+
+/* Dark syntax colors — the pane goes dark when [data-theme='dark'] is set on an
+   ancestor (--md-surface = --doc-surface swaps there), so the token colors must
+   swap on the SAME trigger, not on prefers-color-scheme. Default's light-blue
+   keywords were unreadable on the dark pane. */
+[data-theme='dark'] {
+  --md-hl-keyword: #79c0ff;
+  --md-hl-property: #56d4dd;
+  --md-hl-string: #7ee787;
+  --md-hl-atom: #d2a8ff;
+  --md-hl-comment: #8b949e;
+  --md-hl-variable: #e6edf3;
+  --md-hl-type: #ffa657;
+  --md-hl-punct: #a5adba;
+  --md-hl-meta: #d7ba7d;
 }
 
 /* Dark: --doc-* already swaps under [data-theme='dark'] set by editor.css;

--- a/docx-editor/examples/vite/src/markdown/syntaxTheme.ts
+++ b/docx-editor/examples/vite/src/markdown/syntaxTheme.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Theme-adaptive syntax highlighting for the source editor.
+ *
+ * CodeMirror's built-in `defaultHighlightStyle` bakes in light-mode colors
+ * (dark-blue keywords, etc.) that are barely legible on a dark background. We
+ * define the token colors as CSS custom properties instead, and let
+ * markdown-editor.css swap those properties under `[data-theme='dark']` — so
+ * YAML keys, markdown syntax, comments and strings stay readable in BOTH
+ * themes without any runtime reconfiguration.
+ */
+
+import { HighlightStyle } from '@codemirror/language';
+import { tags as t } from '@lezer/highlight';
+
+export const themeHighlightStyle = HighlightStyle.define([
+  { tag: [t.keyword, t.moduleKeyword, t.operatorKeyword], color: 'var(--md-hl-keyword)' },
+  {
+    tag: [t.propertyName, t.definition(t.propertyName), t.labelName],
+    color: 'var(--md-hl-property)',
+  },
+  { tag: [t.string, t.special(t.string), t.regexp], color: 'var(--md-hl-string)' },
+  { tag: [t.number, t.bool, t.atom, t.null], color: 'var(--md-hl-atom)' },
+  { tag: [t.comment, t.lineComment, t.blockComment], color: 'var(--md-hl-comment)', fontStyle: 'italic' },
+  { tag: [t.variableName, t.name], color: 'var(--md-hl-variable)' },
+  { tag: [t.typeName, t.className, t.namespace], color: 'var(--md-hl-type)' },
+  { tag: [t.operator, t.punctuation, t.separator, t.bracket], color: 'var(--md-hl-punct)' },
+  { tag: [t.meta, t.documentMeta], color: 'var(--md-hl-meta)' },
+  // Markdown structural tags (source mode of a .md file).
+  { tag: [t.heading, t.heading1, t.heading2, t.heading3], color: 'var(--md-hl-keyword)', fontWeight: '700' },
+  { tag: t.strong, fontWeight: '700' },
+  { tag: t.emphasis, fontStyle: 'italic' },
+  { tag: t.strikethrough, textDecoration: 'line-through' },
+  { tag: [t.link, t.url], color: 'var(--md-hl-property)', textDecoration: 'underline' },
+  { tag: t.monospace, color: 'var(--md-hl-string)' },
+  { tag: [t.processingInstruction, t.contentSeparator], color: 'var(--md-hl-comment)' },
+]);

--- a/docx-editor/examples/vite/vite.config.ts
+++ b/docx-editor/examples/vite/vite.config.ts
@@ -78,6 +78,9 @@ export default defineConfig(async () => {
         // The GFM extension's node types must come from the SAME @lezer/markdown
         // instance the parser uses, or the notebook decorations won't match.
         '@lezer/markdown',
+        // Highlight tags are compared by identity, so the HighlightStyle and the
+        // language must share ONE @lezer/highlight instance or nothing colors.
+        '@lezer/highlight',
       ],
       alias: [
         // Resolve package imports to source for live development


### PR DESCRIPTION
Found in the both-themes sweep after the panes fix. In dark mode the `.yml`/`.conf`/`.md`-source tokens kept light-mode colors — dark-blue YAML keys on a near-black pane, barely legible.

**Two causes:** CodeMirror's `defaultHighlightStyle` bakes in fixed light colors, and `basicSetup` already registers it — our override used `{ fallback: true }` so the default won.

**Fix:** a `themeHighlightStyle` whose token colors are CSS custom properties (`--md-hl-*`) that swap under `[data-theme='dark']` (the same trigger the panes use), registered **without** `fallback` so it wins. Added `@lezer/highlight` (deduped — highlight tags are identity-compared).

Verified: light keys teal (Δ=0.67), dark keys cyan (Δ=0.57) — both readable. New e2e asserts the YAML key token contrasts with the pane under `data-theme=dark`.