### PR TITLE
fix(find): search the open header/footer, not just the body

### DIFF
--- a/docx-editor/e2e/tests/find-replace-header-footer.spec.ts
+++ b/docx-editor/e2e/tests/find-replace-header-footer.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Find & Replace must operate on an open header/footer, not the main body.
+ *
+ * The HF inline editor is a separate ProseMirror view with its own document.
+ * Previously the find handlers hardcoded the main body view, so searching while
+ * editing a header found "0 of 0" and Replace did nothing — the header text was
+ * invisible to Find. The handlers now target the active editor (HF when one is
+ * open) and the shared find-highlight plugin paints match decorations inside
+ * the HF view.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+const TESTID = '[data-testid="docx-editor"]';
+const HEADER = `${TESTID} .layout-page-header`;
+const HF_PM = `${TESTID} .hf-editor-pm`;
+
+async function openHeaderEditor(page: import('@playwright/test').Page) {
+  const header = page.locator(HEADER).first();
+  await expect(header).toBeAttached();
+  const box = await header.boundingBox();
+  await page.mouse.dblclick(box!.x + 40, box!.y + box!.height / 2);
+  await page.waitForTimeout(400);
+  await expect(page.locator(`${TESTID} .paged-editor--editing-header`)).toBeAttached();
+}
+
+test('Find highlights and counts matches inside the open header', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.loadDocxFile('fixtures/header-with-table.docx');
+  await page.waitForTimeout(1500);
+
+  await openHeaderEditor(page);
+
+  // Open Find and search for text that only exists in the header
+  // ("HEADER LOGO" + "HEADER TEXT" → two matches).
+  const mod = /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
+  await page.keyboard.press(`${mod}+f`);
+  await page.locator('[data-testid="find-replace-dialog"]').waitFor({ timeout: 3000 });
+  await page.locator('[data-testid="find-input"]').fill('HEADER');
+  await page.locator('[data-testid="find-input"]').press('Enter');
+  await page.waitForTimeout(400);
+
+  // Match decorations are painted inside the HF editor (not the body) — the core
+  // regression: before the fix this was 0 because Find scanned the body doc.
+  const hfHighlights = page.locator(`${HF_PM} .find-match`);
+  await expect(hfHighlights).toHaveCount(2);
+
+  // And the dialog reports the header matches, not "no results".
+  const dlg = page.locator('[data-testid="find-replace-dialog"]');
+  await expect(dlg).toContainText('of 2 matches');
+});
+
+test('Replace All rewrites the open header text', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.loadDocxFile('fixtures/header-with-table.docx');
+  await page.waitForTimeout(1500);
+
+  await openHeaderEditor(page);
+
+  const mod = /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
+  await page.keyboard.press(`${mod}+h`);
+  await page.locator('[data-testid="find-replace-dialog"]').waitFor({ timeout: 3000 });
+  const dlg = page.locator('[data-testid="find-replace-dialog"]');
+  await page.locator('[data-testid="find-input"]').fill('HEADER');
+  await page.locator('[data-testid="find-input"]').press('Enter');
+  await page.waitForTimeout(300);
+  await page.locator('#replace-text').fill('BANNER');
+  await page.waitForTimeout(150);
+
+  await dlg.getByRole('button', { name: /^Replace All$/ }).click();
+  await page.waitForTimeout(400);
+
+  // The header editor now shows the replaced text; "HEADER" is gone.
+  await expect(page.locator(HF_PM)).toContainText('BANNER LOGO');
+  await expect(page.locator(HF_PM)).toContainText('BANNER TEXT');
+  await expect(page.locator(HF_PM)).not.toContainText('HEADER');
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -7632,51 +7632,67 @@ body { background: white; }
   const lastFindQueryRef = useRef<{ searchText: string; options: FindOptions } | null>(null);
 
   // Publish the find matches as highlight decorations (see findHighlightPlugin).
+  // Targets the active editor — the open header/footer when one is being edited,
+  // otherwise the main body — and clears stale decorations in the other view so
+  // highlights don't linger on the body while searching an open header/footer.
   const setFindHighlights = useCallback(
     (matches: FindMatch[], current: number) => {
-      const view = pagedEditorRef.current?.getView();
+      const view = getActiveEditorView();
       if (!view) return;
       const ranges = matches
         .filter((m) => m.pmFrom != null && m.pmTo != null)
         .map((m) => ({ from: m.pmFrom as number, to: m.pmTo as number }));
       view.dispatch(view.state.tr.setMeta(findHighlightKey, { ranges, current }));
+      const mainView = pagedEditorRef.current?.getView();
+      const hfView = hfEditorRef.current?.getView();
+      const other = view === mainView ? hfView : mainView;
+      if (other && other !== view) {
+        other.dispatch(other.state.tr.setMeta(findHighlightKey, { ranges: [], current: -1 }));
+      }
     },
-    [findHighlightKey]
+    [findHighlightKey, getActiveEditorView]
   );
 
   // Select a PM-position match in the editor and scroll its painted span into
   // view. The hidden PM's own scrollIntoView is suppressed (the paginated layer
   // owns scroll), so we scroll the painted DOM directly. Works in table cells.
-  const navigateToMatch = useCallback((match: FindMatch | null): void => {
-    if (!match || match.pmFrom == null || match.pmTo == null) return;
-    const view = pagedEditorRef.current?.getView();
-    if (!view) return;
-    const size = view.state.doc.content.size;
-    const from = Math.max(0, Math.min(match.pmFrom, size));
-    const to = Math.max(from, Math.min(match.pmTo, size));
-    try {
-      view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, from, to)));
-    } catch {
-      return;
-    }
-    const container = containerRef.current;
-    if (!container) return;
-    for (const el of Array.from(
-      container.querySelectorAll<HTMLElement>('.paged-editor__pages [data-pm-start]')
-    )) {
-      const s = Number(el.dataset.pmStart);
-      const e = Number(el.dataset.pmEnd);
-      if (from >= s && from <= e) {
-        el.scrollIntoView({ block: 'center' });
+  const navigateToMatch = useCallback(
+    (match: FindMatch | null): void => {
+      if (!match || match.pmFrom == null || match.pmTo == null) return;
+      const view = getActiveEditorView();
+      if (!view) return;
+      const size = view.state.doc.content.size;
+      const from = Math.max(0, Math.min(match.pmFrom, size));
+      const to = Math.max(from, Math.min(match.pmTo, size));
+      try {
+        view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, from, to)));
+      } catch {
         return;
       }
-    }
-  }, []);
+      // A header/footer editor is already on-screen and renders the match
+      // decoration natively — the painted-page scroll below only applies to body
+      // matches, whose positions live in the main doc, not the HF doc.
+      if (hfEditPosition) return;
+      const container = containerRef.current;
+      if (!container) return;
+      for (const el of Array.from(
+        container.querySelectorAll<HTMLElement>('.paged-editor__pages [data-pm-start]')
+      )) {
+        const s = Number(el.dataset.pmStart);
+        const e = Number(el.dataset.pmEnd);
+        if (from >= s && from <= e) {
+          el.scrollIntoView({ block: 'center' });
+          return;
+        }
+      }
+    },
+    [getActiveEditorView, hfEditPosition]
+  );
 
   // Handle find operation (PM-native — searches table cells too)
   const handleFind = useCallback(
     (searchText: string, options: FindOptions): FindResult | null => {
-      const view = pagedEditorRef.current?.getView();
+      const view = getActiveEditorView();
       if (!view || !searchText.trim()) {
         findResultRef.current = null;
         lastFindQueryRef.current = null;
@@ -7691,7 +7707,7 @@ body { background: white; }
       if (matches.length > 0) navigateToMatch(matches[0]);
       return result;
     },
-    [findReplace, navigateToMatch, setFindHighlights]
+    [findReplace, navigateToMatch, setFindHighlights, getActiveEditorView]
   );
 
   // Handle find next
@@ -7729,7 +7745,7 @@ body { background: white; }
       if (!res || res.matches.length === 0) return false;
       const match = res.matches[res.currentIndex] ?? res.matches[0];
       if (!match || match.pmFrom == null || match.pmTo == null) return false;
-      const view = pagedEditorRef.current?.getView();
+      const view = getActiveEditorView();
       if (!view) return false;
       const size = view.state.doc.content.size;
       const from = Math.max(0, Math.min(match.pmFrom, size));
@@ -7741,7 +7757,7 @@ body { background: white; }
         return false;
       }
       const q = lastFindQueryRef.current;
-      const nextView = pagedEditorRef.current?.getView();
+      const nextView = getActiveEditorView();
       const matches = q && nextView ? findInPmDoc(nextView.state.doc, q.searchText, q.options) : [];
       findResultRef.current = { matches, totalCount: matches.length, currentIndex: 0 };
       findReplace.setMatches(matches, 0);
@@ -7749,7 +7765,7 @@ body { background: white; }
       if (matches.length > 0) navigateToMatch(matches[0]);
       return true;
     },
-    [findReplace, navigateToMatch, setFindHighlights]
+    [findReplace, navigateToMatch, setFindHighlights, getActiveEditorView]
   );
 
   // Replace every match in one undoable transaction. Apply end → start so each
@@ -7757,7 +7773,7 @@ body { background: white; }
   // table cells.
   const handleReplaceAll = useCallback(
     (searchText: string, replaceText: string, options: FindOptions): number => {
-      const view = pagedEditorRef.current?.getView();
+      const view = getActiveEditorView();
       if (!view || !searchText.trim()) return 0;
       const matches = findInPmDoc(view.state.doc, searchText, options).filter(
         (m) => m.pmFrom != null && m.pmTo != null
@@ -7777,7 +7793,7 @@ body { background: white; }
       setFindHighlights([], 0);
       return matches.length;
     },
-    [findReplace, setFindHighlights]
+    [findReplace, setFindHighlights, getActiveEditorView]
   );
 
   // Expose ref methods
@@ -10179,6 +10195,7 @@ body { background: white; }
                                   }
                                   onToggleTitlePg={handleToggleTitlePg}
                                   onToggleEvenAndOdd={handleToggleEvenAndOddHeaders}
+                                  findHighlightPlugin={findHighlightPlugin}
                                 />
                               );
                             })()}

--- a/docx-editor/packages/react/src/components/InlineHeaderFooterEditor.tsx
+++ b/docx-editor/packages/react/src/components/InlineHeaderFooterEditor.tsx
@@ -32,7 +32,7 @@ import React, {
   forwardRef,
 } from 'react';
 import type { CSSProperties } from 'react';
-import { EditorState, TextSelection, Selection } from 'prosemirror-state';
+import { EditorState, TextSelection, Selection, type Plugin } from 'prosemirror-state';
 import { keymap } from 'prosemirror-keymap';
 import { useTranslation } from '../i18n';
 import { EditorView } from 'prosemirror-view';
@@ -86,6 +86,13 @@ export interface InlineHeaderFooterEditorProps {
   onToggleTitlePg?: (value: boolean) => void;
   /** Toggle `w:evenAndOddHeaders` on settings.xml. */
   onToggleEvenAndOdd?: (value: boolean) => void;
+  /**
+   * The Find & Replace highlight plugin, shared from DocxEditor so match
+   * decorations paint inside this header/footer's editor when Find/Replace
+   * runs against the open HF (the HF view is blurred while the find box has
+   * focus, so native selection alone wouldn't show the current match).
+   */
+  findHighlightPlugin?: Plugin;
 }
 
 export interface InlineHeaderFooterEditorRef {
@@ -208,6 +215,7 @@ export const InlineHeaderFooterEditor = forwardRef<
     evenAndOddHeaders,
     onToggleTitlePg,
     onToggleEvenAndOdd,
+    findHighlightPlugin,
   },
   ref
 ) {
@@ -694,7 +702,14 @@ export const InlineHeaderFooterEditor = forwardRef<
         return true;
       },
     });
-    const plugins = [navKeymap, ...hfMgr.getPlugins()];
+    // Append the shared Find & Replace highlight plugin last so its match
+    // decorations render in this HF view. Its state is keyed and per-EditorState,
+    // so reusing the one DocxEditor instance across the main + HF views is safe.
+    const plugins = [
+      navKeymap,
+      ...hfMgr.getPlugins(),
+      ...(findHighlightPlugin ? [findHighlightPlugin] : []),
+    ];
 
     const state = EditorState.create({
       doc: pmDoc,


### PR DESCRIPTION
Find/Replace hardcoded the main body ProseMirror view, so with a header or footer open for editing a search found "0 of 0" and Replace did nothing — the HF content lives in a separate PM view.

The find/navigate/highlight/replace handlers now go through `getActiveEditorView()` (HF editor when one is open, else body), and the shared find-highlight plugin is passed into the HF editor so match decorations paint inside it (the HF view is blurred while the find box has focus, so native selection alone wouldn't show the current match). Highlights in the non-active view are cleared so they don't linger on the body while searching a header.

Regression coverage in `find-replace-header-footer.spec.ts`; existing find/replace and header-edit suites still pass.