### PR TITLE
fix(sdk): scope dark-theme shadcn bridge vars to .ep-root (no host leak)

### DIFF
--- a/docx-editor/e2e/tests/token-scope-leak.spec.ts
+++ b/docx-editor/e2e/tests/token-scope-leak.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * The editor's dark theme must NOT leak its shadcn bridge variables
+ * (--background / --foreground / --card / --primary …) onto the host page's
+ * <html>. Those names collide with tailwind/shadcn defaults, so a bare
+ * `[data-theme='dark']` selector would overwrite an embedding app's own dark
+ * tokens the moment the editor went dark. They are scoped to `.ep-root`
+ * instead (matching the already-scoped light values). The namespaced DS
+ * `--color-*` tokens stay global by design and are not asserted here.
+ */
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+// The editor resolves its `auto` color theme via prefers-color-scheme.
+test.use({ colorScheme: 'dark' });
+
+const SHADCN_VARS = [
+  '--background',
+  '--foreground',
+  '--card',
+  '--popover',
+  '--primary',
+  '--secondary',
+  '--muted',
+  '--accent',
+  '--destructive',
+  '--border',
+  '--input',
+  '--ring',
+];
+
+test('dark-mode shadcn bridge vars stay scoped to .ep-root (no <html> leak)', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await page.waitForTimeout(500);
+
+  // Editor is in dark mode (data-theme set on <html> by the editor).
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.getAttribute('data-theme')))
+    .toBe('dark');
+
+  const result = await page.evaluate((vars) => {
+    const htmlCS = getComputedStyle(document.documentElement);
+    const ep = document.querySelector('.ep-root');
+    const epCS = ep ? getComputedStyle(ep) : null;
+    return {
+      htmlLeaked: vars.filter((v) => htmlCS.getPropertyValue(v).trim() !== ''),
+      epThemed: epCS ? vars.filter((v) => epCS.getPropertyValue(v).trim() !== '') : [],
+    };
+  }, SHADCN_VARS);
+
+  // Nothing leaked onto the host <html> …
+  expect(result.htmlLeaked).toEqual([]);
+  // … but the editor root still carries the full dark bridge palette.
+  expect(result.epThemed.length).toBe(SHADCN_VARS.length);
+});

--- a/docx-editor/packages/react/src/styles/editor.css
+++ b/docx-editor/packages/react/src/styles/editor.css
@@ -181,10 +181,17 @@
  * Google Docs / Word do the same.
  * ============================================================================ */
 
+/* Scoped to `.ep-root` (the editor root — set on the standalone shell, on every
+ * Radix portal wrapper, and inherited by inline dialogs) so these overrides
+ * NEVER leak onto a host page's <html>. The un-namespaced shadcn bridge vars
+ * below (--background / --foreground / --card / --primary …) share their names
+ * with tailwind/shadcn defaults; a bare `[data-theme='dark']` selector would
+ * have overwritten a host app's own dark tokens the moment the editor went
+ * dark. The DS `--color-*` tokens (colors.css) stay global by design — those
+ * are namespaced and shared suite-wide. */
 .ep-root[data-theme='dark'],
-[data-theme='dark'] .ep-root,
-[data-theme='dark'] {
-  /* Native form controls (selects, scrollbars) follow this. */
+[data-theme='dark'] .ep-root {
+  /* Native form controls (selects, scrollbars) inside the editor follow this. */
   color-scheme: dark;
 
   /* WCAG AA overrides for the vendored DS dark tokens. The design-system is a


### PR DESCRIPTION
The dark-theme block in `editor.css` keyed off a bare `[data-theme='dark']` selector, so switching the editor to dark dumped its un-namespaced shadcn bridge vars (`--background` / `--foreground` / `--card` / `--primary` …) — plus the WCAG-AA and `--doc-page-paper` overrides — onto the host page's `<html>`. Those variable names collide with tailwind/shadcn defaults, so embedding `<DocxEditor>` and going dark silently overwrote a host app's own dark tokens.

Scoped the block to `.ep-root` (the light values were already scoped there — this makes the pair symmetric). Editor dark mode is unaffected: Radix portals wrap their content in `.ep-root`, inline dialogs inherit it, and `modals.ts` reads the theme in JS with its own palette. The namespaced DS `--color-*` tokens (colors.css) stay global by design — they're shared suite-wide.

Verified: with the editor dark, `getComputedStyle(<html>)` now exposes none of the 12 bridge vars while `.ep-root` still carries the full dark palette; the font Select portal and chrome/menus/dialogs all render dark correctly. New `token-scope-leak.spec.ts` locks in the no-leak invariant; existing dark-mode contrast tests still pass.