### PR TITLE
feat(ai): connect external MCP servers to the agent (Streamable HTTP + settings)

### DIFF
--- a/docx-editor/e2e/tests/ai-surfaces.spec.ts
+++ b/docx-editor/e2e/tests/ai-surfaces.spec.ts
@@ -307,4 +307,74 @@ test.describe('DocOpsPanel SSE streaming', () => {
     await toggle.click();
     await expect(toggle).toHaveText(/Agent/);
   });
+
+  test('connects an external MCP server and shows its tool count', async ({ page }) => {
+    await page.addInitScript(
+      ({ k, editorKey, panelKey }) => {
+        (window as any).__casualFeatures__ = { docops: true };
+        try {
+          localStorage.setItem(editorKey, k);
+        } catch {
+          /* ignore */
+        }
+        try {
+          localStorage.setItem(panelKey, k);
+        } catch {
+          /* ignore */
+        }
+      },
+      { k: FAKE_KEY, editorKey: DOCX_EDITOR_AI_KEY, panelKey: DOCOPS_PANEL_KEY }
+    );
+
+    // Mock a Streamable-HTTP MCP server: reply to initialize + tools/list.
+    await page.route('**/mcp-test/rpc', async (route) => {
+      const body = JSON.parse(route.request().postData() || '{}');
+      if (body.id === undefined) {
+        await route.fulfill({ status: 202, body: '' }); // notification
+        return;
+      }
+      const result =
+        body.method === 'initialize'
+          ? {
+              protocolVersion: '2025-06-18',
+              capabilities: { tools: {} },
+              serverInfo: { name: 'mock', version: '1' },
+            }
+          : body.method === 'tools/list'
+            ? {
+                tools: [
+                  {
+                    name: 'web_search',
+                    description: 'Search',
+                    inputSchema: { type: 'object', properties: {} },
+                  },
+                ],
+              }
+            : {};
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ jsonrpc: '2.0', id: body.id, result }),
+      });
+    });
+
+    await loadEditor(page);
+
+    const docopsBtn = page.locator('[data-testid="rail-docops"]');
+    if (!(await docopsBtn.isVisible())) {
+      test.skip(true, 'DocOps rail button not present');
+      return;
+    }
+    await docopsBtn.click();
+    await page.waitForSelector('[data-testid="docops-input"]', { timeout: 5000 });
+
+    await page.locator('[data-testid="docops-agent-toggle"]').click();
+    await page.locator('[data-testid="docops-mcp-add"]').click();
+    await page.locator('[data-testid="docops-mcp-input"]').fill('http://localhost/mcp-test/rpc');
+    await page.keyboard.press('Enter');
+
+    await expect(page.locator('[data-testid="docops-mcp-section"]')).toContainText('1 tools', {
+      timeout: 8000,
+    });
+  });
 });

--- a/docx-editor/packages/docops/src/index.ts
+++ b/docx-editor/packages/docops/src/index.ts
@@ -30,5 +30,11 @@ export type {
 
 // Real Model Context Protocol: client (consume external servers) + server
 // (expose the DocOps tools to external agents), over any JSON-RPC transport.
-export { RpcConnection, McpClient, McpServer } from './mcp';
-export type { JsonRpcTransport, McpClientOptions, McpToolProvider, McpServerOptions } from './mcp';
+export { RpcConnection, HttpMcpTransport, McpClient, McpServer } from './mcp';
+export type {
+  JsonRpcTransport,
+  HttpMcpTransportOptions,
+  McpClientOptions,
+  McpToolProvider,
+  McpServerOptions,
+} from './mcp';

--- a/docx-editor/packages/docops/src/mcp/httpTransport.test.ts
+++ b/docx-editor/packages/docops/src/mcp/httpTransport.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { HttpMcpTransport } from './httpTransport';
+import { McpClient } from './client';
+import { McpServer, type McpToolProvider } from './server';
+import type { JsonRpcTransport } from './jsonrpc';
+import type { DocOpsResult, DocOpsTool } from '../types';
+
+const TOOL: DocOpsTool = {
+  name: 'web_search',
+  description: 'Search the web.',
+  input_schema: { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] },
+};
+
+function provider(calls: Array<[string, unknown]>): McpToolProvider {
+  return {
+    listTools: () => [TOOL],
+    callTool: async (name, args): Promise<DocOpsResult> => {
+      calls.push([name, args]);
+      return name === 'web_search'
+        ? { ok: true, data: `hits for ${args.q}` }
+        : { ok: false, code: 'UNSUPPORTED', message: 'no', retryable: false };
+    },
+  };
+}
+
+/** A fetch that routes the POST body through an McpServer and returns its reply. */
+function mcpFetch(prov: McpToolProvider, sse = false): typeof fetch {
+  let reply = '';
+  let serverHandler: ((m: string) => void) | null = null;
+  const t: JsonRpcTransport = {
+    send: (m) => {
+      reply = m;
+    },
+    onMessage: (h) => {
+      serverHandler = h;
+    },
+  };
+  // eslint-disable-next-line no-new
+  new McpServer(t, prov);
+  return (async (_url: string, init: { body?: string }) => {
+    reply = '';
+    serverHandler?.(String(init.body));
+    await new Promise((r) => setTimeout(r, 5)); // let async callTool + send settle
+    const body = sse && reply ? `event: message\ndata: ${reply}\n\n` : reply;
+    return new Response(body, { status: 200 });
+  }) as unknown as typeof fetch;
+}
+
+describe('HttpMcpTransport ↔ McpServer over HTTP', () => {
+  it('lists and calls tools through a POST-based transport', async () => {
+    const calls: Array<[string, unknown]> = [];
+    const transport = new HttpMcpTransport('http://mcp.test/rpc', {
+      fetchImpl: mcpFetch(provider(calls)),
+    });
+    const client = new McpClient(transport, { id: 'mcp:search' });
+
+    const tools = await client.listTools();
+    expect(tools.map((t) => t.name)).toEqual(['web_search']);
+
+    const res = await client.callTool('web_search', { q: 'agents' });
+    expect(res.ok).toBe(true);
+    expect(calls).toContainEqual(['web_search', { q: 'agents' }]);
+  });
+
+  it('parses a JSON-RPC reply delivered as an SSE data frame', async () => {
+    const transport = new HttpMcpTransport('http://mcp.test/rpc', {
+      fetchImpl: mcpFetch(provider([]), true),
+    });
+    const client = new McpClient(transport, { id: 'mcp:sse' });
+    const tools = await client.listTools();
+    expect(tools).toHaveLength(1);
+  });
+});

--- a/docx-editor/packages/docops/src/mcp/httpTransport.ts
+++ b/docx-editor/packages/docops/src/mcp/httpTransport.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Streamable-HTTP transport for the MCP client — the standard way a browser
+ * reaches a remote MCP server. Each JSON-RPC message is POSTed to the server
+ * endpoint; the response body carries the matching JSON-RPC reply, which is
+ * handed back to RpcConnection. Notifications (no id) POST and ignore the reply.
+ *
+ * This keeps McpClient transport-agnostic: swap this for a stdio bridge on the
+ * desktop without touching the client or the agent.
+ */
+
+import type { JsonRpcTransport } from './jsonrpc';
+
+export interface HttpMcpTransportOptions {
+  /** Extra headers, e.g. Authorization for an authenticated MCP server. */
+  headers?: Record<string, string>;
+  /** Injected fetch (defaults to global). Lets tests supply their own. */
+  fetchImpl?: typeof fetch;
+}
+
+export class HttpMcpTransport implements JsonRpcTransport {
+  private handler: ((message: string) => void) | null = null;
+  private readonly headers: Record<string, string>;
+  private readonly doFetch: typeof fetch;
+  private closed = false;
+
+  constructor(
+    private readonly url: string,
+    options: HttpMcpTransportOptions = {}
+  ) {
+    this.headers = options.headers ?? {};
+    // Bind to globalThis: native `fetch` throws "Illegal invocation" when
+    // called as a method of another object (this === transport).
+    this.doFetch = options.fetchImpl ?? fetch.bind(globalThis);
+  }
+
+  send(message: string): void {
+    if (this.closed) return;
+    void this.doFetch(this.url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        ...this.headers,
+      },
+      body: message,
+    })
+      .then(async (resp) => {
+        const text = await resp.text();
+        if (this.closed) return;
+        // Accept both a bare JSON body and a single SSE `data:` frame.
+        const payload = extractJson(text);
+        if (payload) this.handler?.(payload);
+      })
+      .catch(() => {
+        /* RpcConnection times out the pending request on its own. */
+      });
+  }
+
+  onMessage(handler: (message: string) => void): void {
+    this.handler = handler;
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+/** Pull the JSON-RPC object out of a plain body or an SSE `data:` frame. */
+function extractJson(body: string): string | null {
+  const trimmed = body.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return trimmed;
+  // SSE: take the last non-empty `data:` line.
+  const dataLines = trimmed
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith('data:'))
+    .map((l) => l.slice(5).trim())
+    .filter(Boolean);
+  return dataLines.length ? dataLines[dataLines.length - 1] : null;
+}

--- a/docx-editor/packages/docops/src/mcp/index.ts
+++ b/docx-editor/packages/docops/src/mcp/index.ts
@@ -4,6 +4,8 @@
 
 export { RpcConnection } from './jsonrpc';
 export type { JsonRpcTransport } from './jsonrpc';
+export { HttpMcpTransport } from './httpTransport';
+export type { HttpMcpTransportOptions } from './httpTransport';
 export { McpClient } from './client';
 export type { McpClientOptions } from './client';
 export { McpServer } from './server';

--- a/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
+++ b/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
@@ -20,14 +20,30 @@ import { useCallback, useEffect, useRef, useState, type CSSProperties } from 're
 import { RightDockPanel } from '../components/RightDockPanel';
 import { MaterialSymbol } from '../components/ui/Icons';
 import type { DocsBridge } from './bridge';
-import { DOCOPS_CATALOG, runAgent, type AgentEvent, type AgentTask } from '@casualoffice/docops';
-import { createAgentRegistry, transportLlm } from './agentRuntime';
+import {
+  DOCOPS_CATALOG,
+  runAgent,
+  type AgentEvent,
+  type AgentTask,
+  type McpClient,
+  type ToolSource,
+} from '@casualoffice/docops';
+import { createAgentRegistry, createMcpClient, transportLlm } from './agentRuntime';
 import {
   DirectTransport,
   type DocOpsTransport,
   type LlmCallPayload,
   type ToolExecutor,
 } from './transport';
+
+interface McpServerState {
+  id: string;
+  url: string;
+  status: 'connecting' | 'connected' | 'error';
+  toolCount: number;
+  source: McpClient | null;
+  error?: string;
+}
 
 // ── LLM wire types (messages-API shape) ───────────────────────────────────
 
@@ -207,6 +223,62 @@ const agentToggleStyle = (active: boolean): CSSProperties => ({
   background: active ? 'var(--doc-primary, #1a73e8)' : 'var(--doc-surface-sunken, #f8f9fa)',
   border: `1px solid ${active ? 'var(--doc-primary, #1a73e8)' : 'var(--doc-border-light)'}`,
 });
+
+const mcpAddBtnStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 4,
+  fontSize: 11.5,
+  fontWeight: 600,
+  padding: '2px 8px',
+  borderRadius: 999,
+  cursor: 'pointer',
+  color: 'var(--doc-text-muted)',
+  background: 'var(--doc-surface-sunken, #f8f9fa)',
+  border: '1px solid var(--doc-border-light)',
+  marginLeft: 6,
+};
+
+const mcpSectionStyle: CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 6,
+  padding: '4px 12px 0',
+};
+
+const mcpChipStyle = (status: 'connecting' | 'connected' | 'error'): CSSProperties => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 5,
+  fontSize: 11,
+  padding: '2px 6px',
+  borderRadius: 6,
+  color: status === 'error' ? 'var(--doc-danger, #c62828)' : 'var(--doc-text-muted)',
+  background: 'var(--doc-surface-sunken, #f8f9fa)',
+  border: '1px solid var(--doc-border-light)',
+});
+
+const mcpRemoveStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  background: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+  padding: 0,
+  color: 'inherit',
+  opacity: 0.7,
+};
+
+const mcpInputStyle: CSSProperties = {
+  flex: 1,
+  minWidth: 200,
+  fontSize: 12,
+  padding: '4px 8px',
+  borderRadius: 6,
+  border: '1px solid var(--doc-border-light)',
+  background: 'var(--doc-surface, #fff)',
+  color: 'var(--doc-text)',
+};
 
 const inputRowStyle: CSSProperties = {
   display: 'flex',
@@ -390,6 +462,50 @@ export function DocOpsPanel({
   // Opt-in via the toggle; only available when the panel drives the loop
   // (Direct/Desktop, not collab where the server owns the loop).
   const [agentMode, setAgentMode] = useState(false);
+  // External MCP servers whose tools join the agent's registry.
+  const [mcpServers, setMcpServers] = useState<McpServerState[]>([]);
+  const [mcpUrlDraft, setMcpUrlDraft] = useState('');
+  const [showMcpAdd, setShowMcpAdd] = useState(false);
+
+  const connectMcp = useCallback(
+    async (rawUrl: string) => {
+      const url = rawUrl.trim();
+      if (!url) return;
+      const id = `mcp:${url}`;
+      if (mcpServers.some((s) => s.id === id)) return;
+      const client = createMcpClient(url, id);
+      setMcpServers((prev) => [
+        ...prev,
+        { id, url, status: 'connecting', toolCount: 0, source: client },
+      ]);
+      setMcpUrlDraft('');
+      setShowMcpAdd(false);
+      try {
+        const tools = await client.listTools();
+        setMcpServers((prev) =>
+          prev.map((s) =>
+            s.id === id ? { ...s, status: 'connected', toolCount: tools.length } : s
+          )
+        );
+      } catch (err) {
+        setMcpServers((prev) =>
+          prev.map((s) =>
+            s.id === id
+              ? { ...s, status: 'error', error: err instanceof Error ? err.message : String(err) }
+              : s
+          )
+        );
+      }
+    },
+    [mcpServers]
+  );
+
+  const removeMcp = useCallback((id: string) => {
+    setMcpServers((prev) => {
+      prev.find((s) => s.id === id)?.source?.close();
+      return prev.filter((s) => s.id !== id);
+    });
+  }, []);
   // Label for the "thinking" row shown while the (non-streaming) model runs,
   // so the user sees progress between click and reply.
   const [thinkingLabel, setThinkingLabel] = useState('Thinking…');
@@ -503,7 +619,10 @@ export function DocOpsPanel({
           // The panel-driven agent decomposes the goal, runs each sub-task
           // through the tool loop, and reflects. Built-in DocOps tools plus any
           // external MCP tools flow through one ToolRegistry.
-          const registry = createAgentRegistry(bridge);
+          const mcpSources = mcpServers
+            .filter((s) => s.status === 'connected' && s.source)
+            .map((s) => s.source as ToolSource);
+          const registry = createAgentRegistry(bridge, mcpSources);
           const llm = transportLlm(transport, { model: MODEL, apiKey: apiKey || undefined });
           const result = await runAgent(
             text,
@@ -678,6 +797,7 @@ export function DocOpsPanel({
       updateLastToolStep,
       agentMode,
       handleAgentEvent,
+      mcpServers,
     ]
   );
 
@@ -920,6 +1040,61 @@ export function DocOpsPanel({
                     <MaterialSymbol name="smart_toy" size={13} />
                     {agentMode ? 'Agent' : 'Chat'}
                   </button>
+                  {agentMode && (
+                    <button
+                      type="button"
+                      onClick={() => setShowMcpAdd((v) => !v)}
+                      style={mcpAddBtnStyle}
+                      data-testid="docops-mcp-add"
+                      title="Connect an external MCP server; its tools join the agent"
+                    >
+                      <MaterialSymbol name="hub" size={13} />
+                      MCP
+                    </button>
+                  )}
+                </div>
+              )}
+              {agentMode && !transport.drivesLoop && (mcpServers.length > 0 || showMcpAdd) && (
+                <div style={mcpSectionStyle} data-testid="docops-mcp-section">
+                  {mcpServers.map((s) => (
+                    <div key={s.id} style={mcpChipStyle(s.status)}>
+                      {s.status === 'connecting' ? (
+                        <span style={spinnerStyle} aria-hidden="true" />
+                      ) : s.status === 'connected' ? (
+                        <MaterialSymbol name="check_circle" size={12} />
+                      ) : (
+                        <MaterialSymbol name="error" size={12} />
+                      )}
+                      <span title={s.error ?? s.url}>
+                        {s.url.replace(/^https?:\/\//, '')}
+                        {s.status === 'connected' ? ` · ${s.toolCount} tools` : ''}
+                        {s.status === 'error' ? ' · failed' : ''}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => removeMcp(s.id)}
+                        style={mcpRemoveStyle}
+                        aria-label="Remove MCP server"
+                      >
+                        <MaterialSymbol name="close" size={11} />
+                      </button>
+                    </div>
+                  ))}
+                  {showMcpAdd && (
+                    <input
+                      value={mcpUrlDraft}
+                      onChange={(e) => setMcpUrlDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          void connectMcp(mcpUrlDraft);
+                        }
+                      }}
+                      placeholder="https://mcp.example.com/rpc  (Enter to connect)"
+                      style={mcpInputStyle}
+                      data-testid="docops-mcp-input"
+                    />
+                  )}
                 </div>
               )}
               <div style={inputRowStyle}>

--- a/docx-editor/packages/react/src/docops/agentRuntime.ts
+++ b/docx-editor/packages/react/src/docops/agentRuntime.ts
@@ -11,6 +11,8 @@
 
 import {
   DOCOPS_CATALOG,
+  HttpMcpTransport,
+  McpClient,
   ToolRegistry,
   type LlmFn,
   type LlmResponse,
@@ -26,6 +28,20 @@ export function bridgeToolSource(bridge: DocsBridge): ToolSource {
     listTools: () => DOCOPS_CATALOG,
     callTool: (name, args) => bridge.callTool(name, args),
   };
+}
+
+/**
+ * Connect to an external MCP server over Streamable HTTP and return it as a
+ * ToolSource (McpClient). `id` namespaces it in the registry (e.g. 'mcp:search').
+ * Call `.listTools()` on the result to verify the server is reachable before
+ * registering it.
+ */
+export function createMcpClient(
+  url: string,
+  id: string,
+  headers?: Record<string, string>
+): McpClient {
+  return new McpClient(new HttpMcpTransport(url, { headers }), { id });
 }
 
 /**


### PR DESCRIPTION
Completes the MCP client host wiring: HttpMcpTransport (Streamable-HTTP) + a settings UI in the DocOps panel (Agent mode) to add an MCP server URL, which connects, verifies via tools/list, and registers the server's tools into the agent's ToolRegistry. Tested: HttpMcpTransport<->McpServer round-trip (unit) + an e2e connecting the panel to a mocked MCP HTTP server. Note: fetch is bound to globalThis to avoid 'Illegal invocation' (caught by the e2e).