### PR TITLE
feat(ai): local-first RAG — BM25 retrieval + search_document tool

### DIFF
--- a/docx-editor/.changeset/rag-bm25-retrieval.md
+++ b/docx-editor/.changeset/rag-bm25-retrieval.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': minor
+---
+
+Add local-first RAG: a BM25 retrieval layer and a `search_document` tool that returns the passages most relevant to a query (with their blockIds). `get_doc_stats` no longer dumps the full document text, which previously overflowed the local model's context on long documents and silently truncated summaries.

--- a/docx-editor/packages/docops/src/catalog.ts
+++ b/docx-editor/packages/docops/src/catalog.ts
@@ -35,10 +35,29 @@ export const DOCOPS_CATALOG: DocOpsTool[] = [
   {
     name: 'get_doc_stats',
     description:
-      'Returns document statistics: word count, paragraph count, table count, image count, and heading levels used.',
+      'Returns document statistics: word count, paragraph count, table count, image count, heading levels, and a short text preview. To summarize or answer questions about the content, use search_document — do NOT rely on the preview alone.',
     input_schema: {
       type: 'object',
       properties: {},
+    },
+  },
+  {
+    name: 'search_document',
+    description:
+      'Retrieve the passages of the document most relevant to a natural-language query (top-k chunks with their heading path and block IDs). Use this — NOT get_doc_stats — to summarize, answer questions, or locate content to edit in anything longer than a couple of paragraphs. Edit via the returned blockIds.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'What to look for, in natural language.',
+        },
+        k: {
+          type: 'number',
+          description: 'Max passages to return (1–8). Defaults to 5.',
+        },
+      },
+      required: ['query'],
     },
   },
   {

--- a/docx-editor/packages/docops/src/index.ts
+++ b/docx-editor/packages/docops/src/index.ts
@@ -13,6 +13,10 @@ export type {
 
 export { DOCOPS_CATALOG } from './catalog';
 
+// Local-first RAG: BM25 retrieval over in-memory chunks (no embeddings/model).
+export { tokenize, Bm25Index, retrieve } from './retrieval';
+export type { RetrievalChunk, RetrievedChunk, RetrieveOptions, RetrieveResult } from './retrieval';
+
 // Agentic layer: plan → execute → reflect over a pluggable tool registry.
 export { ToolRegistry, runAgent } from './agent';
 export type {

--- a/docx-editor/packages/docops/src/retrieval/bm25.test.ts
+++ b/docx-editor/packages/docops/src/retrieval/bm25.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { retrieve, tokenize } from './bm25';
+import type { RetrievalChunk } from './types';
+
+const chunks: RetrievalChunk[] = [
+  {
+    id: 'c1',
+    text: 'The introduction explains the project goals and scope.',
+    meta: { blockIds: ['b1'] },
+  },
+  {
+    id: 'c2',
+    text: 'Revenue grew 40% in Q3 driven by the new pricing model.',
+    meta: { blockIds: ['b2'] },
+  },
+  {
+    id: 'c3',
+    text: 'The conclusion summarizes findings and proposes next steps.',
+    meta: { blockIds: ['b3'] },
+  },
+  {
+    id: 'c4',
+    text: 'Our pricing strategy uses tiered subscription revenue tiers.',
+    meta: { blockIds: ['b4'] },
+  },
+];
+
+describe('tokenize', () => {
+  it('lowercases, splits, and drops stopwords + 1-char tokens', () => {
+    expect(tokenize('The Revenue, in Q3!')).toEqual(['revenue', 'q3']);
+  });
+});
+
+describe('retrieve (BM25)', () => {
+  it('ranks the on-topic chunks first', () => {
+    const res = retrieve(chunks, 'how did pricing affect revenue', { k: 2 });
+    const ids = res.chunks.map((c) => c.id);
+    // c2 and c4 both mention pricing + revenue; they should outrank intro/conclusion.
+    expect(ids).toContain('c2');
+    expect(ids).toContain('c4');
+    expect(ids).not.toContain('c1');
+  });
+
+  it('carries locator metadata through for edit targeting', () => {
+    const res = retrieve(chunks, 'conclusion next steps', { k: 1 });
+    expect(res.chunks[0].id).toBe('c3');
+    expect((res.chunks[0].meta as { blockIds: string[] }).blockIds).toEqual(['b3']);
+  });
+
+  it('drops zero-score chunks (no lexical overlap)', () => {
+    const res = retrieve(chunks, 'quarterly revenue', { k: 5 });
+    // Only the revenue chunks overlap; intro/conclusion score 0 and are dropped.
+    expect(res.chunks.every((c) => c.score > 0)).toBe(true);
+    expect(res.chunks.length).toBeLessThan(chunks.length);
+  });
+
+  it('respects the character budget and flags truncation', () => {
+    // The top match ("Revenue grew 40% …", 55 chars) fits in 58; the next
+    // (60 chars) does not, so exactly one is returned and truncated is set.
+    const res = retrieve(chunks, 'pricing revenue', { k: 5, charBudget: 58 });
+    expect(res.chunks.length).toBe(1);
+    expect(res.truncated).toBe(true);
+  });
+
+  it('returns empty (not a crash) when nothing matches', () => {
+    const res = retrieve(chunks, 'xylophone spacecraft', {});
+    expect(res.chunks).toHaveLength(0);
+  });
+});

--- a/docx-editor/packages/docops/src/retrieval/bm25.ts
+++ b/docx-editor/packages/docops/src/retrieval/bm25.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * BM25 lexical retrieval — pure TypeScript, no embeddings, no model, no extra
+ * download. Runs in microseconds over in-memory chunks so grounding happens
+ * JS-side BEFORE the prompt reaches the (8k-context) local model. This is the
+ * fix for get_doc_stats dumping the whole document and blowing the context.
+ */
+
+import type { RetrievalChunk, RetrieveOptions, RetrieveResult, RetrievedChunk } from './types';
+
+const K1 = 1.5;
+const B = 0.75;
+const DEFAULT_K = 5;
+const DEFAULT_CHAR_BUDGET = 10_000; // ~2,800 tokens
+
+// Small, high-frequency stopword set — enough to stop query noise dominating.
+const STOPWORDS = new Set(
+  (
+    'a an and are as at be but by for from has have i in is it its of on or that the to was were will with ' +
+    'this these those what which who whom whose when where why how do does did can could should would may might'
+  ).split(' ')
+);
+
+/** Lowercase, split on non-alphanumerics, drop stopwords + 1-char tokens. */
+export function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 1 && !STOPWORDS.has(t));
+}
+
+/** Precomputed BM25 index over a fixed set of chunks. */
+export class Bm25Index {
+  private readonly docs: { chunk: RetrievalChunk; tf: Map<string, number>; len: number }[] = [];
+  private readonly df = new Map<string, number>();
+  private avgLen = 0;
+
+  constructor(chunks: RetrievalChunk[]) {
+    let totalLen = 0;
+    for (const chunk of chunks) {
+      const tokens = tokenize(chunk.text);
+      const tf = new Map<string, number>();
+      for (const tok of tokens) tf.set(tok, (tf.get(tok) ?? 0) + 1);
+      for (const tok of tf.keys()) this.df.set(tok, (this.df.get(tok) ?? 0) + 1);
+      this.docs.push({ chunk, tf, len: tokens.length });
+      totalLen += tokens.length;
+    }
+    this.avgLen = this.docs.length ? totalLen / this.docs.length : 0;
+  }
+
+  /** Score every chunk against the query; returns them sorted by score desc. */
+  score(query: string): RetrievedChunk[] {
+    const qTokens = [...new Set(tokenize(query))];
+    const N = this.docs.length;
+    const scored = this.docs.map(({ chunk, tf, len }) => {
+      let s = 0;
+      for (const q of qTokens) {
+        const f = tf.get(q);
+        if (!f) continue;
+        const n = this.df.get(q) ?? 0;
+        // BM25 idf with the +0.5 smoothing; clamp to >= 0 so ubiquitous terms
+        // don't push scores negative.
+        const idf = Math.max(0, Math.log((N - n + 0.5) / (n + 0.5) + 1));
+        const denom = f + K1 * (1 - B + (B * len) / (this.avgLen || 1));
+        s += idf * ((f * (K1 + 1)) / denom);
+      }
+      return { ...chunk, score: s };
+    });
+    return scored.sort((a, b) => b.score - a.score);
+  }
+}
+
+/**
+ * Retrieve the top chunks for a query, packed greedily to a character budget so
+ * the injected context is provably bounded. `truncated` is true when k or the
+ * budget dropped chunks that still had a positive score.
+ */
+export function retrieve(
+  chunks: RetrievalChunk[],
+  query: string,
+  options: RetrieveOptions = {}
+): RetrieveResult {
+  const k = options.k ?? DEFAULT_K;
+  const charBudget = options.charBudget ?? DEFAULT_CHAR_BUDGET;
+  const ranked = new Bm25Index(chunks).score(query).filter((c) => c.score > 0);
+
+  const picked: RetrievedChunk[] = [];
+  let used = 0;
+  let truncated = false;
+  for (const chunk of ranked) {
+    if (picked.length >= k) {
+      truncated = true;
+      break;
+    }
+    if (used + chunk.text.length > charBudget) {
+      // Skip this one but keep scanning for a smaller chunk that still fits.
+      truncated = true;
+      continue;
+    }
+    picked.push(chunk);
+    used += chunk.text.length;
+  }
+  return { chunks: picked, truncated };
+}

--- a/docx-editor/packages/docops/src/retrieval/index.ts
+++ b/docx-editor/packages/docops/src/retrieval/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+export { tokenize, Bm25Index, retrieve } from './bm25';
+export type { RetrievalChunk, RetrievedChunk, RetrieveOptions, RetrieveResult } from './types';

--- a/docx-editor/packages/docops/src/retrieval/types.ts
+++ b/docx-editor/packages/docops/src/retrieval/types.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Retrieval types for the local-first RAG layer. A chunk is a unit of document
+ * (a section, a band of spreadsheet rows) carrying the LOCATOR metadata the
+ * write tools consume (blockIds / a1Range), so retrieve-then-edit still targets
+ * the right place.
+ */
+
+export interface RetrievalChunk {
+  id: string;
+  /** The text scored + returned. For docs, prefix a heading breadcrumb. */
+  text: string;
+  /** Locator + display metadata (blockIds, headingPath, a1Range, sheetName…). */
+  meta?: Record<string, unknown>;
+}
+
+export interface RetrievedChunk extends RetrievalChunk {
+  score: number;
+}
+
+export interface RetrieveOptions {
+  /** Max chunks returned. Default 5. */
+  k?: number;
+  /** Total character budget across returned chunks (~token budget × 3.6). */
+  charBudget?: number;
+}
+
+export interface RetrieveResult {
+  chunks: RetrievedChunk[];
+  /** True when k or the char budget capped the returned set. */
+  truncated: boolean;
+}

--- a/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
+++ b/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
@@ -88,10 +88,11 @@ const SYSTEM_PROMPT = `You are DocOps, an AI assistant inside a .docx editor.
 IMPORTANT: You do not have the document text. It is not in this chat. You are the one who calls tools — the user never runs tools. When you need information about the document, YOU emit a <tool_call> block and the editor runs it and returns the result to you.
 
 Read tools (inspect the document — never mutate):
-- get_doc_stats() — returns word/paragraph/table/image counts AND the FULL document text. Call this to summarize, describe, or answer "what is this about".
+- search_document(query) — returns the passages most relevant to the query, each with its heading path and blockIds. Use this to summarize, describe, or answer questions — it works on documents of any length.
+- get_doc_stats() — word/paragraph/table/image counts + a short preview (NOT the full text).
 - get_outline() — returns the heading tree.
 - get_selection() — returns the user's currently selected text.
-- find_text(query) — searches the document for a phrase.
+- find_text(query) — exact-phrase search; returns blockIds + snippets.
 - list_styles() — lists paragraph styles and fonts used.
 
 Write tools — direct edits (immediately visible):
@@ -102,12 +103,12 @@ Write tools — suggestion mode (user reviews in the sidebar):
 - suggest_text_change, set_paragraph_style, add_comment, rewrite_selection (call get_selection first), delete_paragraphs (pass paraIds from get_outline/find_text), insert_paragraph_after, harmonize_styles (call list_styles first), insert_report_from_data, create_document (call get_doc_stats first, confirm wordCount === 0)
 
 Rules:
-- To summarize, describe, or answer ANY question about the document, your VERY FIRST response must be a <tool_call> for get_doc_stats. Do not write prose first. Do not ask the user to do anything. Do not assume or invent the document's content.
-- Emit exactly this and nothing else, then stop:
+- To summarize, describe, or answer ANY question about the document, your VERY FIRST response must be a <tool_call> for search_document with a query built from the user's request. Do not write prose first. Do not ask the user to do anything. Do not assume or invent the document's content.
+- Emit exactly this and nothing else, then stop (replace the query with the topic asked about; for a whole-document summary use the main subject or "overview"):
 <tool_call>
-{"name": "get_doc_stats", "arguments": {}}
+{"name": "search_document", "arguments": {"query": "overview main topics"}}
 </tool_call>
-- After the tool result arrives, write a short, plain-language answer.
+- After the tool result arrives, write a short, plain-language answer grounded only in the retrieved passages.
 - Always read before you write. For suggest_text_change the search text must be exact (case-sensitive) — call find_text first. For rewrite_selection, call get_selection first.
 - Tracked changes appear in the comments sidebar — tell the user to open it to review.
 - Keep responses short. Users want results, not explanations.`;
@@ -851,7 +852,30 @@ export function DocOpsPanel({
           return String(d.text ?? d.selection ?? d.selectionText ?? '').trim();
         };
         if (action.id === 'summarize' || action.id === 'outline') {
-          context = readField(await bridge.callTool('get_doc_stats', {}));
+          // RAG: retrieve representative passages (budget-bounded) instead of
+          // dumping the whole document — grounds the answer and can't blow the
+          // local model's context on a long doc. Broad query for a generic
+          // summary; fall back to the doc preview if nothing matches.
+          const search = await bridge.callTool('search_document', {
+            query: 'overview summary introduction main points key findings results conclusion',
+            k: 6,
+          });
+          const chunks =
+            (search as { data?: { chunks?: Array<{ headingPath?: string[]; snippet?: string }> } })
+              ?.data?.chunks ?? [];
+          context = chunks
+            .map(
+              (c) =>
+                (c.headingPath?.length ? c.headingPath.join(' › ') + '\n' : '') + (c.snippet ?? '')
+            )
+            .join('\n\n')
+            .trim();
+          if (!context) {
+            const stats = (await bridge.callTool('get_doc_stats', {})) as {
+              data?: { preview?: string };
+            };
+            context = String(stats?.data?.preview ?? '').trim();
+          }
           if (!context) {
             appendDisplay({
               kind: 'assistant',

--- a/docx-editor/packages/react/src/docops/bridge.ts
+++ b/docx-editor/packages/react/src/docops/bridge.ts
@@ -14,7 +14,7 @@ import type { EditorView } from 'prosemirror-view';
 import { collectHeadings } from '@eigenpal/docx-core/utils';
 import { generateTOC } from '@eigenpal/docx-core/prosemirror/commands';
 import { convertSelectionToTable } from '../utils/convertTextToTable';
-import type { DocOpsResult } from '@casualoffice/docops';
+import { retrieve, type DocOpsResult, type RetrievalChunk } from '@casualoffice/docops';
 
 /**
  * Subset of DocxEditorRef exposed to the bridge for mutation operations.
@@ -72,6 +72,8 @@ export class DocsBridge {
         return this.getSelection();
       case 'get_doc_stats':
         return this.getDocStats();
+      case 'search_document':
+        return this.searchDocument(args);
       case 'list_styles':
         return this.listStyles();
       case 'find_text':
@@ -200,15 +202,14 @@ export class DocsBridge {
       }
     });
 
-    // Cap the returned text so a long document can't overflow the local
-    // model's context window. ~14k chars ≈ 3.5k tokens, well within the
-    // 8k-token worker context alongside the prompt + generation.
-    const MAX_TEXT_CHARS = 14000;
+    // Do NOT dump the whole document here — that overflowed the local model's
+    // 8k-token context (TOO_LARGE) and silently truncated long docs. Return a
+    // short preview for orientation; the model reads real content via
+    // search_document (relevant passages) or get_block (a specific block).
+    const PREVIEW_CHARS = 1200;
     const fullText = textParts.join('\n');
-    const text =
-      fullText.length > MAX_TEXT_CHARS
-        ? fullText.slice(0, MAX_TEXT_CHARS) + '\n…[document truncated]'
-        : fullText;
+    const preview =
+      fullText.length > PREVIEW_CHARS ? fullText.slice(0, PREVIEW_CHARS) + '…' : fullText;
 
     return {
       ok: true,
@@ -220,7 +221,97 @@ export class DocsBridge {
         headingLevels: Array.from(headingLevelSet)
           .sort()
           .map((l) => l + 1),
-        text,
+        preview,
+        note: 'preview is only the first ~1200 chars. To summarize or answer questions, call search_document(query) to retrieve the relevant passages.',
+      },
+    };
+  }
+
+  /**
+   * RAG: chunk the document by heading section and return the passages most
+   * relevant to `query` (BM25), each with its blockIds so the agent can edit
+   * the retrieved text. Replaces dumping the whole document into the prompt.
+   */
+  private searchDocument(args: Record<string, unknown>): DocOpsResult {
+    const view = this.getView();
+    if (!view) return this.noView();
+    const query = String(args.query ?? '').trim();
+    if (!query) {
+      return { ok: false, code: 'VALIDATION', message: 'query is required.', retryable: false };
+    }
+    const k = typeof args.k === 'number' ? Math.min(Math.max(Math.floor(args.k), 1), 8) : 5;
+
+    const CHUNK_CHARS = 1800;
+    const chunks: RetrievalChunk[] = [];
+    const headingStack: { level: number; text: string }[] = [];
+    let seq = 0;
+    let headingPath: string[] = [];
+    let blockIds: string[] = [];
+    let parts: string[] = [];
+
+    const flush = () => {
+      const body = parts.join('\n').trim();
+      if (body) {
+        const prefix = headingPath.length ? headingPath.join(' › ') + '\n' : '';
+        chunks.push({
+          id: `dc${seq++}`,
+          text: prefix + body,
+          meta: { blockIds: [...blockIds], headingPath: [...headingPath] },
+        });
+      }
+      blockIds = [];
+      parts = [];
+    };
+
+    view.state.doc.descendants((node) => {
+      if (node.type.name !== 'paragraph') return;
+      const paraId = node.attrs.paraId as string | undefined;
+      let text = '';
+      node.forEach((child) => {
+        if (child.isText) text += child.text ?? '';
+      });
+
+      const level = node.attrs.outlineLevel as number | null;
+      const styleId = node.attrs.styleId as string | null;
+      let effLevel = level;
+      if (effLevel == null && styleId) {
+        const m = styleId.match(/^[Hh]eading(\d)$/);
+        if (m) effLevel = parseInt(m[1], 10) - 1;
+      }
+
+      if (effLevel != null) {
+        // New section — close the previous chunk and reset the heading path.
+        flush();
+        while (headingStack.length && headingStack[headingStack.length - 1].level >= effLevel) {
+          headingStack.pop();
+        }
+        headingStack.push({ level: effLevel, text: text.trim() });
+        headingPath = headingStack.map((h) => h.text).filter(Boolean);
+        if (paraId) blockIds.push(paraId);
+      } else {
+        if (paraId) blockIds.push(paraId);
+        if (text.trim()) parts.push(text);
+        if (parts.join('\n').length > CHUNK_CHARS) flush();
+      }
+    });
+    flush();
+
+    const result = retrieve(chunks, query, { k });
+    return {
+      ok: true,
+      data: {
+        chunks: result.chunks.map((c) => ({
+          chunkId: c.id,
+          headingPath: (c.meta as { headingPath?: string[] })?.headingPath ?? [],
+          blockIds: (c.meta as { blockIds?: string[] })?.blockIds ?? [],
+          snippet: c.text.slice(0, 700),
+          score: Math.round(c.score * 100) / 100,
+        })),
+        count: result.chunks.length,
+        truncated: result.truncated,
+        note: result.chunks.length
+          ? 'These are the passages most relevant to the query. Edit via the blockIds.'
+          : 'No passages matched the query.',
       },
     };
   }


### PR DESCRIPTION
Replaces get_doc_stats dumping the whole document (which overflowed the 8k local-model context on long docs / silently truncated summaries) with BM25 retrieval: a search_document(query,k) tool returning the top-k relevant passages with their blockIds. Pure TS, no embeddings/model/extra download. Unit-tested; typecheck + docops tests green.