### PR TITLE
fix(mcp): stream SSE responses, session id, pagination

### DIFF
--- a/docx-editor/.changeset/mcp-streaming-transport.md
+++ b/docx-editor/.changeset/mcp-streaming-transport.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+MCP Streamable-HTTP transport now reads `text/event-stream` responses incrementally instead of buffering the whole body, so it no longer hangs against spec-compliant streaming MCP servers. Also captures the `Mcp-Session-Id` for stateful servers, sends the protocol-version header, follows `tools/list` pagination, and aborts in-flight requests on close.

--- a/docx-editor/packages/docops/src/mcp/client.ts
+++ b/docx-editor/packages/docops/src/mcp/client.ts
@@ -63,8 +63,19 @@ export class McpClient implements ToolSource {
 
   async listTools(): Promise<DocOpsTool[]> {
     await this.ensureInitialized();
-    const res = await this.rpc.request<{ tools?: McpToolDef[] }>('tools/list');
-    return (res.tools ?? []).map((t) => ({
+    // Follow the pagination cursor so a server that pages its catalog doesn't
+    // silently expose only the first page.
+    const all: McpToolDef[] = [];
+    let cursor: string | undefined;
+    do {
+      const res = await this.rpc.request<{ tools?: McpToolDef[]; nextCursor?: string }>(
+        'tools/list',
+        cursor ? { cursor } : undefined
+      );
+      all.push(...(res.tools ?? []));
+      cursor = res.nextCursor;
+    } while (cursor && all.length < 500);
+    return all.map((t) => ({
       name: t.name,
       description: t.description ?? t.name,
       input_schema: {

--- a/docx-editor/packages/docops/src/mcp/httpTransport.test.ts
+++ b/docx-editor/packages/docops/src/mcp/httpTransport.test.ts
@@ -74,4 +74,44 @@ describe('HttpMcpTransport ↔ McpServer over HTTP', () => {
     const tools = await client.listTools();
     expect(tools).toHaveLength(1);
   });
+
+  it('reads a streaming text/event-stream body incrementally (chunked)', async () => {
+    const prov = provider([]);
+    let reply = '';
+    let serverHandler: ((m: string) => void) | null = null;
+    const t: JsonRpcTransport = {
+      send: (m) => {
+        reply = m;
+      },
+      onMessage: (h) => {
+        serverHandler = h;
+      },
+    };
+    // eslint-disable-next-line no-new
+    new McpServer(t, prov);
+    const streamingFetch = (async (_url: string, init: { body?: string }) => {
+      reply = '';
+      serverHandler?.(String(init.body));
+      await new Promise((r) => setTimeout(r, 5));
+      const frame = `event: message\ndata: ${reply}\n\n`;
+      const enc = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          // Split mid-frame to prove incremental parsing, not buffering.
+          controller.enqueue(enc.encode(frame.slice(0, 12)));
+          controller.enqueue(enc.encode(frame.slice(12)));
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    }) as unknown as typeof fetch;
+
+    const transport = new HttpMcpTransport('http://mcp.test/rpc', { fetchImpl: streamingFetch });
+    const client = new McpClient(transport, { id: 'mcp:stream' });
+    const tools = await client.listTools();
+    expect(tools).toHaveLength(1);
+  });
 });

--- a/docx-editor/packages/docops/src/mcp/httpTransport.ts
+++ b/docx-editor/packages/docops/src/mcp/httpTransport.ts
@@ -4,9 +4,16 @@
 
 /**
  * Streamable-HTTP transport for the MCP client — the standard way a browser
- * reaches a remote MCP server. Each JSON-RPC message is POSTed to the server
- * endpoint; the response body carries the matching JSON-RPC reply, which is
- * handed back to RpcConnection. Notifications (no id) POST and ignore the reply.
+ * reaches a remote MCP server (MCP spec 2025-06-18). Each JSON-RPC message is
+ * POSTed to the server endpoint. The reply may come back as:
+ *   - a buffered `application/json` body (one JSON-RPC object), or
+ *   - a `text/event-stream` (SSE) body, possibly long-lived, delivering one or
+ *     more `data:` JSON-RPC frames.
+ *
+ * We must NOT `await resp.text()` on the SSE case — that blocks until the stream
+ * closes, hanging every request against a spec-compliant streaming server until
+ * the RpcConnection timeout. Instead we read the body incrementally and dispatch
+ * each SSE frame as it arrives.
  *
  * This keeps McpClient transport-agnostic: swap this for a stdio bridge on the
  * desktop without touching the client or the agent.
@@ -14,17 +21,26 @@
 
 import type { JsonRpcTransport } from './jsonrpc';
 
+const DEFAULT_PROTOCOL_VERSION = '2025-06-18';
+
 export interface HttpMcpTransportOptions {
   /** Extra headers, e.g. Authorization for an authenticated MCP server. */
   headers?: Record<string, string>;
   /** Injected fetch (defaults to global). Lets tests supply their own. */
   fetchImpl?: typeof fetch;
+  /** MCP protocol version echoed on every request after initialize. */
+  protocolVersion?: string;
 }
 
 export class HttpMcpTransport implements JsonRpcTransport {
   private handler: ((message: string) => void) | null = null;
   private readonly headers: Record<string, string>;
   private readonly doFetch: typeof fetch;
+  private readonly protocolVersion: string;
+  private readonly inflight = new Set<AbortController>();
+  // Captured from the initialize response — stateful servers require it echoed
+  // on every subsequent request (spec: Mcp-Session-Id).
+  private sessionId: string | null = null;
   private closed = false;
 
   constructor(
@@ -32,6 +48,7 @@ export class HttpMcpTransport implements JsonRpcTransport {
     options: HttpMcpTransportOptions = {}
   ) {
     this.headers = options.headers ?? {};
+    this.protocolVersion = options.protocolVersion ?? DEFAULT_PROTOCOL_VERSION;
     // Bind to globalThis: native `fetch` throws "Illegal invocation" when
     // called as a method of another object (this === transport).
     this.doFetch = options.fetchImpl ?? fetch.bind(globalThis);
@@ -39,25 +56,62 @@ export class HttpMcpTransport implements JsonRpcTransport {
 
   send(message: string): void {
     if (this.closed) return;
+    const controller = new AbortController();
+    this.inflight.add(controller);
     void this.doFetch(this.url, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
         accept: 'application/json, text/event-stream',
+        'mcp-protocol-version': this.protocolVersion,
+        ...(this.sessionId ? { 'mcp-session-id': this.sessionId } : {}),
         ...this.headers,
       },
       body: message,
+      signal: controller.signal,
     })
       .then(async (resp) => {
-        const text = await resp.text();
+        const sid = resp.headers.get('mcp-session-id');
+        if (sid) this.sessionId = sid;
         if (this.closed) return;
-        // Accept both a bare JSON body and a single SSE `data:` frame.
-        const payload = extractJson(text);
-        if (payload) this.handler?.(payload);
+        const ctype = resp.headers.get('content-type') ?? '';
+        if (ctype.includes('text/event-stream') && resp.body) {
+          await this.readSse(resp.body);
+        } else {
+          const payload = extractJson(await resp.text());
+          if (payload && !this.closed) this.handler?.(payload);
+        }
       })
       .catch(() => {
-        /* RpcConnection times out the pending request on its own. */
-      });
+        /* aborted, or RpcConnection times out the pending request on its own. */
+      })
+      .finally(() => this.inflight.delete(controller));
+  }
+
+  /** Read an SSE body incrementally, dispatching each `data:` frame as it lands. */
+  private async readSse(body: ReadableStream<Uint8Array>): Promise<void> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done || this.closed) break;
+        // Normalise CRLF so a single frame delimiter works.
+        buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, '\n');
+        let sep: number;
+        while ((sep = buffer.indexOf('\n\n')) !== -1) {
+          const frame = buffer.slice(0, sep);
+          buffer = buffer.slice(sep + 2);
+          const data = frameData(frame);
+          if (data && !this.closed) this.handler?.(data);
+        }
+      }
+    } catch {
+      /* stream aborted on close */
+    } finally {
+      reader.releaseLock();
+    }
   }
 
   onMessage(handler: (message: string) => void): void {
@@ -66,15 +120,27 @@ export class HttpMcpTransport implements JsonRpcTransport {
 
   close(): void {
     this.closed = true;
+    for (const c of this.inflight) c.abort();
+    this.inflight.clear();
   }
 }
 
-/** Pull the JSON-RPC object out of a plain body or an SSE `data:` frame. */
+/** Join the `data:` lines of a single SSE frame into one JSON-RPC payload. */
+function frameData(frame: string): string | null {
+  const data = frame
+    .split('\n')
+    .filter((l) => l.startsWith('data:'))
+    .map((l) => l.slice(5).replace(/^ /, ''))
+    .join('\n')
+    .trim();
+  return data || null;
+}
+
+/** Pull the JSON-RPC object out of a plain body or a buffered SSE body. */
 function extractJson(body: string): string | null {
   const trimmed = body.trim();
   if (!trimmed) return null;
   if (trimmed.startsWith('{') || trimmed.startsWith('[')) return trimmed;
-  // SSE: take the last non-empty `data:` line.
   const dataLines = trimmed
     .split('\n')
     .map((l) => l.trim())


### PR DESCRIPTION
From the MCP deep-analysis: the Streamable-HTTP transport did await resp.text(), buffering the whole body and hanging against a spec-compliant long-lived SSE server until the RPC timeout. Now reads the stream incrementally and dispatches each frame; captures Mcp-Session-Id + protocol-version for stateful servers; follows tools/list pagination; aborts in-flight on close. Streaming test added; MCP tests green (7).