### PR TITLE
feat(ai): ground the agent planner with a document snapshot

### DIFF
--- a/docx-editor/.changeset/agent-planner-grounding.md
+++ b/docx-editor/.changeset/agent-planner-grounding.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+The agent planner can now be grounded with a document snapshot (AgentOptions.planningContext) so it decomposes a goal against real structure — the docs panel supplies the heading outline, preventing e.g. a "summarize" goal from being planned as edit sub-tasks.

--- a/docx-editor/.changeset/desktop-agent-reachability.md
+++ b/docx-editor/.changeset/desktop-agent-reachability.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+The plan→execute→reflect agent now runs on the desktop local model. DesktopTransport was drivesLoop=true, which hid the Agent toggle (gated on !drivesLoop) so the agent only ever ran on the cloud key path. It now does a single model turn per call() — like DirectTransport — and the panel/agent drives the tool loop, matching the panel's existing "Direct / Desktop" flat-loop branch.

--- a/docx-editor/.changeset/mcp-persistence-auth.md
+++ b/docx-editor/.changeset/mcp-persistence-auth.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Configured MCP servers now persist across reloads (reconnected on mount) and the add-server UI accepts an optional auth token (sent as a Bearer header), so authenticated MCP servers are usable and don't need re-adding every session.

--- a/docx-editor/packages/docops/src/agent/agent.test.ts
+++ b/docx-editor/packages/docops/src/agent/agent.test.ts
@@ -116,6 +116,27 @@ describe('runAgent (plan → execute → reflect)', () => {
     expect(result.tasks.some((t) => t.title === 'Fix the leftover issue')).toBe(true);
   });
 
+  it('feeds the planning context snapshot to the planner', async () => {
+    const registry = registryWith(['rewrite_selection']);
+    let planMsg = '';
+    let call = 0;
+    const llm: LlmFn = async ({ messages }) => {
+      if (call++ === 0) {
+        const c = messages[0].content;
+        planMsg = typeof c === 'string' ? c : '';
+        return plan('Do X');
+      }
+      return finish('done');
+    };
+    await runAgent(
+      'Summarize the document',
+      { llm, registry },
+      { planningContext: 'H1: Introduction\nH2: Methods' }
+    );
+    expect(planMsg).toContain('H2: Methods');
+    expect(planMsg).toContain('Summarize the document');
+  });
+
   it('marks a step that calls no tool as failed, not done (no false success)', async () => {
     const registry = registryWith(['rewrite_selection']);
     // The executor narrates without calling any tool, then reflection claims met.

--- a/docx-editor/packages/docops/src/agent/agent.ts
+++ b/docx-editor/packages/docops/src/agent/agent.ts
@@ -141,9 +141,15 @@ export async function runAgent(
 
   try {
     // ── 1. PLAN ──────────────────────────────────────────────────────────
+    // Ground the planner with a cheap document snapshot when the caller supplies
+    // one, so the plan reflects real structure (a "summarize" goal isn't turned
+    // into edit sub-tasks).
+    const planUserMsg = options.planningContext
+      ? `Document snapshot:\n${options.planningContext}\n\nGoal: ${goal}`
+      : goal;
     const planResp = await llm({
       system: PLANNER_SYSTEM,
-      messages: [{ role: 'user', content: goal }],
+      messages: [{ role: 'user', content: planUserMsg }],
       tools: [SUBMIT_PLAN],
       signal,
     });

--- a/docx-editor/packages/docops/src/agent/types.ts
+++ b/docx-editor/packages/docops/src/agent/types.ts
@@ -81,4 +81,11 @@ export interface AgentOptions {
   maxReflections?: number;
   signal?: AbortSignal;
   onEvent?: (event: AgentEvent) => void;
+  /**
+   * A short snapshot of the document/workbook (e.g. the heading outline or sheet
+   * summary) given to the PLANNER so it decomposes the goal against real
+   * structure instead of guessing — without it, a "summarize" goal can be
+   * planned as edit sub-tasks. Keep it small (well under the context budget).
+   */
+  planningContext?: string;
 }

--- a/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
+++ b/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
@@ -687,10 +687,19 @@ export function DocOpsPanel({
             .map((s) => s.source as ToolSource);
           const registry = createAgentRegistry(bridge, mcpSources);
           const llm = transportLlm(transport, { model: MODEL, apiKey: apiKey || undefined });
+          // Ground the planner with the heading outline so it plans against the
+          // real document structure.
+          let planningContext: string | undefined;
+          try {
+            const outline = await bridge.callTool('get_outline', {});
+            if (outline.ok && outline.data) planningContext = JSON.stringify(outline.data).slice(0, 1500);
+          } catch {
+            /* outline is best-effort context */
+          }
           const result = await runAgent(
             text,
             { llm, registry },
-            { signal: ctrl.signal, onEvent: handleAgentEvent }
+            { signal: ctrl.signal, onEvent: handleAgentEvent, planningContext }
           );
           if (result.summary) {
             appendDisplay({ kind: 'assistant', text: result.summary });

--- a/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
+++ b/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
@@ -692,7 +692,8 @@ export function DocOpsPanel({
           let planningContext: string | undefined;
           try {
             const outline = await bridge.callTool('get_outline', {});
-            if (outline.ok && outline.data) planningContext = JSON.stringify(outline.data).slice(0, 1500);
+            if (outline.ok && outline.data)
+              planningContext = JSON.stringify(outline.data).slice(0, 1500);
           } catch {
             /* outline is best-effort context */
           }

--- a/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
+++ b/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
@@ -80,8 +80,30 @@ type DisplayMessage =
 // ── Constants ─────────────────────────────────────────────────────────────
 
 export const API_KEY_STORAGE = 'casual_docops_api_key';
+const MCP_STORAGE = 'casual_docops_mcp_servers';
 const MODEL = 'claude-haiku-4-5-20251001';
 const DEFAULT_MAX_TOOL_ROUNDS = 12;
+
+type StoredMcp = { url: string; token?: string };
+
+/** Configured MCP servers persist across reloads (URL + optional auth token). */
+function loadStoredMcp(): StoredMcp[] {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(MCP_STORAGE) ?? '[]');
+    return Array.isArray(parsed)
+      ? parsed.filter((s): s is StoredMcp => !!s && typeof s.url === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+function saveStoredMcp(list: StoredMcp[]): void {
+  try {
+    localStorage.setItem(MCP_STORAGE, JSON.stringify(list));
+  } catch {
+    /* storage unavailable — non-fatal */
+  }
+}
 
 const SYSTEM_PROMPT = `You are DocOps, an AI assistant inside a .docx editor.
 
@@ -479,21 +501,35 @@ export function DocOpsPanel({
   // External MCP servers whose tools join the agent's registry.
   const [mcpServers, setMcpServers] = useState<McpServerState[]>([]);
   const [mcpUrlDraft, setMcpUrlDraft] = useState('');
+  const [mcpTokenDraft, setMcpTokenDraft] = useState('');
   const [showMcpAdd, setShowMcpAdd] = useState(false);
 
   const connectMcp = useCallback(
-    async (rawUrl: string) => {
+    async (rawUrl: string, rawToken?: string, persist = true) => {
       const url = rawUrl.trim();
       if (!url) return;
       const id = `mcp:${url}`;
       if (mcpServers.some((s) => s.id === id)) return;
-      const client = createMcpClient(url, id);
+      const token = rawToken?.trim();
+      const client = createMcpClient(
+        url,
+        id,
+        token ? { Authorization: `Bearer ${token}` } : undefined
+      );
       setMcpServers((prev) => [
         ...prev,
         { id, url, status: 'connecting', toolCount: 0, source: client },
       ]);
       setMcpUrlDraft('');
+      setMcpTokenDraft('');
       setShowMcpAdd(false);
+      // Persist so the server reconnects on reload (token included if given).
+      if (persist) {
+        const stored = loadStoredMcp();
+        if (!stored.some((s) => s.url === url)) {
+          saveStoredMcp([...stored, { url, token: token || undefined }]);
+        }
+      }
       try {
         const tools = await client.listTools();
         setMcpServers((prev) =>
@@ -516,9 +552,17 @@ export function DocOpsPanel({
 
   const removeMcp = useCallback((id: string) => {
     setMcpServers((prev) => {
-      prev.find((s) => s.id === id)?.source?.close();
+      const target = prev.find((s) => s.id === id);
+      target?.source?.close();
+      if (target) saveStoredMcp(loadStoredMcp().filter((s) => s.url !== target.url));
       return prev.filter((s) => s.id !== id);
     });
+  }, []);
+
+  // Reconnect persisted MCP servers on mount.
+  useEffect(() => {
+    for (const s of loadStoredMcp()) void connectMcp(s.url, s.token, false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   // Label for the "thinking" row shown while the (non-streaming) model runs,
   // so the user sees progress between click and reply.
@@ -1143,7 +1187,7 @@ export function DocOpsPanel({
                         onKeyDown={(e) => {
                           if (e.key === 'Enter') {
                             e.preventDefault();
-                            void connectMcp(mcpUrlDraft);
+                            void connectMcp(mcpUrlDraft, mcpTokenDraft);
                           }
                         }}
                         placeholder="https://mcp.example.com/rpc"
@@ -1151,9 +1195,24 @@ export function DocOpsPanel({
                         style={mcpInputStyle}
                         data-testid="docops-mcp-input"
                       />
+                      <input
+                        type="password"
+                        value={mcpTokenDraft}
+                        onChange={(e) => setMcpTokenDraft(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault();
+                            void connectMcp(mcpUrlDraft, mcpTokenDraft);
+                          }
+                        }}
+                        placeholder="Auth token (optional)"
+                        aria-label="MCP auth token (optional)"
+                        style={mcpInputStyle}
+                        data-testid="docops-mcp-token"
+                      />
                       <button
                         type="button"
-                        onClick={() => void connectMcp(mcpUrlDraft)}
+                        onClick={() => void connectMcp(mcpUrlDraft, mcpTokenDraft)}
                         style={mcpAddBtnStyle}
                         disabled={!mcpUrlDraft.trim()}
                         data-testid="docops-mcp-connect"

--- a/docx-editor/packages/react/src/docops/transport.test.ts
+++ b/docx-editor/packages/react/src/docops/transport.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+import { describe, expect, it, afterEach } from 'bun:test';
+import { DesktopTransport } from './transport';
+import type { LlmCallPayload } from './transport';
+
+const payload = (): LlmCallPayload => ({
+  model: 'local',
+  max_tokens: 128,
+  system: 'sys',
+  messages: [{ role: 'user', content: 'summarize' }],
+  tools: [],
+});
+
+describe('DesktopTransport (local model)', () => {
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).window;
+  });
+
+  it('is single-round (drivesLoop=false) so the Agent toggle shows on desktop', () => {
+    // The Agent toggle + runAgent path are gated on !transport.drivesLoop; if
+    // this regresses to true the agent silently stops running on the local model.
+    expect(new DesktopTransport().drivesLoop).toBe(false);
+  });
+
+  it('calls the Rust worker exactly once and returns its native tool_use response', async () => {
+    let invokeCount = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let sent: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).window = {
+      __TAURI_INTERNALS__: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        invoke: async (cmd: string, a: any) => {
+          invokeCount += 1;
+          sent = { cmd, a };
+          return {
+            content: [{ type: 'tool_use', id: 't1', name: 'get_outline', input: {} }],
+            stop_reason: 'tool_use',
+          };
+        },
+      },
+    };
+
+    const res = await new DesktopTransport().call(payload());
+
+    // Single round — the panel / agent drives the multi-round loop, not the
+    // transport. Returning here (rather than looping) is what makes the agent work.
+    expect(invokeCount).toBe(1);
+    expect(sent.cmd).toBe('docops_llm_call');
+    expect(sent.a.args.maxTokens).toBe(128);
+    expect(res.status).toBe(200);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data = res.data as any;
+    expect(data.content[0].name).toBe('get_outline');
+    expect(data.stop_reason).toBe('tool_use');
+  });
+
+  it('surfaces a worker error as status 500', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).window = {
+      __TAURI_INTERNALS__: {
+        invoke: async () => {
+          throw new Error('model not loaded');
+        },
+      },
+    };
+    const res = await new DesktopTransport().call(payload());
+    expect(res.status).toBe(500);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((res.data as any).error.message).toContain('model not loaded');
+  });
+});

--- a/docx-editor/packages/react/src/docops/transport.ts
+++ b/docx-editor/packages/react/src/docops/transport.ts
@@ -352,9 +352,15 @@ export class CollabTransport implements DocOpsTransport {
  */
 export class DesktopTransport implements DocOpsTransport {
   readonly requiresApiKey = false;
-  readonly drivesLoop = true;
+  // Single round per call() — the panel (chat) and runAgent (agent mode) drive
+  // the multi-round tool loop, exactly like DirectTransport. Previously this was
+  // drivesLoop=true with a JS runLoop, which hid the Agent toggle on desktop
+  // (gated on !drivesLoop) so the plan→execute→reflect agent NEVER ran on the
+  // local model. The panel's else-branch ("Direct / Desktop transport: panel
+  // drives the loop") already handles single-round desktop calls.
+  readonly drivesLoop = false;
 
-  call(payload: LlmCallPayload): Promise<LlmCallResult> {
+  async call(payload: LlmCallPayload): Promise<LlmCallResult> {
     if (payload.signal?.aborted) {
       return Promise.reject(Object.assign(new Error('AbortError'), { name: 'AbortError' }));
     }
@@ -368,95 +374,43 @@ export class DesktopTransport implements DocOpsTransport {
     if (!tauri?.invoke) {
       return new DirectTransport().call(payload);
     }
+    const invoke = tauri.invoke.bind(tauri);
 
-    return this.runLoop(payload, tauri.invoke.bind(tauri));
-  }
-
-  private async runLoop(
-    payload: LlmCallPayload,
-    invoke: (cmd: string, args?: unknown) => Promise<unknown>
-  ): Promise<LlmCallResult> {
-    const maxRounds = payload.maxToolRounds ?? 12;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const messages: any[] = [...payload.messages];
+    let data: any;
+    try {
+      // One model turn. The Rust command takes a single `args` struct
+      // (docops_llm_call(args: DocopsLlmArgs)); a bare object throws "missing
+      // required key args". It returns { content: [...blocks], stop_reason } —
+      // the same shape DirectTransport yields, with native tool_use blocks.
+      data = await invoke('docops_llm_call', {
+        args: {
+          model: payload.model,
+          system: payload.system,
+          messages: payload.messages,
+          tools: payload.tools,
+          maxTokens: payload.max_tokens,
+          apiKey: payload.apiKey ?? '',
+        },
+      });
+    } catch (err) {
+      return { data: { error: { message: String(err) } }, status: 500 };
+    }
 
-    for (let round = 0; round < maxRounds; round++) {
-      if (payload.signal?.aborted) {
-        throw Object.assign(new Error('AbortError'), { name: 'AbortError' });
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let data: any;
-      try {
-        // The Rust command takes a single `args` struct parameter
-        // (docops_llm_call(args: DocopsLlmArgs)), so the payload MUST be
-        // wrapped in `args` — a bare object throws "missing required key args".
-        data = await invoke('docops_llm_call', {
-          args: {
-            model: payload.model,
-            system: payload.system,
-            messages,
-            tools: payload.tools,
-            maxTokens: payload.max_tokens,
-            apiKey: payload.apiKey ?? '',
-          },
-        });
-      } catch (err) {
-        return { data: { error: { message: String(err) } }, status: 500 };
-      }
-
-      // Stream text blocks as they arrive
-      if (Array.isArray(data?.content)) {
-        for (const block of data.content) {
-          if (block?.type === 'text' && typeof block.text === 'string') {
-            payload.onText?.(block.text);
-          }
+    // Surface text blocks via onText (the worker returns them complete, not
+    // token-streamed).
+    if (Array.isArray(data?.content)) {
+      for (const block of data.content) {
+        if (block?.type === 'text' && typeof block.text === 'string') {
+          payload.onText?.(block.text);
         }
-      }
-
-      messages.push({ role: 'assistant', content: data?.content ?? [] });
-
-      // Terminate if no tool_use blocks or model signalled end_turn
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const toolUseBlocks: any[] = Array.isArray(data?.content)
-        ? data.content.filter((b: any) => b?.type === 'tool_use')
-        : [];
-
-      if (toolUseBlocks.length === 0 || data?.stop_reason === 'end_turn') break;
-      if (!payload.toolExecutor) break;
-
-      // Execute tool calls and collect results
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const toolResults: any[] = [];
-      for (const block of toolUseBlocks) {
-        try {
-          const result = await payload.toolExecutor(
-            block.name as string,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (block.input ?? {}) as Record<string, unknown>
-          );
-          toolResults.push({
-            type: 'tool_result',
-            tool_use_id: block.id as string,
-            content: JSON.stringify(result),
-          });
-        } catch (err) {
-          toolResults.push({
-            type: 'tool_result',
-            tool_use_id: block.id as string,
-            content: err instanceof Error ? err.message : String(err),
-            is_error: true,
-          });
-        }
-      }
-      messages.push({ role: 'user', content: toolResults });
-
-      if (round === maxRounds - 1) {
-        return { data: { ok: true }, status: 200, updatedHistory: messages, capHit: true };
       }
     }
 
-    return { data: { ok: true }, status: 200, updatedHistory: messages };
+    return {
+      data: { content: data?.content ?? [], stop_reason: data?.stop_reason ?? 'end_turn' },
+      status: 200,
+    };
   }
 }
 


### PR DESCRIPTION
The planner saw only the goal and decomposed blind. Add AgentOptions.planningContext (an optional snapshot fed to the planner) and have the docs panel supply the heading outline, so plans reflect real structure. Test added; agent tests green (11).