### PR TITLE
feat(ai): WorkspaceIndex — on-device multi-document RAG with citations

### DIFF
--- a/docx-editor/.changeset/workspace-rag-core.md
+++ b/docx-editor/.changeset/workspace-rag-core.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': minor
+---
+
+Add WorkspaceIndex — on-device BM25 retrieval across many documents, returning per-source citations. The reusable core for local "workspace RAG": the host feeds it plain text extracted from local files, and it retrieves relevant passages across all of them without anything leaving the machine.

--- a/docx-editor/packages/docops/src/index.ts
+++ b/docx-editor/packages/docops/src/index.ts
@@ -14,8 +14,16 @@ export type {
 export { DOCOPS_CATALOG } from './catalog';
 
 // Local-first RAG: BM25 retrieval over in-memory chunks (no embeddings/model).
-export { tokenize, Bm25Index, retrieve } from './retrieval';
-export type { RetrievalChunk, RetrievedChunk, RetrieveOptions, RetrieveResult } from './retrieval';
+export { tokenize, Bm25Index, retrieve, WorkspaceIndex } from './retrieval';
+export type {
+  RetrievalChunk,
+  RetrievedChunk,
+  RetrieveOptions,
+  RetrieveResult,
+  WorkspaceDoc,
+  WorkspaceHit,
+  WorkspaceSearchResult,
+} from './retrieval';
 
 // Agentic layer: plan → execute → reflect over a pluggable tool registry.
 export { ToolRegistry, runAgent } from './agent';

--- a/docx-editor/packages/docops/src/retrieval/index.ts
+++ b/docx-editor/packages/docops/src/retrieval/index.ts
@@ -3,4 +3,6 @@
  */
 
 export { tokenize, Bm25Index, retrieve } from './bm25';
+export { WorkspaceIndex } from './workspace';
 export type { RetrievalChunk, RetrievedChunk, RetrieveOptions, RetrieveResult } from './types';
+export type { WorkspaceDoc, WorkspaceHit, WorkspaceSearchResult } from './workspace';

--- a/docx-editor/packages/docops/src/retrieval/workspace.test.ts
+++ b/docx-editor/packages/docops/src/retrieval/workspace.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { WorkspaceIndex } from './workspace';
+
+function seeded(): WorkspaceIndex {
+  const idx = new WorkspaceIndex();
+  idx.add({
+    id: '/docs/q3.docx',
+    name: 'Q3 Report.docx',
+    text: 'Revenue grew 40% in Q3 driven by the new pricing model and strong enterprise sales.',
+  });
+  idx.add({
+    id: '/docs/roadmap.docx',
+    name: 'Roadmap.docx',
+    text: 'The 2026 roadmap prioritizes the offline AI assistant and local model support.',
+  });
+  idx.add({
+    id: '/docs/hr.docx',
+    name: 'HR Policy.docx',
+    text: 'Employees accrue paid time off monthly and may carry over up to ten days.',
+  });
+  return idx;
+}
+
+describe('WorkspaceIndex', () => {
+  it('retrieves across documents and attributes each hit to its source', () => {
+    const res = seeded().search('how did revenue and pricing perform', 3);
+    expect(res.hits[0].docName).toBe('Q3 Report.docx');
+    expect(res.hits[0].snippet).toContain('Revenue');
+    // Every hit carries a citation.
+    expect(res.hits.every((h) => h.docId && h.docName)).toBe(true);
+  });
+
+  it('lists distinct sources for a citation list', () => {
+    const idx = new WorkspaceIndex();
+    idx.add({ id: 'a', name: 'A', text: 'pricing revenue pricing' });
+    idx.add({ id: 'b', name: 'B', text: 'pricing strategy tiers' });
+    const res = idx.search('pricing', 6);
+    expect(res.sources.map((s) => s.docId).sort()).toEqual(['a', 'b']);
+  });
+
+  it('does not match unrelated documents', () => {
+    const res = seeded().search('paid time off carryover', 6);
+    // Only the HR doc should surface.
+    expect(res.hits.every((h) => h.docName === 'HR Policy.docx')).toBe(true);
+  });
+
+  it('add() replaces an existing document (no stale chunks)', () => {
+    const idx = new WorkspaceIndex();
+    idx.add({ id: 'x', name: 'X', text: 'alpha bravo charlie' });
+    idx.add({ id: 'x', name: 'X', text: 'delta echo foxtrot' });
+    expect(idx.size).toBe(1);
+    expect(idx.search('alpha', 6).hits).toHaveLength(0);
+    expect(idx.search('delta', 6).hits).toHaveLength(1);
+  });
+
+  it('remove() drops a document from results', () => {
+    const idx = seeded();
+    idx.remove('/docs/q3.docx');
+    expect(idx.size).toBe(2);
+    expect(idx.search('revenue pricing', 6).hits).toHaveLength(0);
+  });
+});

--- a/docx-editor/packages/docops/src/retrieval/workspace.ts
+++ b/docx-editor/packages/docops/src/retrieval/workspace.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * WorkspaceIndex — BM25 retrieval across MANY documents (the user's local
+ * folder), the on-device answer to the cloud "workspace RAG" the incumbents
+ * ship. Everything stays in memory / on the machine: the host (desktop shell)
+ * reads local files and extracts plain text; this indexes and retrieves across
+ * them, returning per-source citations so the model can attribute answers.
+ *
+ * North-star O2. Reuses the same BM25 core as single-document search.
+ */
+
+import { retrieve } from './bm25';
+import type { RetrievalChunk } from './types';
+
+export interface WorkspaceDoc {
+  /** Stable id — the file path. */
+  id: string;
+  /** Display name for citations (e.g. the file name). */
+  name: string;
+  /** Full plain text; the host extracts this from .docx/.xlsx/etc. */
+  text: string;
+}
+
+export interface WorkspaceHit {
+  docId: string;
+  docName: string;
+  snippet: string;
+  score: number;
+}
+
+export interface WorkspaceSearchResult {
+  hits: WorkspaceHit[];
+  /** Distinct source documents represented in the hits (for a citation list). */
+  sources: { docId: string; docName: string }[];
+  truncated: boolean;
+}
+
+const CHUNK_CHARS = 1800;
+const SNIPPET_CHARS = 700;
+
+/** Split plain text into ~CHUNK_CHARS chunks on paragraph boundaries. */
+function chunkText(text: string): string[] {
+  const paras = text
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const chunks: string[] = [];
+  let buf = '';
+  for (const para of paras) {
+    if (buf && buf.length + para.length > CHUNK_CHARS) {
+      chunks.push(buf);
+      buf = '';
+    }
+    // A single oversized paragraph becomes its own (possibly long) chunk.
+    buf = buf ? `${buf}\n${para}` : para;
+    if (buf.length >= CHUNK_CHARS) {
+      chunks.push(buf);
+      buf = '';
+    }
+  }
+  if (buf) chunks.push(buf);
+  return chunks;
+}
+
+export class WorkspaceIndex {
+  private chunks: RetrievalChunk[] = [];
+  private readonly docs = new Map<string, string>(); // id → name
+
+  /** Add or replace a document in the index. */
+  add(doc: WorkspaceDoc): void {
+    this.remove(doc.id);
+    this.docs.set(doc.id, doc.name);
+    chunkText(doc.text).forEach((text, i) => {
+      this.chunks.push({
+        id: `${doc.id}#${i}`,
+        text,
+        meta: { docId: doc.id, docName: doc.name },
+      });
+    });
+  }
+
+  /** Remove a document (e.g. deleted or closed file). */
+  remove(docId: string): void {
+    if (!this.docs.has(docId)) return;
+    this.docs.delete(docId);
+    this.chunks = this.chunks.filter((c) => (c.meta as { docId: string }).docId !== docId);
+  }
+
+  clear(): void {
+    this.chunks = [];
+    this.docs.clear();
+  }
+
+  get size(): number {
+    return this.docs.size;
+  }
+
+  /** Retrieve the passages most relevant to `query` across ALL indexed docs. */
+  search(query: string, k = 6): WorkspaceSearchResult {
+    const result = retrieve(this.chunks, query, { k });
+    const hits: WorkspaceHit[] = result.chunks.map((c) => {
+      const meta = c.meta as { docId: string; docName: string };
+      return {
+        docId: meta.docId,
+        docName: meta.docName,
+        snippet: c.text.slice(0, SNIPPET_CHARS),
+        score: Math.round(c.score * 100) / 100,
+      };
+    });
+    // Distinct sources, first-seen order, for a citation list.
+    const seen = new Set<string>();
+    const sources: { docId: string; docName: string }[] = [];
+    for (const h of hits) {
+      if (seen.has(h.docId)) continue;
+      seen.add(h.docId);
+      sources.push({ docId: h.docId, docName: h.docName });
+    }
+    return { hits, sources, truncated: result.truncated };
+  }
+}


### PR DESCRIPTION
North-star O2 (on-device workspace RAG). Adds WorkspaceIndex: chunks + BM25-indexes many documents and retrieves relevant passages across all of them, each hit attributed to its source file (citations) — the on-device answer to cloud workspace RAG. Pure TS, reuses the BM25 core, 5 unit tests. Next increment: desktop folder-indexing + a search_workspace tool + citation UI.