### PR TITLE
feat(ai): search_workspace tool — cite across the user's local folder

### DIFF
--- a/docx-editor/.changeset/search-workspace-tool.md
+++ b/docx-editor/.changeset/search-workspace-tool.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': minor
+---
+
+Add the search_workspace tool + DocsBridge.setWorkspaceDocs() API: the host (desktop shell) can push plain text from the user's local folder into the bridge, and the AI can then retrieve and cite passages across ALL those files — on-device, no cloud. Gracefully unavailable until a workspace is provided.

--- a/docx-editor/packages/docops/src/catalog.ts
+++ b/docx-editor/packages/docops/src/catalog.ts
@@ -61,6 +61,25 @@ export const DOCOPS_CATALOG: DocOpsTool[] = [
     },
   },
   {
+    name: 'search_workspace',
+    description:
+      "Retrieve relevant passages from the user's OTHER local files (the open folder/workspace), not just the current document. Returns passages each tagged with their source file so you can cite them. Use when the question spans multiple documents ('what did we say about X across my files'). Only available when a workspace folder is open.",
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'What to look for across the workspace, in natural language.',
+        },
+        k: {
+          type: 'number',
+          description: 'Max passages to return (1–8). Defaults to 6.',
+        },
+      },
+      required: ['query'],
+    },
+  },
+  {
     name: 'list_styles',
     description: 'Lists paragraph styles and fonts used in the document, sorted by frequency.',
     input_schema: {

--- a/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
+++ b/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
@@ -111,6 +111,7 @@ IMPORTANT: You do not have the document text. It is not in this chat. You are th
 
 Read tools (inspect the document — never mutate):
 - search_document(query) — returns the passages most relevant to the query, each with its heading path and blockIds. Use this to summarize, describe, or answer questions — it works on documents of any length.
+- search_workspace(query) — searches the user's OTHER local files (when a folder is open), returning passages tagged with their source file to cite. Use for questions that span multiple documents.
 - get_doc_stats() — word/paragraph/table/image counts + a short preview (NOT the full text).
 - get_outline() — returns the heading tree.
 - get_selection() — returns the user's currently selected text.

--- a/docx-editor/packages/react/src/docops/bridge.ts
+++ b/docx-editor/packages/react/src/docops/bridge.ts
@@ -14,7 +14,13 @@ import type { EditorView } from 'prosemirror-view';
 import { collectHeadings } from '@eigenpal/docx-core/utils';
 import { generateTOC } from '@eigenpal/docx-core/prosemirror/commands';
 import { convertSelectionToTable } from '../utils/convertTextToTable';
-import { retrieve, type DocOpsResult, type RetrievalChunk } from '@casualoffice/docops';
+import {
+  retrieve,
+  WorkspaceIndex,
+  type DocOpsResult,
+  type RetrievalChunk,
+  type WorkspaceDoc,
+} from '@casualoffice/docops';
 
 /**
  * Subset of DocxEditorRef exposed to the bridge for mutation operations.
@@ -59,10 +65,32 @@ export interface DocsBridgeActions {
 }
 
 export class DocsBridge {
+  // On-device workspace RAG (north-star O2): the host (desktop shell) extracts
+  // plain text from the user's local files and pushes it here via
+  // setWorkspaceDocs; search_workspace then retrieves across all of them. Null
+  // until a workspace is provided, so search_workspace degrades gracefully.
+  private workspace: WorkspaceIndex | null = null;
+
   constructor(
     private readonly getView: () => EditorView | null,
     private readonly getActions: () => DocsBridgeActions | null = () => null
   ) {}
+
+  /** Replace the indexed workspace (host-driven; files stay on the machine). */
+  setWorkspaceDocs(docs: WorkspaceDoc[]): void {
+    const idx = new WorkspaceIndex();
+    for (const doc of docs) idx.add(doc);
+    this.workspace = idx;
+  }
+
+  /** True when a local workspace has been indexed (gates the search_workspace tool). */
+  hasWorkspace(): boolean {
+    return !!this.workspace && this.workspace.size > 0;
+  }
+
+  clearWorkspace(): void {
+    this.workspace = null;
+  }
 
   async callTool(name: string, args: Record<string, unknown>): Promise<DocOpsResult> {
     switch (name) {
@@ -74,6 +102,8 @@ export class DocsBridge {
         return this.getDocStats();
       case 'search_document':
         return this.searchDocument(args);
+      case 'search_workspace':
+        return this.searchWorkspace(args);
       case 'list_styles':
         return this.listStyles();
       case 'find_text':
@@ -312,6 +342,44 @@ export class DocsBridge {
         note: result.chunks.length
           ? 'These are the passages most relevant to the query. Edit via the blockIds.'
           : 'No passages matched the query.',
+      },
+    };
+  }
+
+  /**
+   * RAG across the user's LOCAL workspace (other files in the folder), not just
+   * the open document — the on-device answer to cloud workspace search. Returns
+   * the best passages with the source file for each, so the model can cite them.
+   */
+  private searchWorkspace(args: Record<string, unknown>): DocOpsResult {
+    if (!this.workspace || this.workspace.size === 0) {
+      return {
+        ok: false,
+        code: 'UNSUPPORTED',
+        message: 'No workspace folder is indexed. Ask the user to open a folder first.',
+        retryable: false,
+      };
+    }
+    const query = String(args.query ?? '').trim();
+    if (!query) {
+      return { ok: false, code: 'VALIDATION', message: 'query is required.', retryable: false };
+    }
+    const k = typeof args.k === 'number' ? Math.min(Math.max(Math.floor(args.k), 1), 8) : 6;
+    const result = this.workspace.search(query, k);
+    return {
+      ok: true,
+      data: {
+        hits: result.hits.map((h) => ({
+          source: h.docName,
+          snippet: h.snippet,
+          score: h.score,
+        })),
+        sources: result.sources.map((s) => s.docName),
+        count: result.hits.length,
+        truncated: result.truncated,
+        note: result.hits.length
+          ? 'Passages from across the workspace. Cite the source file for each claim.'
+          : 'No passages in the workspace matched the query.',
       },
     };
   }


### PR DESCRIPTION
North-star O2 wiring (editor side). DocsBridge owns a WorkspaceIndex + exposes setWorkspaceDocs(docs); the new search_workspace tool retrieves + cites passages across the user's local files, on-device. Degrades gracefully until a workspace is provided. Next increment: desktop folder picker + headless .docx→text extraction feeding setWorkspaceDocs. Typecheck + 30 docops tests green.