### PR TITLE
fix(ai): stop the agent looping on repeated identical tool calls

### DIFF
--- a/docx-editor/.changeset/agent-repeated-call-guard.md
+++ b/docx-editor/.changeset/agent-repeated-call-guard.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+The agent's per-task loop now stops when the model repeats the identical tool call two rounds in a row, instead of burning the whole round budget re-calling the same tool with no progress — a common small-local-model failure.

--- a/docx-editor/packages/docops/src/agent/agent.test.ts
+++ b/docx-editor/packages/docops/src/agent/agent.test.ts
@@ -116,6 +116,22 @@ describe('runAgent (plan → execute → reflect)', () => {
     expect(result.tasks.some((t) => t.title === 'Fix the leftover issue')).toBe(true);
   });
 
+  it('stops a task that repeats the identical tool call (loop guard)', async () => {
+    const toolCalls: string[] = [];
+    const registry = registryWith(['get_outline'], toolCalls);
+    // The executor emits the SAME call every round; scriptedLlm repeats the last
+    // response, so without the guard it would run all maxRoundsPerTask rounds.
+    const { llm } = scriptedLlm([
+      plan('Read the outline'),
+      callTool('get_outline'),
+      callTool('get_outline'),
+      reflection(true),
+    ]);
+    await runAgent('Goal', { llm, registry }, { maxRoundsPerTask: 6 });
+    // Executed once, then the guard broke the loop — not 6 identical calls.
+    expect(toolCalls).toEqual(['get_outline']);
+  });
+
   it('feeds the planning context snapshot to the planner', async () => {
     const registry = registryWith(['rewrite_selection']);
     let planMsg = '';

--- a/docx-editor/packages/docops/src/agent/agent.ts
+++ b/docx-editor/packages/docops/src/agent/agent.ts
@@ -246,6 +246,8 @@ async function executeTask(
   let lastError: string | undefined;
   let attemptedTools = 0;
   let failedTools = 0;
+  // Signature of the previous round's tool calls — for the repeated-call guard.
+  let lastSig: string | null = null;
 
   for (let round = 0; round < opts.maxRounds; round++) {
     if (opts.signal?.aborted) return { changed, failed: true, error: 'Cancelled.' };
@@ -264,6 +266,20 @@ async function executeTask(
       content: resp.stop_reason === 'tool_use' ? resp.content : textOf(resp.content) || ' ',
     });
     if (resp.stop_reason !== 'tool_use' || calls.length === 0) break;
+
+    // Loop guard: a small model can repeat the SAME tool call every round,
+    // burning the whole budget with no progress. If this round's calls are
+    // identical to the previous round's, stop — it's stuck, not working.
+    const sig = calls.map((c) => `${c.name}:${JSON.stringify(c.input ?? {})}`).join('|');
+    if (sig === lastSig) {
+      opts.emit({
+        type: 'task-text',
+        taskId: task.id,
+        text: '(stopped: the model repeated the same tool call without progress)',
+      });
+      break;
+    }
+    lastSig = sig;
 
     const results: LlmContentBlock[] = [];
     for (const call of calls) {


### PR DESCRIPTION
Small local models often re-call the same tool with the same args every round, burning the per-task budget with no progress. Detect a round whose calls are identical to the previous round's and break early. Distinct args unaffected. Test added; 13 agent tests green. (Hardens the on-device agent path for north-star O3.)