### PR TITLE
fix(ai): find_text matches any textblock, not just paragraphs

### DIFF
--- a/docx-editor/.changeset/find-text-textblock.md
+++ b/docx-editor/.changeset/find-text-textblock.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+find_text now matches any textblock (headings, list items, …), not only paragraph nodes — consistent with get_block. It previously missed text in non-paragraph blocks, so the model could locate a block by other means and then get "not found" from find_text.

--- a/docx-editor/packages/react/src/docops/bridge.ts
+++ b/docx-editor/packages/react/src/docops/bridge.ts
@@ -436,7 +436,10 @@ export class DocsBridge {
 
     view.state.doc.descendants((node, pos) => {
       if (matches.length >= limit) return false;
-      if (node.type.name !== 'paragraph') return;
+      // Match any textblock (paragraphs, headings, list items, …) so find_text
+      // is consistent with get_block, which also keys on isTextblock. The old
+      // paragraph-only check silently missed text in other block types.
+      if (!node.isTextblock) return;
 
       let text = '';
       node.forEach((child) => {


### PR DESCRIPTION
find_text keyed on node.type.name === 'paragraph' while get_block keys on isTextblock, so find_text silently missed text in non-paragraph textblocks (an inconsistency the model can't reason around). Align find_text on isTextblock. Typecheck + docops tests green.