### PR TITLE
feat(ai): embed command to populate the on-device workspace index

### DIFF
--- a/docs/internal/13-iframe-protocol.md
+++ b/docs/internal/13-iframe-protocol.md
@@ -346,6 +346,18 @@ Update theme / locale at runtime. Editor re-renders.
 Move keyboard focus into the editor — useful when the host renders
 custom chrome that captures focus.
 
+### `command.set.workspace` (host → editor)
+
+Populate the editor's on-device workspace index for RAG across the user's
+local folder. The host extracts plain text from each local file and sends it;
+the AI's `search_workspace` tool then retrieves + cites across all of them.
+Nothing leaves the machine. Empty `docs` clears the workspace.
+
+```
+{ type: 'casual.command.set.workspace', app: 'docs', v: 1,
+  data: { docs: [{ id: '/path/a.docx', name: 'a.docx', text: '…' }] } }
+```
+
 ---
 
 ## Binary payloads

--- a/docx-editor/.changeset/workspace-embed-command.md
+++ b/docx-editor/.changeset/workspace-embed-command.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': minor
+---
+
+Add the casual.command.set.workspace embed command + host API (EmbedHostTransport.sendSetWorkspace) so a host can push plain text from the user's local folder into a shared on-device workspace index; the AI's search_workspace tool then retrieves and cites across those files. Nothing leaves the machine.

--- a/docx-editor/packages/react/src/docops/bridge.ts
+++ b/docx-editor/packages/react/src/docops/bridge.ts
@@ -21,6 +21,7 @@ import {
   type RetrievalChunk,
   type WorkspaceDoc,
 } from '@casualoffice/docops';
+import { getSharedWorkspace } from './workspaceStore';
 
 /**
  * Subset of DocxEditorRef exposed to the bridge for mutation operations.
@@ -85,7 +86,7 @@ export class DocsBridge {
 
   /** True when a local workspace has been indexed (gates the search_workspace tool). */
   hasWorkspace(): boolean {
-    return !!this.workspace && this.workspace.size > 0;
+    return (!!this.workspace && this.workspace.size > 0) || !!getSharedWorkspace();
   }
 
   clearWorkspace(): void {
@@ -352,7 +353,10 @@ export class DocsBridge {
    * the best passages with the source file for each, so the model can cite them.
    */
   private searchWorkspace(args: Record<string, unknown>): DocOpsResult {
-    if (!this.workspace || this.workspace.size === 0) {
+    // Prefer a workspace set directly on this bridge; otherwise use the shared
+    // process-level workspace the host populates (embed command / desktop).
+    const ws = this.workspace && this.workspace.size > 0 ? this.workspace : getSharedWorkspace();
+    if (!ws) {
       return {
         ok: false,
         code: 'UNSUPPORTED',
@@ -365,7 +369,7 @@ export class DocsBridge {
       return { ok: false, code: 'VALIDATION', message: 'query is required.', retryable: false };
     }
     const k = typeof args.k === 'number' ? Math.min(Math.max(Math.floor(args.k), 1), 8) : 6;
-    const result = this.workspace.search(query, k);
+    const result = ws.search(query, k);
     return {
       ok: true,
       data: {

--- a/docx-editor/packages/react/src/docops/workspaceStore.ts
+++ b/docx-editor/packages/react/src/docops/workspaceStore.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Shared, process-level workspace index for on-device workspace RAG
+ * (north-star O2). There is ONE user workspace (the open local folder)
+ * regardless of how many editor tabs/instances exist, so the index is a
+ * module singleton the host populates once (via the embed `setWorkspace`
+ * command or a desktop bridge) and every DocsBridge consults.
+ *
+ * Everything stays in memory / on the machine — the host extracts plain text
+ * from local files and pushes it here; nothing leaves the device.
+ */
+
+import { WorkspaceIndex, type WorkspaceDoc } from '@casualoffice/docops';
+
+let shared: WorkspaceIndex | null = null;
+
+/** Replace the indexed workspace with `docs` (host-driven). */
+export function setWorkspaceDocs(docs: WorkspaceDoc[]): void {
+  if (!docs.length) {
+    shared = null;
+    return;
+  }
+  const idx = new WorkspaceIndex();
+  for (const doc of docs) idx.add(doc);
+  shared = idx;
+}
+
+export function clearWorkspace(): void {
+  shared = null;
+}
+
+/** The shared index, or null when no workspace folder is open. */
+export function getSharedWorkspace(): WorkspaceIndex | null {
+  return shared && shared.size > 0 ? shared : null;
+}

--- a/docx-editor/packages/react/src/embed-runtime/index.tsx
+++ b/docx-editor/packages/react/src/embed-runtime/index.tsx
@@ -33,6 +33,7 @@ import { CasualEditor } from '../components/CasualEditor';
 import { EmbedTransport } from '../embed/EmbedTransport';
 import { createIframeFileSource } from '../embed/IframeFileSource';
 import type { CasualApp } from '../embed/protocol';
+import { setWorkspaceDocs } from '../docops/workspaceStore';
 
 /** Parsed shape of the iframe URL — what `mountEmbedded()` reads
  *  before the host's `casual.hello` arrives. */
@@ -163,6 +164,11 @@ export function mountEmbedded(opts: MountEmbeddedOptions): void {
     onCommandSetViewMode: ({ viewMode }) => {
       opts.root.setAttribute('data-view-mode', viewMode);
       render(viewMode);
+    },
+    // On-device workspace RAG: the host pushes plain text extracted from the
+    // user's local folder into the shared workspace index the AI searches.
+    onCommandSetWorkspace: ({ docs }) => {
+      setWorkspaceDocs(docs);
     },
   });
 }

--- a/docx-editor/packages/react/src/embed/EmbedHostTransport.ts
+++ b/docx-editor/packages/react/src/embed/EmbedHostTransport.ts
@@ -27,6 +27,7 @@ import {
   type CommandSetThemeData,
   type CommandSetLocaleData,
   type CommandSetViewModeData,
+  type CommandSetWorkspaceData,
   type EditorHelloData,
   type HostHelloData,
   type LoadRequestData,
@@ -108,6 +109,12 @@ export class EmbedHostTransport {
   /** Tell the editor to switch chrome density without re-mounting. */
   sendSetViewMode(data: CommandSetViewModeData): void {
     this.post('casual.command.set.viewmode', data);
+  }
+
+  /** Populate the editor's on-device workspace index for RAG across the user's
+   *  local folder. The host extracts plain text from each file first. */
+  sendSetWorkspace(data: CommandSetWorkspaceData): void {
+    this.post('casual.command.set.workspace', data);
   }
 
   sendSetReadOnly(data: CommandSetReadOnlyData): void {

--- a/docx-editor/packages/react/src/embed/EmbedTransport.ts
+++ b/docx-editor/packages/react/src/embed/EmbedTransport.ts
@@ -32,6 +32,7 @@ import {
   type CommandSetThemeData,
   type CommandSetLocaleData,
   type CommandSetViewModeData,
+  type CommandSetWorkspaceData,
   type CasualErrorData,
   type SignatureRequestData,
   type SignatureRequestAckData,
@@ -66,6 +67,8 @@ export interface EmbedTransportHandlers {
   onCommandSetLocale?: (data: CommandSetLocaleData) => void | Promise<void>;
   /** Host → editor: switch chrome density (preview ↔ editor). */
   onCommandSetViewMode?: (data: CommandSetViewModeData) => void | Promise<void>;
+  /** Host → editor: populate the on-device workspace index for RAG. */
+  onCommandSetWorkspace?: (data: CommandSetWorkspaceData) => void | Promise<void>;
   onCommandFocus?: () => void | Promise<void>;
   onCommandSave?: () => void | Promise<void>;
   onCommandLoad?: () => void | Promise<void>;
@@ -222,6 +225,9 @@ export class EmbedTransport {
         return;
       case 'casual.command.set.viewmode':
         await this.handlers.onCommandSetViewMode?.(env.data as CommandSetViewModeData);
+        return;
+      case 'casual.command.set.workspace':
+        await this.handlers.onCommandSetWorkspace?.(env.data as CommandSetWorkspaceData);
         return;
       case 'casual.command.focus':
         await this.handlers.onCommandFocus?.();

--- a/docx-editor/packages/react/src/embed/protocol.ts
+++ b/docx-editor/packages/react/src/embed/protocol.ts
@@ -134,6 +134,13 @@ export interface CommandSetViewModeData {
   viewMode: 'preview' | 'editor';
 }
 
+/** Host → editor: populate the on-device workspace index for RAG across the
+ *  user's local folder. The host extracts plain text from each file and sends
+ *  it here; nothing leaves the machine. Empty `docs` clears the workspace. */
+export interface CommandSetWorkspaceData {
+  docs: { id: string; name: string; text: string }[];
+}
+
 // ---------------------------------------------------------------
 // Errors (editor → host fatal signals)
 // ---------------------------------------------------------------


### PR DESCRIPTION
North-star O2 wiring (editor + protocol side). Adds a shared workspace store + the casual.command.set.workspace embed message (editor receiver + host sender) so a host can push local-folder text into a shared on-device index; search_workspace consults it and cites across files. Typecheck + 21 tests green; protocol doc updated. Final increment: desktop shell folder picker + headless .docx text extraction calling sendSetWorkspace.