### PR TITLE
feat(ai): desktop 'Folder' button to index a local folder for the AI

### DIFF
--- a/docx-editor/.changeset/workspace-panel-button.md
+++ b/docx-editor/.changeset/workspace-panel-button.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': minor
+---
+
+DocOps AI panel: on the desktop app, a "Folder" button indexes a local folder for on-device workspace RAG (picks a folder, extracts text via the native shell, populates the workspace index the AI's search_workspace tool searches + cites). Shows an "N indexed" chip; click to clear. Adds a folder icon. Hidden on web/iframe (no desktop shell).

--- a/docx-editor/packages/react/src/components/ui/Icons.tsx
+++ b/docx-editor/packages/react/src/components/ui/Icons.tsx
@@ -835,6 +835,14 @@ export function IconNoteAdd(props: IconProps) {
   );
 }
 
+export function IconFolder(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M160-160q-33 0-56.5-23.5T80-240v-480q0-33 23.5-56.5T160-800h240l80 80h320q33 0 56.5 23.5T880-640v400q0 33-23.5 56.5T800-160H160Zm0-80h640v-400H447l-80-80H160v480Zm0 0v-480 480Z" />
+    </SvgIcon>
+  );
+}
+
 export function IconContentCut(props: IconProps) {
   return (
     <SvgIcon {...props}>
@@ -1066,6 +1074,7 @@ const iconMap: Record<string, React.ComponentType<IconProps>> = {
   auto_awesome: IconAgentSparkle,
   // File menu — `tune` and `settings` already registered above
   note_add: IconNoteAdd,
+  folder: IconFolder,
   // Edit menu — clipboard ops
   content_cut: IconContentCut,
   content_copy: IconContentCopy,

--- a/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
+++ b/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
@@ -40,6 +40,22 @@ import {
   type LlmCallPayload,
   type ToolExecutor,
 } from './transport';
+import { setWorkspaceDocs } from './workspaceStore';
+
+/** The desktop shell exposes Tauri's invoke on the top-level window; returns it
+ *  when running inside Casual Desktop, else null (web / iframe). */
+function desktopInvoke():
+  | ((cmd: string, args?: Record<string, unknown>) => Promise<unknown>)
+  | null {
+  const inv = (
+    window as {
+      __TAURI__?: {
+        core?: { invoke?: (c: string, a?: Record<string, unknown>) => Promise<unknown> };
+      };
+    }
+  ).__TAURI__?.core?.invoke;
+  return typeof inv === 'function' ? inv : null;
+}
 
 interface McpServerState {
   id: string;
@@ -504,6 +520,39 @@ export function DocOpsPanel({
   const [mcpUrlDraft, setMcpUrlDraft] = useState('');
   const [mcpTokenDraft, setMcpTokenDraft] = useState('');
   const [showMcpAdd, setShowMcpAdd] = useState(false);
+
+  // On-device workspace RAG (desktop only): { count, folder } once a local
+  // folder is indexed; null otherwise. 'indexing' while the picker/read runs.
+  const [workspace, setWorkspace] = useState<{ count: number; folder: string } | null>(null);
+  const [indexingWorkspace, setIndexingWorkspace] = useState(false);
+  const canIndexWorkspace = !!desktopInvoke();
+
+  const indexWorkspace = useCallback(async () => {
+    const invoke = desktopInvoke();
+    if (!invoke || indexingWorkspace) return;
+    setIndexingWorkspace(true);
+    try {
+      const folder = (await invoke('pick_workspace_folder')) as string | null;
+      if (!folder) return; // dismissed
+      const docs = (await invoke('read_workspace_folder', { path: folder })) as {
+        id: string;
+        name: string;
+        text: string;
+      }[];
+      setWorkspaceDocs(docs);
+      const folderName = folder.split(/[\\/]/).pop() || folder;
+      setWorkspace(docs.length ? { count: docs.length, folder: folderName } : null);
+    } catch {
+      /* dialog cancelled or read failed — leave the current workspace as-is */
+    } finally {
+      setIndexingWorkspace(false);
+    }
+  }, [indexingWorkspace]);
+
+  const clearWorkspaceFolder = useCallback(() => {
+    setWorkspaceDocs([]);
+    setWorkspace(null);
+  }, []);
 
   const connectMcp = useCallback(
     async (rawUrl: string, rawToken?: string, persist = true) => {
@@ -1148,6 +1197,31 @@ export function DocOpsPanel({
                       MCP
                     </button>
                   )}
+                  {canIndexWorkspace &&
+                    (workspace ? (
+                      <button
+                        type="button"
+                        onClick={clearWorkspaceFolder}
+                        style={mcpAddBtnStyle}
+                        data-testid="docops-workspace-chip"
+                        title={`${workspace.count} file${workspace.count === 1 ? '' : 's'} from "${workspace.folder}" indexed for the AI. Click to clear.`}
+                      >
+                        <MaterialSymbol name="folder" size={13} />
+                        {workspace.count} indexed
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={indexWorkspace}
+                        style={mcpAddBtnStyle}
+                        disabled={indexingWorkspace}
+                        data-testid="docops-workspace-add"
+                        title="Index a local folder so the AI can search and cite across your files — on-device"
+                      >
+                        <MaterialSymbol name="folder" size={13} />
+                        {indexingWorkspace ? 'Indexing…' : 'Folder'}
+                      </button>
+                    ))}
                 </div>
               )}
               {agentMode && !transport.drivesLoop && (mcpServers.length > 0 || showMcpAdd) && (


### PR DESCRIPTION
North-star O2 last mile (editor side). On the desktop app, the AI panel gains a 'Folder' button: picks a local folder (pick_workspace_folder), extracts text (read_workspace_folder), populates the shared on-device workspace index the search_workspace tool searches + cites. 'N indexed' chip clears it. Adds a registered folder icon. Desktop-gated on window.__TAURI__ so web/iframe unaffected. Typecheck + retrieval tests green. Only the folder-dialog + chip visuals need on-device verification.