### PR TITLE
feat(mcp): HttpMcpTransport proxyUrl — route external MCP through a CORS proxy

### DIFF
--- a/docx-editor/.changeset/mcp-transport-proxy.md
+++ b/docx-editor/.changeset/mcp-transport-proxy.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+HttpMcpTransport gains a proxyUrl option: when set, MCP JSON-RPC is POSTed to a same-origin CORS proxy (e.g. the collab server's /api/mcp-proxy) as { url, headers, body } and forwarded server-side, so the web editor can reach external MCP servers that don't send CORS headers. Direct connections are unchanged.

--- a/docx-editor/packages/docops/src/mcp/httpTransport.test.ts
+++ b/docx-editor/packages/docops/src/mcp/httpTransport.test.ts
@@ -75,6 +75,36 @@ describe('HttpMcpTransport ↔ McpServer over HTTP', () => {
     expect(tools).toHaveLength(1);
   });
 
+  it('routes through the proxy URL, wrapping the target url + body', async () => {
+    let sawUrl = '';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let sawEnvelope: any = null;
+    const fetchImpl = (async (u: string, init: { body?: string }) => {
+      sawUrl = u;
+      sawEnvelope = JSON.parse(String(init.body));
+      const inner = JSON.parse(sawEnvelope.body);
+      const result =
+        inner.method === 'initialize'
+          ? { protocolVersion: '2025-06-18', capabilities: {}, serverInfo: {} }
+          : { tools: [] };
+      return new Response(JSON.stringify({ jsonrpc: '2.0', id: inner.id, result }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const transport = new HttpMcpTransport('https://mcp.example.com/rpc', {
+      proxyUrl: 'https://collab.test/api/mcp-proxy',
+      headers: { Authorization: 'Bearer t' },
+      fetchImpl,
+    });
+    await new McpClient(transport, { id: 'mcp:proxied' }).listTools();
+
+    // Requests hit the PROXY, carrying the real target url + the JSON-RPC body +
+    // the auth header for the proxy to forward.
+    expect(sawUrl).toBe('https://collab.test/api/mcp-proxy');
+    expect(sawEnvelope.url).toBe('https://mcp.example.com/rpc');
+    expect(typeof sawEnvelope.body).toBe('string');
+    expect(sawEnvelope.headers.Authorization).toBe('Bearer t');
+  });
+
   it('reads a streaming text/event-stream body incrementally (chunked)', async () => {
     const prov = provider([]);
     let reply = '';

--- a/docx-editor/packages/docops/src/mcp/httpTransport.test.ts
+++ b/docx-editor/packages/docops/src/mcp/httpTransport.test.ts
@@ -87,7 +87,9 @@ describe('HttpMcpTransport ↔ McpServer over HTTP', () => {
         inner.method === 'initialize'
           ? { protocolVersion: '2025-06-18', capabilities: {}, serverInfo: {} }
           : { tools: [] };
-      return new Response(JSON.stringify({ jsonrpc: '2.0', id: inner.id, result }), { status: 200 });
+      return new Response(JSON.stringify({ jsonrpc: '2.0', id: inner.id, result }), {
+        status: 200,
+      });
     }) as unknown as typeof fetch;
 
     const transport = new HttpMcpTransport('https://mcp.example.com/rpc', {

--- a/docx-editor/packages/docops/src/mcp/httpTransport.ts
+++ b/docx-editor/packages/docops/src/mcp/httpTransport.ts
@@ -78,7 +78,11 @@ export class HttpMcpTransport implements JsonRpcTransport {
     const target = this.proxyUrl ?? this.url;
     const reqHeaders: Record<string, string> = this.proxyUrl
       ? { 'content-type': 'application/json' }
-      : { 'content-type': 'application/json', accept: 'application/json, text/event-stream', ...mcpHeaders };
+      : {
+          'content-type': 'application/json',
+          accept: 'application/json, text/event-stream',
+          ...mcpHeaders,
+        };
     const reqBody = this.proxyUrl
       ? JSON.stringify({ url: this.url, headers: mcpHeaders, body: message })
       : message;

--- a/docx-editor/packages/docops/src/mcp/httpTransport.ts
+++ b/docx-editor/packages/docops/src/mcp/httpTransport.ts
@@ -30,6 +30,12 @@ export interface HttpMcpTransportOptions {
   fetchImpl?: typeof fetch;
   /** MCP protocol version echoed on every request after initialize. */
   protocolVersion?: string;
+  /**
+   * Same-origin CORS proxy (e.g. the collab server's /api/mcp-proxy). When set,
+   * requests are POSTed here as { url, headers, body } and forwarded server-side
+   * — the browser workaround for MCP servers that don't send CORS headers.
+   */
+  proxyUrl?: string;
 }
 
 export class HttpMcpTransport implements JsonRpcTransport {
@@ -43,12 +49,15 @@ export class HttpMcpTransport implements JsonRpcTransport {
   private sessionId: string | null = null;
   private closed = false;
 
+  private readonly proxyUrl: string | undefined;
+
   constructor(
     private readonly url: string,
     options: HttpMcpTransportOptions = {}
   ) {
     this.headers = options.headers ?? {};
     this.protocolVersion = options.protocolVersion ?? DEFAULT_PROTOCOL_VERSION;
+    this.proxyUrl = options.proxyUrl;
     // Bind to globalThis: native `fetch` throws "Illegal invocation" when
     // called as a method of another object (this === transport).
     this.doFetch = options.fetchImpl ?? fetch.bind(globalThis);
@@ -58,16 +67,25 @@ export class HttpMcpTransport implements JsonRpcTransport {
     if (this.closed) return;
     const controller = new AbortController();
     this.inflight.add(controller);
-    void this.doFetch(this.url, {
+    // The MCP headers (auth, session, protocol version) belong on the request to
+    // the target server. Direct: put them on this request. Proxied: hand them to
+    // the proxy in the body so it forwards them server-side.
+    const mcpHeaders: Record<string, string> = {
+      'mcp-protocol-version': this.protocolVersion,
+      ...(this.sessionId ? { 'mcp-session-id': this.sessionId } : {}),
+      ...this.headers,
+    };
+    const target = this.proxyUrl ?? this.url;
+    const reqHeaders: Record<string, string> = this.proxyUrl
+      ? { 'content-type': 'application/json' }
+      : { 'content-type': 'application/json', accept: 'application/json, text/event-stream', ...mcpHeaders };
+    const reqBody = this.proxyUrl
+      ? JSON.stringify({ url: this.url, headers: mcpHeaders, body: message })
+      : message;
+    void this.doFetch(target, {
       method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        accept: 'application/json, text/event-stream',
-        'mcp-protocol-version': this.protocolVersion,
-        ...(this.sessionId ? { 'mcp-session-id': this.sessionId } : {}),
-        ...this.headers,
-      },
-      body: message,
+      headers: reqHeaders,
+      body: reqBody,
       signal: controller.signal,
     })
       .then(async (resp) => {


### PR DESCRIPTION
Pairs with collab's new /api/mcp-proxy (CasualOffice/collab#8) to close the web-MCP CORS gap. When proxyUrl is set, MCP JSON-RPC POSTs { url, headers, body } to the same-origin proxy for server-side forwarding; direct connections unchanged. Test added; 8 MCP tests + typecheck green.