### PR TITLE
feat(mcp): web panel routes external MCP through the same-origin proxy

### DIFF
--- a/docx-editor/.changeset/mcp-web-proxy-wiring.md
+++ b/docx-editor/.changeset/mcp-web-proxy-wiring.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+The DocOps panel now routes external MCP connections through the same-origin /api/mcp-proxy when running on the web (browsers can't reach most MCP servers directly — no CORS); desktop connects directly. Completes the web-MCP path end to end.

--- a/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
+++ b/docx-editor/packages/react/src/docops/DocOpsPanel.tsx
@@ -561,10 +561,15 @@ export function DocOpsPanel({
       const id = `mcp:${url}`;
       if (mcpServers.some((s) => s.id === id)) return;
       const token = rawToken?.trim();
+      // On the web, browsers can't reach most external MCP servers (no CORS), so
+      // route through the same-origin collab proxy. On desktop the Tauri webview
+      // fetches cross-origin freely, so connect directly.
+      const proxyUrl = desktopInvoke() ? undefined : '/api/mcp-proxy';
       const client = createMcpClient(
         url,
         id,
-        token ? { Authorization: `Bearer ${token}` } : undefined
+        token ? { Authorization: `Bearer ${token}` } : undefined,
+        proxyUrl
       );
       setMcpServers((prev) => [
         ...prev,

--- a/docx-editor/packages/react/src/docops/agentRuntime.ts
+++ b/docx-editor/packages/react/src/docops/agentRuntime.ts
@@ -39,9 +39,10 @@ export function bridgeToolSource(bridge: DocsBridge): ToolSource {
 export function createMcpClient(
   url: string,
   id: string,
-  headers?: Record<string, string>
+  headers?: Record<string, string>,
+  proxyUrl?: string
 ): McpClient {
-  return new McpClient(new HttpMcpTransport(url, { headers }), { id });
+  return new McpClient(new HttpMcpTransport(url, { headers, proxyUrl }), { id });
 }
 
 /**


### PR DESCRIPTION
Completes the web-MCP CORS path end to end. createMcpClient gains proxyUrl; the panel passes '/api/mcp-proxy' on web (no browser CORS to external MCP servers) and undefined on desktop. Pairs with collab /api/mcp-proxy + transport proxyUrl. Typecheck green. (Final resolution of the relative URL is confirmed on a live bundled deploy.)