### PR TITLE
fix(ai): attribute AI edits to the triggering user, not 'DocOps AI'

### DIFF
--- a/docx-editor/.changeset/ai-edit-attribution.md
+++ b/docx-editor/.changeset/ai-edit-attribution.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': patch
+---
+
+Attribute AI-triggered document edits and comments to the initiating user (e.g. "Alice via AI") instead of a hardcoded "DocOps AI", so co-editors can tell who ran an AI action in a shared document.

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -2795,6 +2795,11 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       () => docsBridgeActionsRef.current
     );
   }
+  // Attribute AI-triggered mutations to the human who ran them (e.g. "Alice
+  // via AI") rather than an anonymous bot, mirroring the human `author` prop.
+  useEffect(() => {
+    docsBridgeRef.current?.setAiAuthor(author);
+  }, [author]);
 
   // Right-side panel mutex. Google Docs / Microsoft Word only ever
   // expose ONE right-edge panel at a time (Comments XOR Outline,

--- a/docx-editor/packages/react/src/docops/bridge.ts
+++ b/docx-editor/packages/react/src/docops/bridge.ts
@@ -72,10 +72,25 @@ export class DocsBridge {
   // until a workspace is provided, so search_workspace degrades gracefully.
   private workspace: WorkspaceIndex | null = null;
 
+  // Display name of the human who triggered the current AI action. Used to
+  // attribute AI-authored mutations (tracked changes, comments) so co-editors
+  // can tell who ran the AI — e.g. "Alice via AI" instead of an anonymous bot.
+  private aiUser: string | null = null;
+
   constructor(
     private readonly getView: () => EditorView | null,
     private readonly getActions: () => DocsBridgeActions | null = () => null
   ) {}
+
+  /** Set the human whose AI actions are attributed (host-driven; see aiUser). */
+  setAiAuthor(user: string | null): void {
+    this.aiUser = user && user.trim() ? user.trim() : null;
+  }
+
+  /** Author label for AI-triggered mutations: "<user> via AI", or "AI" when unknown. */
+  private aiAuthor(): string {
+    return this.aiUser ? `${this.aiUser} via AI` : 'AI';
+  }
 
   /** Replace the indexed workspace (host-driven; files stay on the machine). */
   setWorkspaceDocs(docs: WorkspaceDoc[]): void {
@@ -520,7 +535,7 @@ export class DocsBridge {
       return { ok: false, code: 'VALIDATION', message: 'paraId is required.', retryable: false };
     }
 
-    const success = actions.proposeChange({ paraId, search, replaceWith, author: 'DocOps AI' });
+    const success = actions.proposeChange({ paraId, search, replaceWith, author: this.aiAuthor() });
     if (!success) {
       return {
         ok: false,
@@ -578,7 +593,7 @@ export class DocsBridge {
       };
     }
 
-    const commentId = actions.addComment({ paraId, text, author: 'DocOps AI', search });
+    const commentId = actions.addComment({ paraId, text, author: this.aiAuthor(), search });
     if (commentId == null) {
       return {
         ok: false,
@@ -728,7 +743,7 @@ export class DocsBridge {
       };
     }
 
-    const success = actions.rewriteSelection({ newText, author: 'DocOps AI' });
+    const success = actions.rewriteSelection({ newText, author: this.aiAuthor() });
     if (!success) {
       return {
         ok: false,
@@ -758,7 +773,7 @@ export class DocsBridge {
       };
     }
 
-    const success = actions.deleteParagraphs({ paraIds, author: 'DocOps AI' });
+    const success = actions.deleteParagraphs({ paraIds, author: this.aiAuthor() });
     if (!success) {
       return {
         ok: false,
@@ -795,7 +810,7 @@ export class DocsBridge {
       paraId,
       text,
       styleId,
-      author: 'DocOps AI',
+      author: this.aiAuthor(),
     });
     if (!success) {
       return {


### PR DESCRIPTION
AI-triggered mutations (tracked changes, comments, paragraph inserts/deletes) hardcoded `author: 'DocOps AI'` in `docops/bridge.ts`, so in a shared document co-editors couldn't tell who ran an AI action.

Thread the human's display name into `DocsBridge` via a new `setAiAuthor` setter and attribute AI edits as `"<user> via AI"` (falling back to `"AI"` when unknown). Wired from the existing `author` prop where the bridge is constructed in `DocxEditor.tsx`. Backward-compatible; no signature changes.