### PR TITLE
feat(collab): default reconnecting/offline indicator in the editor

### DIFF
--- a/docx-editor/.changeset/default-reconnect-banner.md
+++ b/docx-editor/.changeset/default-reconnect-banner.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': minor
+---
+
+CasualEditor now shows a default reconnecting/offline banner above the editor while a collab session is degraded. Driven by the live collab status, it renders an amber "Reconnecting…" strip when connecting and a red "You're offline — edits saved locally" strip when disconnected, and nothing once connected. Theme-token styled via `--doc-*` vars. Also exported as the standalone `ReconnectBanner` component for hosts that compose their own layout.

--- a/docx-editor/packages/react/src/collab/ReconnectBanner.tsx
+++ b/docx-editor/packages/react/src/collab/ReconnectBanner.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+// Default reconnecting/offline indicator for the SDK. A thin strip
+// rendered above the editing surface whenever the Yjs provider isn't
+// `connected`. The editor stays usable — edits buffer locally and
+// flush on reconnect — but the user sees that their changes aren't
+// being broadcast right now. Theme-token styled via --doc-* vars so
+// it inherits the host's light/dark surface.
+import type { CSSProperties } from 'react';
+import type { CollabStatus } from './useCollab';
+
+const base: CSSProperties = {
+  flex: '0 0 auto',
+  padding: '6px 16px',
+  fontSize: 12,
+  fontWeight: 500,
+  textAlign: 'center',
+  fontFamily:
+    'var(--doc-font-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif)',
+};
+
+const byStatus: Record<Exclude<CollabStatus, 'connected'>, CSSProperties> = {
+  connecting: {
+    background: 'var(--doc-warning-bg, #fffbeb)',
+    color: 'var(--doc-warning-text, #92400e)',
+    borderBottom: '1px solid var(--doc-warning-border, #fde68a)',
+  },
+  disconnected: {
+    background: 'var(--doc-danger-bg, #fef2f2)',
+    color: 'var(--doc-danger-text, #991b1b)',
+    borderBottom: '1px solid var(--doc-danger-border, #fecaca)',
+  },
+};
+
+const labels: Record<Exclude<CollabStatus, 'connected'>, string> = {
+  connecting: 'Reconnecting to the session…',
+  disconnected:
+    "You're offline — edits are saved locally and will sync when the connection comes back.",
+};
+
+/**
+ * Renders nothing when `status` is `connected`; otherwise a full-width
+ * amber (connecting) or red (disconnected) strip with a short message.
+ */
+export function ReconnectBanner({ status }: { status: CollabStatus }) {
+  if (status === 'connected') return null;
+  return (
+    <div role="status" aria-live="polite" style={{ ...base, ...byStatus[status] }}>
+      {labels[status]}
+    </div>
+  );
+}

--- a/docx-editor/packages/react/src/components/CasualEditor.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.tsx
@@ -47,6 +47,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type ReactNode,
 } from 'react';
 
@@ -65,6 +66,7 @@ import {
   type CollabStatus,
 } from '../collab/useCollab';
 import { commentsFromMap, observeComments, writeCommentsToMap } from '../collab/commentSync';
+import { ReconnectBanner } from '../collab/ReconnectBanner';
 import {
   useFileSourceAutoSave,
   type UseFileSourceAutoSaveReturn,
@@ -333,19 +335,35 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
       />
     );
 
-    // Without an active signing session, return the editor alone.
-    if (!signing) return editor;
-
-    // With a signing session, wrap the editor in a SigningProvider
-    // and render the SigningPane alongside. The provider captures
-    // the current document bytes so the eventual `onComplete`
-    // payload carries the right base buffer.
-    return (
+    // Without an active signing session, the content is the editor
+    // alone; otherwise wrap it in a SigningProvider and render the
+    // SigningPane alongside. The provider captures the current
+    // document bytes so the eventual `onComplete` payload carries the
+    // right base buffer.
+    const content = !signing ? (
+      editor
+    ) : (
       <SigningProvider session={signing} documentBytes={loadState.buffer}>
         {editor}
         <SigningPane banner={signing.banner} />
       </SigningProvider>
     );
+
+    // In collab mode, show the default reconnecting/offline banner
+    // above the editor whenever the session isn't connected. Hosts
+    // that render their own indicator can ignore it — the strip only
+    // appears while degraded. Standalone/connected renders unchanged
+    // so existing (non-collab) host layouts keep the editor as root.
+    if (collabState && collabState.status !== 'connected') {
+      return (
+        <div style={bannerLayoutStyle}>
+          <ReconnectBanner status={collabState.status} />
+          <div style={bannerBodyStyle}>{content}</div>
+        </div>
+      );
+    }
+
+    return content;
   }
 );
 
@@ -382,6 +400,23 @@ function useCollabSafe(args: {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   return useCollab({ backend: args.backend, room: args.room, user: args.user });
 }
+
+// Flex-column wrapper used only when the reconnect banner is visible,
+// so the strip sits above a full-height editor body. Applied lazily
+// (collab + degraded) to avoid changing the DOM for the common case.
+const bannerLayoutStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  minHeight: 0,
+};
+
+const bannerBodyStyle: CSSProperties = {
+  flex: '1 1 auto',
+  minHeight: 0,
+  display: 'flex',
+  flexDirection: 'column',
+};
 
 function blankDoc(): Document {
   return createEmptyDocument();

--- a/docx-editor/packages/react/src/index.ts
+++ b/docx-editor/packages/react/src/index.ts
@@ -52,6 +52,11 @@ export {
   type CasualEditorRef,
 } from './components/CasualEditor';
 
+// ReconnectBanner — default reconnecting/offline strip, driven by a
+// CollabStatus. CasualEditor renders it automatically in collab mode;
+// exported for hosts that compose their own layout.
+export { ReconnectBanner } from './collab/ReconnectBanner';
+
 // CasualEditorIframe — iframe-mounting variant of CasualEditor.
 // Doc 16 in the parent repo. Use this for hosts that need CSS / React
 // runtime isolation (most consumers; Drive in particular). The


### PR DESCRIPTION
The docs SDK shipped no default reconnect/offline UI — a banner existed only in `examples/vite/src/collab`. CasualEditor now renders a built-in strip above the editor while an active collab session is degraded (amber "Reconnecting…", red "You're offline"), driven by `collabStatus()`, and nothing once connected. Adapted from the example's DisconnectedBanner into `packages/react` with `--doc-*` theme tokens and no example-only deps; also exported as a standalone `ReconnectBanner`. Standalone/connected renders are unchanged. Closes docs#263.