### PR TITLE
feat(ai): CollabTransport single-round — agent + chat run on the web

### DIFF
--- a/docx-editor/.changeset/collab-transport-single-round.md
+++ b/docx-editor/.changeset/collab-transport-single-round.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': minor
+---
+
+CollabTransport is now single-round (drivesLoop=false): the collab server is a key-holding LLM proxy for one turn and the panel/agent drives the tool loop — so the plan→execute→reflect agent (and the flat chat loop) run on the web, not only on desktop. Previously the server drove the whole loop, which hid the Agent toggle on every web session.

--- a/docx-editor/packages/react/src/docops/transport.test.ts
+++ b/docx-editor/packages/react/src/docops/transport.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, it, afterEach } from 'bun:test';
-import { DesktopTransport } from './transport';
+import { DesktopTransport, CollabTransport } from './transport';
 import type { LlmCallPayload } from './transport';
 
 const payload = (): LlmCallPayload => ({
@@ -72,5 +72,64 @@ describe('DesktopTransport (local model)', () => {
     expect(res.status).toBe(500);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((res.data as any).error.message).toContain('model not loaded');
+  });
+});
+
+describe('CollabTransport (single-round, web AI proxy)', () => {
+  const origWs = (globalThis as { WebSocket?: unknown }).WebSocket;
+  afterEach(() => {
+    (globalThis as { WebSocket?: unknown }).WebSocket = origWs;
+  });
+
+  it('is single-round (drivesLoop=false) so the Agent toggle shows on web', () => {
+    // Previously true — which hid the agent on ALL web sessions. Guard it.
+    expect(new CollabTransport('ws://x/api/ai').drivesLoop).toBe(false);
+  });
+
+  it('sends singleRound and resolves the round frame as a native response', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let sent: any;
+    class MockWS {
+      listeners: Record<string, ((a?: unknown) => void)[]> = {};
+      constructor(_url: string) {
+        queueMicrotask(() => this.emit('open'));
+      }
+      addEventListener(ev: string, cb: (a?: unknown) => void) {
+        (this.listeners[ev] ||= []).push(cb);
+      }
+      removeEventListener() {}
+      emit(ev: string, arg?: unknown) {
+        (this.listeners[ev] || []).forEach((cb) => cb(arg));
+      }
+      send(data: string) {
+        sent = JSON.parse(data);
+        queueMicrotask(() =>
+          this.emit('message', {
+            data: JSON.stringify({
+              type: 'round',
+              content: [{ type: 'tool_use', id: 't', name: 'get_outline', input: {} }],
+              stop_reason: 'tool_use',
+            }),
+          })
+        );
+      }
+      close() {}
+    }
+    (globalThis as { WebSocket?: unknown }).WebSocket = MockWS as unknown;
+
+    const res = await new CollabTransport('ws://x/api/ai', 'room1').call({
+      model: 'm',
+      max_tokens: 100,
+      system: 's',
+      messages: [{ role: 'user', content: 'hi' }],
+      tools: [],
+    } as LlmCallPayload);
+
+    expect(sent.singleRound).toBe(true);
+    expect(res.status).toBe(200);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data = res.data as any;
+    expect(data.content[0].name).toBe('get_outline');
+    expect(data.stop_reason).toBe('tool_use');
   });
 });

--- a/docx-editor/packages/react/src/docops/transport.ts
+++ b/docx-editor/packages/react/src/docops/transport.ts
@@ -202,7 +202,11 @@ export class DirectTransport implements DocOpsTransport {
  */
 export class CollabTransport implements DocOpsTransport {
   readonly requiresApiKey = false;
-  readonly drivesLoop = true;
+  // Single round per call() — the panel (chat) and runAgent (agent mode) drive
+  // the tool loop; the collab server is just a key-holding LLM proxy for one
+  // turn. Previously drivesLoop=true ceded the whole loop to the server, which
+  // hid the Agent toggle (gated on !drivesLoop) so the agent never ran on web.
+  readonly drivesLoop = false;
 
   constructor(
     /** WebSocket URL for the AI endpoint, e.g. "wss://collab.example.com/api/ai". */
@@ -256,9 +260,9 @@ export class CollabTransport implements DocOpsTransport {
             system: payload.system,
             messages: payload.messages,
             tools: payload.tools,
+            singleRound: true,
             ...(payload.apiKey ? { apiKey: payload.apiKey } : {}),
             ...(this.room ? { roomName: this.room } : {}),
-            ...(payload.maxToolRounds != null ? { maxToolRounds: payload.maxToolRounds } : {}),
           })
         );
       });
@@ -273,7 +277,16 @@ export class CollabTransport implements DocOpsTransport {
           return;
         }
 
-        if (msg.type === 'text') {
+        if (msg.type === 'round') {
+          // Single-round reply: the panel/agent drives the loop from here.
+          settle({
+            data: {
+              content: msg.content ?? [],
+              stop_reason: (msg.stop_reason as string) ?? 'end_turn',
+            },
+            status: 200,
+          });
+        } else if (msg.type === 'text') {
           payload.onText?.(msg.text as string);
         } else if (msg.type === 'tool_call') {
           const id = msg.id as string;


### PR DESCRIPTION
Part 2/3 of docs#264 (agent mode dead on web). CollabTransport was drivesLoop=true (server drove the whole loop), hiding the Agent toggle on every web session. Now single-round + drivesLoop=false: sends singleRound:true, resolves the server's {type:'round',...} frame, panel/agent drives the loop (no panel change — the else-branch already handles drivesLoop=false). Pairs with CasualOffice/collab#11. transport tests added; typecheck + 35 docops tests green.