### PR TITLE
feat(collab): share dialog with view/comment/edit roles in the editor

### DIFF
--- a/docx-editor/.changeset/share-dialog-roles.md
+++ b/docx-editor/.changeset/share-dialog-roles.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': minor
+---
+
+Add a built-in ShareDialog to CasualEditor's collab presence cluster: the title-bar Share button now opens a dialog with a room link, a view/comment/edit role selector, and a copy button. Shown only when collab is active; a host-supplied `onShare` still overrides it. Exported `ShareDialog` and `buildShareUrl` for hosts that want to render it themselves.

--- a/docx-editor/packages/react/i18n/de.json
+++ b/docx-editor/packages/react/i18n/de.json
@@ -1056,5 +1056,18 @@
       "table": null,
       "translate": null
     }
+  },
+  "share": {
+    "copied": null,
+    "copy": null,
+    "description": null,
+    "done": null,
+    "linkLabel": null,
+    "roleComment": null,
+    "roleEdit": null,
+    "roleLabel": null,
+    "roleView": null,
+    "secureNote": null,
+    "title": null
   }
 }

--- a/docx-editor/packages/react/i18n/en.json
+++ b/docx-editor/packages/react/i18n/en.json
@@ -1056,5 +1056,18 @@
       "translate": "Translate to Spanish",
       "summarize": "Summarize this"
     }
+  },
+  "share": {
+    "title": "Share this document",
+    "description": "Anyone with the link can join this live document at the role you pick.",
+    "roleLabel": "Anyone with the link can",
+    "roleView": "View only",
+    "roleComment": "Comment",
+    "roleEdit": "Edit",
+    "linkLabel": "Share link",
+    "copy": "Copy",
+    "copied": "Copied",
+    "secureNote": "The role is set by a link parameter today. Server-enforced secure links are coming soon.",
+    "done": "Done"
   }
 }

--- a/docx-editor/packages/react/i18n/he.json
+++ b/docx-editor/packages/react/i18n/he.json
@@ -1056,5 +1056,18 @@
       "table": null,
       "translate": null
     }
+  },
+  "share": {
+    "copied": null,
+    "copy": null,
+    "description": null,
+    "done": null,
+    "linkLabel": null,
+    "roleComment": null,
+    "roleEdit": null,
+    "roleLabel": null,
+    "roleView": null,
+    "secureNote": null,
+    "title": null
   }
 }

--- a/docx-editor/packages/react/i18n/pl.json
+++ b/docx-editor/packages/react/i18n/pl.json
@@ -1056,5 +1056,18 @@
       "table": null,
       "translate": null
     }
+  },
+  "share": {
+    "copied": null,
+    "copy": null,
+    "description": null,
+    "done": null,
+    "linkLabel": null,
+    "roleComment": null,
+    "roleEdit": null,
+    "roleLabel": null,
+    "roleView": null,
+    "secureNote": null,
+    "title": null
   }
 }

--- a/docx-editor/packages/react/i18n/pt-BR.json
+++ b/docx-editor/packages/react/i18n/pt-BR.json
@@ -1056,5 +1056,18 @@
       "table": null,
       "translate": null
     }
+  },
+  "share": {
+    "copied": null,
+    "copy": null,
+    "description": null,
+    "done": null,
+    "linkLabel": null,
+    "roleComment": null,
+    "roleEdit": null,
+    "roleLabel": null,
+    "roleView": null,
+    "secureNote": null,
+    "title": null
   }
 }

--- a/docx-editor/packages/react/i18n/tr.json
+++ b/docx-editor/packages/react/i18n/tr.json
@@ -1056,5 +1056,18 @@
       "table": null,
       "translate": null
     }
+  },
+  "share": {
+    "copied": null,
+    "copy": null,
+    "description": null,
+    "done": null,
+    "linkLabel": null,
+    "roleComment": null,
+    "roleEdit": null,
+    "roleLabel": null,
+    "roleView": null,
+    "secureNote": null,
+    "title": null
   }
 }

--- a/docx-editor/packages/react/i18n/zh-CN.json
+++ b/docx-editor/packages/react/i18n/zh-CN.json
@@ -1056,5 +1056,18 @@
       "table": null,
       "translate": null
     }
+  },
+  "share": {
+    "copied": null,
+    "copy": null,
+    "description": null,
+    "done": null,
+    "linkLabel": null,
+    "roleComment": null,
+    "roleEdit": null,
+    "roleLabel": null,
+    "roleView": null,
+    "secureNote": null,
+    "title": null
   }
 }

--- a/docx-editor/packages/react/src/components/CasualEditor.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.tsx
@@ -53,6 +53,7 @@ import {
 
 import { DocxEditor, type DocxEditorProps, type DocxEditorRef } from './DocxEditor';
 import { PresenceCluster } from './PresenceCluster';
+import { ShareDialog } from './ShareDialog';
 import { createDocOpsTransport } from '../docops';
 import { createEmptyDocument } from '@eigenpal/docx-core/utils';
 import type { Document } from '@eigenpal/docx-core/types/document';
@@ -129,10 +130,11 @@ export interface CasualEditorProps {
    */
   onCollabState?: (state: CollabState) => void;
   /**
-   * Share action for the collab presence cluster. When set (and
-   * collab is active), the title-bar PresenceCluster renders a
-   * Share button that invokes this. Omit to hide the button — the
-   * wrapper never invents a share backend.
+   * Share action for the collab presence cluster. When collab is
+   * active the title-bar PresenceCluster always shows a Share button;
+   * passing `onShare` overrides its default behaviour (which opens the
+   * wrapper's built-in ShareDialog — a room link + view/comment/edit
+   * role picker) with the host's own flow.
    */
   onShare?: () => void;
   /** Custom render override for the loading state. Default is a centered "Loading…" string. */
@@ -278,10 +280,17 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
       [collabState]
     );
 
+    // Built-in share surface. When collab is active the title-bar Share
+    // button opens the wrapper's own ShareDialog (a room link + role picker);
+    // a host that passes `onShare` overrides that with its own flow. Gated on
+    // collab so standalone docs never show a Share affordance.
+    const [shareOpen, setShareOpen] = useState(false);
+    const handleShare = onShare ?? (() => setShareOpen(true));
+
     // Live presence in the title bar — avatar stack + room-status badge
-    // (+ optional Share). Only mounted when collab is active, so standalone
-    // docs keep the plain title bar. Fed by the same peers + status the ref
-    // exposes via collabPeers()/collabStatus().
+    // (+ Share). Only mounted when collab is active, so standalone docs keep
+    // the plain title bar. Fed by the same peers + status the ref exposes via
+    // collabPeers()/collabStatus().
     const renderCollabPresence = collabState
       ? () => (
           <PresenceCluster
@@ -291,7 +300,7 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
               active: true,
             }))}
             status={collabState.status}
-            onShare={onShare}
+            onShare={handleShare}
           />
         )
       : undefined;
@@ -377,6 +386,14 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
       </SigningProvider>
     );
 
+    // Built-in share dialog — rendered only for the wrapper's own Share
+    // flow (collab active, host didn't supply its own `onShare`). Fixed-
+    // positioned, so it never disturbs the editor layout when closed.
+    const shareDialog =
+      collabState && !onShare ? (
+        <ShareDialog isOpen={shareOpen} onClose={() => setShareOpen(false)} roomId={docId} />
+      ) : null;
+
     // In collab mode, show the default reconnecting/offline banner
     // above the editor whenever the session isn't connected. Hosts
     // that render their own indicator can ignore it — the strip only
@@ -387,11 +404,17 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
         <div style={bannerLayoutStyle}>
           <ReconnectBanner status={collabState.status} />
           <div style={bannerBodyStyle}>{content}</div>
+          {shareDialog}
         </div>
       );
     }
 
-    return content;
+    return (
+      <>
+        {content}
+        {shareDialog}
+      </>
+    );
   }
 );
 

--- a/docx-editor/packages/react/src/components/ShareDialog.test.ts
+++ b/docx-editor/packages/react/src/components/ShareDialog.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Unit coverage for the pure role→URL mapping behind ShareDialog. The DOM
+ * dialog itself is exercised by the app-level e2e suite; here we pin the
+ * contract the copy button depends on.
+ */
+import { describe, expect, it } from 'bun:test';
+
+import { buildShareUrl } from './ShareDialog';
+
+describe('buildShareUrl', () => {
+  const base = 'https://docs.example.com/r/abc123';
+
+  it('omits the role param for edit (the room default is editable)', () => {
+    expect(buildShareUrl(base, 'edit')).toBe(base);
+  });
+
+  it('sets role=view for a view-only link', () => {
+    expect(buildShareUrl(base, 'view')).toBe(`${base}?role=view`);
+  });
+
+  it('sets role=comment for a comment link', () => {
+    expect(buildShareUrl(base, 'comment')).toBe(`${base}?role=comment`);
+  });
+
+  it('replaces an existing role param rather than appending a second one', () => {
+    expect(buildShareUrl(`${base}?role=view`, 'comment')).toBe(`${base}?role=comment`);
+    expect(buildShareUrl(`${base}?role=view`, 'edit')).toBe(base);
+  });
+
+  it('preserves unrelated query params', () => {
+    const url = buildShareUrl(`${base}?theme=dark`, 'view');
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('theme')).toBe('dark');
+    expect(parsed.searchParams.get('role')).toBe('view');
+  });
+});

--- a/docx-editor/packages/react/src/components/ShareDialog.tsx
+++ b/docx-editor/packages/react/src/components/ShareDialog.tsx
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * ShareDialog — the editor's built-in "share this live document" surface.
+ *
+ * Mounted by CasualEditor and wired to PresenceCluster's Share button; it
+ * only appears when collab is active (a `backendUrl` is set), so standalone
+ * docs never see it.
+ *
+ * MVP scope (matches the sister sheet app's anonymous-room links): the doc is
+ * ALREADY in a live room — the room id is the `docId` the editor is connected
+ * to — so sharing is just handing out the current room URL with a role query
+ * param. `edit` links carry no param (the room's default is editable); `view`
+ * and `comment` links append `?role=…`, which the collab server's anonymous
+ * join path honours (view/comment → read-only; see collab's
+ * `auth/join-role.ts`).
+ *
+ * TODO(share-token): server-ENFORCED secure links (a minted `?share=<token>`
+ * whose role can't be changed by editing the URL) live behind the collab
+ * server's `/files/:id/shares` routes and need a saved server file id. That is
+ * a follow-up; the `?role=` param here is a client-side hint only.
+ */
+
+import { useMemo, useState, type CSSProperties, type ReactElement } from 'react';
+import { Dialog } from './ui/Dialog';
+import { MaterialSymbol } from './ui/Icons';
+import { useTranslation } from '../i18n';
+
+/** The three roles a share link can grant. Mirrors the collab server's
+ *  `view | comment | edit` share roles. */
+export type ShareRole = 'view' | 'comment' | 'edit';
+
+export interface ShareDialogProps {
+  /** Show / hide anchor so the host can render unconditionally. */
+  isOpen: boolean;
+  /** Invoked on close (X / Esc / backdrop / Done). */
+  onClose: () => void;
+  /**
+   * Room the editor is connected to (the collab `docId`). Reserved for the
+   * token-mint path (see file header TODO); today the link is derived from
+   * the current location so it points at whatever route loaded this room.
+   */
+  roomId: string;
+  /**
+   * Base URL the share link is built from. Defaults to the current
+   * `window.location.href`. Injectable so the pure builder is testable and
+   * hosts embedding under a custom route can override it.
+   */
+  baseHref?: string;
+}
+
+/**
+ * Build a shareable room URL for `role` from `baseHref`. Pure + exported so
+ * the role→URL mapping is unit-testable without a DOM. `edit` clears the
+ * `role` param (the room default is editable); `view`/`comment` set it.
+ */
+export function buildShareUrl(baseHref: string, role: ShareRole): string {
+  const url = new URL(baseHref);
+  if (role === 'edit') {
+    url.searchParams.delete('role');
+  } else {
+    url.searchParams.set('role', role);
+  }
+  return url.toString();
+}
+
+const ROLE_ORDER: ShareRole[] = ['edit', 'comment', 'view'];
+
+const fieldStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  marginBottom: 16,
+};
+
+const labelStyle: CSSProperties = {
+  fontSize: 12.5,
+  fontWeight: 500,
+  color: 'var(--doc-text-muted)',
+};
+
+const selectStyle: CSSProperties = {
+  padding: '8px 10px',
+  borderRadius: 8,
+  border: '1px solid var(--doc-border)',
+  background: 'var(--doc-surface)',
+  color: 'var(--doc-text)',
+  fontSize: 14,
+  cursor: 'pointer',
+};
+
+const linkRowStyle: CSSProperties = {
+  display: 'flex',
+  gap: 8,
+  alignItems: 'stretch',
+};
+
+const linkInputStyle: CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  padding: '8px 10px',
+  borderRadius: 8,
+  border: '1px solid var(--doc-border)',
+  background: 'var(--doc-surface-muted)',
+  color: 'var(--doc-text)',
+  fontSize: 13,
+  fontFamily: 'var(--doc-font-mono, ui-monospace, monospace)',
+};
+
+const copyBtnStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '8px 14px',
+  borderRadius: 8,
+  border: '1px solid var(--doc-border)',
+  background: 'var(--doc-surface)',
+  color: 'var(--doc-text)',
+  fontSize: 13,
+  fontWeight: 500,
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+};
+
+const noteStyle: CSSProperties = {
+  margin: '4px 0 0',
+  fontSize: 12,
+  lineHeight: 1.45,
+  color: 'var(--doc-text-muted)',
+};
+
+const doneBtnStyle: CSSProperties = {
+  padding: '7px 16px',
+  borderRadius: 8,
+  border: 'none',
+  background: 'var(--doc-accent, #2563eb)',
+  color: '#fff',
+  fontSize: 13,
+  fontWeight: 500,
+  cursor: 'pointer',
+};
+
+export function ShareDialog({
+  isOpen,
+  onClose,
+  roomId,
+  baseHref,
+}: ShareDialogProps): ReactElement | null {
+  const { t } = useTranslation();
+  const [role, setRole] = useState<ShareRole>('edit');
+  const [copied, setCopied] = useState(false);
+
+  // `roomId` isn't used to build the URL yet (see file header TODO) — reference
+  // it so the reserved prop doesn't read as dead to lint / reviewers.
+  void roomId;
+
+  const href = baseHref ?? (typeof window !== 'undefined' ? window.location.href : 'about:blank');
+  const shareUrl = useMemo(() => buildShareUrl(href, role), [href, role]);
+
+  const roleLabel: Record<ShareRole, string> = {
+    view: t('share.roleView'),
+    comment: t('share.roleComment'),
+    edit: t('share.roleEdit'),
+  };
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    } catch {
+      /* clipboard blocked — the field is still selectable */
+    }
+  };
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title={t('share.title')}
+      icon={<MaterialSymbol name="share" size={18} />}
+      width={460}
+      testId="share-dialog"
+      footer={
+        <button
+          type="button"
+          onClick={onClose}
+          style={doneBtnStyle}
+          data-testid="share-dialog-done"
+        >
+          {t('share.done')}
+        </button>
+      }
+    >
+      <p style={{ margin: '0 0 16px', color: 'var(--doc-text-muted)', fontSize: 13 }}>
+        {t('share.description')}
+      </p>
+
+      <div style={fieldStyle}>
+        <label style={labelStyle} htmlFor="share-dialog-role">
+          {t('share.roleLabel')}
+        </label>
+        <select
+          id="share-dialog-role"
+          style={selectStyle}
+          value={role}
+          data-testid="share-dialog-role"
+          onChange={(e) => setRole(e.target.value as ShareRole)}
+        >
+          {ROLE_ORDER.map((r) => (
+            <option key={r} value={r}>
+              {roleLabel[r]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div style={fieldStyle}>
+        <label style={labelStyle} htmlFor="share-dialog-link">
+          {t('share.linkLabel')}
+        </label>
+        <div style={linkRowStyle}>
+          <input
+            id="share-dialog-link"
+            type="text"
+            readOnly
+            style={linkInputStyle}
+            value={shareUrl}
+            data-testid="share-dialog-link"
+            onFocus={(e) => e.currentTarget.select()}
+          />
+          <button
+            type="button"
+            style={copyBtnStyle}
+            onClick={() => void copy()}
+            data-testid="share-dialog-copy"
+          >
+            <MaterialSymbol name={copied ? 'check' : 'content_copy'} size={16} />
+            {copied ? t('share.copied') : t('share.copy')}
+          </button>
+        </div>
+      </div>
+
+      <p style={noteStyle}>{t('share.secureNote')}</p>
+    </Dialog>
+  );
+}
+
+export default ShareDialog;

--- a/docx-editor/packages/react/src/components/ui/Icons.tsx
+++ b/docx-editor/packages/react/src/components/ui/Icons.tsx
@@ -859,6 +859,14 @@ export function IconContentCopy(props: IconProps) {
   );
 }
 
+export function IconShare(props: IconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M680-80q-50 0-85-35t-35-85q0-6 3-28L282-392q-16 15-37 23.5T200-360q-50 0-85-35t-35-85q0-50 35-85t85-35q24 0 45 8.5t37 23.5l286-167q-2-7-2.5-13.5T600-760q0-50 35-85t85-35q50 0 85 35t35 85q0 50-35 85t-85 35q-24 0-45-8.5T678-672L392-505q2 7 2.5 13.5t.5 13.5q0 7-.5 13.5T392-441l286 167q16-15 37-23.5t45-8.5q50 0 85 35t35 85q0 50-35 85t-85 35Z" />
+    </SvgIcon>
+  );
+}
+
 export function IconContentPaste(props: IconProps) {
   return (
     <SvgIcon {...props}>
@@ -1078,6 +1086,7 @@ const iconMap: Record<string, React.ComponentType<IconProps>> = {
   // Edit menu — clipboard ops
   content_cut: IconContentCut,
   content_copy: IconContentCopy,
+  share: IconShare,
   content_paste: IconContentPaste,
   content_paste_go: IconContentPasteGo,
   find_replace: IconFindReplace,

--- a/docx-editor/packages/react/src/index.ts
+++ b/docx-editor/packages/react/src/index.ts
@@ -144,6 +144,16 @@ export {
   type PresencePeer,
 } from './components/PresenceCluster';
 
+// ShareDialog — the editor's built-in "share this live document" surface.
+// CasualEditor mounts it automatically in collab mode; exported so hosts can
+// render it themselves (e.g. from a custom `onShare`).
+export {
+  ShareDialog,
+  buildShareUrl,
+  type ShareDialogProps,
+  type ShareRole,
+} from './components/ShareDialog';
+
 // Collab — Yjs/y-websocket wiring exposed so SDK consumers (host
 // apps embedding the editor) can opt into co-edit by passing the
 // returned plugins into DocxEditor's `externalPlugins`. `yjs`,


### PR DESCRIPTION
Wires the collab presence cluster's Share button to a built-in ShareDialog. When collab is active, clicking Share opens a dialog with a room link, a view/comment/edit role selector, and a copy button; `edit` links carry no param, `view`/`comment` append `?role=…` (honoured by the collab server's anonymous join path). A host-supplied `onShare` still overrides the built-in flow, and standalone docs show no Share affordance.

Server-enforced secure links (minted `?share=<token>`) are a noted follow-up; the role param here is a client-side hint. `ShareDialog` and `buildShareUrl` are exported for hosts that want to render it themselves.