### PR TITLE
feat(sdk): documentMode ('editing'|'viewing'|'suggesting') prop + runtime setter

### DIFF
--- a/docx-editor/.changeset/document-mode-prop.md
+++ b/docx-editor/.changeset/document-mode-prop.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': minor
+---
+
+Add a `documentMode` prop (`'editing' | 'suggesting' | 'viewing'`) to DocxEditor and CasualEditor, using SuperDoc vocabulary so the docs and sheets SDKs match. It maps onto the existing mode mechanism and takes precedence over the legacy `mode`/`readOnly` props when both are supplied. Also adds runtime `setDocumentMode(mode)` / `getDocumentMode()` methods on the editor ref.

--- a/docx-editor/packages/react/src/components/CasualEditor.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.tsx
@@ -112,6 +112,13 @@ export interface CasualEditorProps {
   autosaveInterval?: number;
   /** Author used by comments + track-change attribution. */
   author?: string;
+  /**
+   * Document mode (SuperDoc vocabulary): `'editing'`, `'suggesting'`, or
+   * `'viewing'`. Forwarded to DocxEditor.documentMode.
+   */
+  documentMode?: DocxEditorProps['documentMode'];
+  /** Fires when the document mode changes (forwarded from DocxEditor). */
+  onModeChange?: DocxEditorProps['onModeChange'];
   /** Forwarded to DocxEditor.onSave for hosts that want a hook. */
   onSave?: DocxEditorProps['onSave'];
   /** Forwarded to DocxEditor.onSelectionChange — Drive uses this for the right-panel sync. */
@@ -184,6 +191,8 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
       autosave = false,
       autosaveInterval = 30000,
       author,
+      documentMode,
+      onModeChange,
       onSave,
       onSelectionChange,
       onError,
@@ -363,6 +372,8 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
         comments={collabState ? collabComments : undefined}
         onCommentsChange={collabState ? handleCommentsChange : undefined}
         author={author}
+        documentMode={documentMode}
+        onModeChange={onModeChange}
         onSave={onSave}
         onSelectionChange={onSelectionChange}
         onError={onError}

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -689,6 +689,14 @@ export interface DocxEditorProps {
   onCut?: () => void;
   /** Callback when content is pasted */
   onPaste?: () => void;
+  /**
+   * Document mode (SuperDoc vocabulary, matches the sheet SDK's `documentMode`):
+   * `'editing'` (direct edits), `'suggesting'` (track changes), or `'viewing'`
+   * (read-only). This is the preferred public name; it maps onto the same
+   * internal mechanism as `mode`. When both `documentMode` and `mode`/`readOnly`
+   * are supplied, `documentMode` wins.
+   */
+  documentMode?: EditorMode;
   /** Editor mode: 'editing' (direct edits), 'suggesting' (track changes), or 'viewing' (read-only). Default: 'editing' */
   mode?: EditorMode;
   /** Callback when the editing mode changes */
@@ -981,6 +989,15 @@ export interface DocxEditorRef {
     title: string;
     sections: Array<{ heading: string; level?: number; paragraphs?: string[] }>;
   }) => boolean;
+  /**
+   * Switch the document mode at runtime (SuperDoc vocabulary): `'editing'`,
+   * `'suggesting'`, or `'viewing'`. Fires `onModeChange`. In uncontrolled mode
+   * this updates internal state; when `documentMode`/`mode` is a controlled prop
+   * the host is expected to react to `onModeChange` and update the prop.
+   */
+  setDocumentMode: (mode: EditorMode) => void;
+  /** Read the current document mode (`'editing'` | `'suggesting'` | `'viewing'`). */
+  getDocumentMode: () => EditorMode;
 }
 
 /**
@@ -1703,6 +1720,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     onCopy: _onCopy,
     onCut: _onCut,
     onPaste: _onPaste,
+    documentMode,
     mode: modeProp,
     onModeChange,
     onCommentAdd,
@@ -1951,10 +1969,15 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     to: number;
   } | null>(null);
   const [addCommentYPosition, setAddCommentYPosition] = useState<number | null>(null);
-  const [editingModeInternal, setEditingModeInternal] = useState<EditorMode>(modeProp ?? 'editing');
-  const editingMode = modeProp ?? editingModeInternal;
+  // `documentMode` (SuperDoc vocabulary, sheet-SDK parity) is the preferred
+  // public name and wins over the legacy `mode` prop when both are set.
+  const controlledMode = documentMode ?? modeProp;
+  const [editingModeInternal, setEditingModeInternal] = useState<EditorMode>(
+    controlledMode ?? 'editing'
+  );
+  const editingMode = controlledMode ?? editingModeInternal;
   const setEditingMode = (mode: EditorMode) => {
-    if (!modeProp) setEditingModeInternal(mode);
+    if (!controlledMode) setEditingModeInternal(mode);
     onModeChange?.(mode);
   };
   // Refs so the global keydown listener can read latest without re-binding.
@@ -1966,8 +1989,11 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   useEffect(() => {
     setEditingModeRef.current = setEditingMode;
   });
-  // 'viewing' mode acts as read-only
-  const readOnly = readOnlyProp || editingMode === 'viewing';
+  // 'viewing' mode acts as read-only. When `documentMode` is explicitly set it
+  // is the single source of truth for editability, so it overrides the legacy
+  // `readOnly` prop (documentMode wins when both are supplied).
+  const readOnly =
+    documentMode != null ? editingMode === 'viewing' : readOnlyProp || editingMode === 'viewing';
 
   // Agent panel open state (uncontrolled fallback when `agentPanel.open` is undefined).
   const [agentPanelInternalOpen, setAgentPanelInternalOpen] = useState(false);
@@ -8596,6 +8622,11 @@ body { background: white; }
         view.dispatch(tr.scrollIntoView());
         return true;
       },
+
+      // Runtime document-mode switching (SuperDoc vocabulary). Reads/writes the
+      // latest value via refs so the handle needn't be re-created on mode change.
+      setDocumentMode: (mode) => setEditingModeRef.current(mode),
+      getDocumentMode: () => editingModeRef.current,
     };
     // Expose the same handle to the onReady effect below,
     // and register mutation methods with the DocOps bridge.


### PR DESCRIPTION
Adds a `documentMode` prop to `DocxEditor` (with pass-through on `CasualEditor`) using SuperDoc vocabulary — `'editing' | 'viewing' | 'suggesting'` — so the docs and sheets SDKs share the same mode names.

It maps onto the editor's existing editing-mode mechanism and takes precedence over the legacy `mode`/`readOnly` props when both are supplied. Also exposes runtime `setDocumentMode(mode)` / `getDocumentMode()` on the editor ref, reusing the existing mode-switching internals.

Closes docs#268.