### PR TITLE
feat(collab): show an 'asking AI' presence chip with the user's name

### DIFF
--- a/docx-editor/.changeset/ai-presence-chip.md
+++ b/docx-editor/.changeset/ai-presence-chip.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Show an "asking AI" presence chip: useCollab now exposes `aiEditingBy` (the peer who triggered the running AI request) alongside `aiIsEditing`, and PresenceCluster renders a small chip naming the requester or a generic "AI is editing…" when the name is unknown or it's the local user.

--- a/docx-editor/packages/react/i18n/de.json
+++ b/docx-editor/packages/react/i18n/de.json
@@ -1069,5 +1069,9 @@
     "roleView": null,
     "secureNote": null,
     "title": null
+  },
+  "presence": {
+    "aiEditing": null,
+    "askingAi": null
   }
 }

--- a/docx-editor/packages/react/i18n/en.json
+++ b/docx-editor/packages/react/i18n/en.json
@@ -1069,5 +1069,9 @@
     "copied": "Copied",
     "secureNote": "The role is set by a link parameter today. Server-enforced secure links are coming soon.",
     "done": "Done"
+  },
+  "presence": {
+    "aiEditing": "AI is editing…",
+    "askingAi": "{name} is asking AI…"
   }
 }

--- a/docx-editor/packages/react/i18n/he.json
+++ b/docx-editor/packages/react/i18n/he.json
@@ -1069,5 +1069,9 @@
     "roleView": null,
     "secureNote": null,
     "title": null
+  },
+  "presence": {
+    "aiEditing": null,
+    "askingAi": null
   }
 }

--- a/docx-editor/packages/react/i18n/pl.json
+++ b/docx-editor/packages/react/i18n/pl.json
@@ -1069,5 +1069,9 @@
     "roleView": null,
     "secureNote": null,
     "title": null
+  },
+  "presence": {
+    "aiEditing": null,
+    "askingAi": null
   }
 }

--- a/docx-editor/packages/react/i18n/pt-BR.json
+++ b/docx-editor/packages/react/i18n/pt-BR.json
@@ -1069,5 +1069,9 @@
     "roleView": null,
     "secureNote": null,
     "title": null
+  },
+  "presence": {
+    "aiEditing": null,
+    "askingAi": null
   }
 }

--- a/docx-editor/packages/react/i18n/tr.json
+++ b/docx-editor/packages/react/i18n/tr.json
@@ -1069,5 +1069,9 @@
     "roleView": null,
     "secureNote": null,
     "title": null
+  },
+  "presence": {
+    "aiEditing": null,
+    "askingAi": null
   }
 }

--- a/docx-editor/packages/react/i18n/zh-CN.json
+++ b/docx-editor/packages/react/i18n/zh-CN.json
@@ -1069,5 +1069,9 @@
     "roleView": null,
     "secureNote": null,
     "title": null
+  },
+  "presence": {
+    "aiEditing": null,
+    "askingAi": null
   }
 }

--- a/docx-editor/packages/react/src/collab/useCollab.ts
+++ b/docx-editor/packages/react/src/collab/useCollab.ts
@@ -24,7 +24,7 @@
  *   - When peers' awareness picks up users, remote cursors light up.
  *   - On unmount, provider is destroyed and the Y.Doc closed.
  */
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import * as Y from 'yjs';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import { ySyncPlugin, yCursorPlugin, yUndoPlugin, ySyncPluginKey } from 'y-prosemirror';
@@ -52,6 +52,13 @@ export interface CollabState {
   peers: CollabPeer[];
   /** True while the server-side AI orchestrator is running a tool loop for this room. */
   aiIsEditing: boolean;
+  /**
+   * Display name of the peer who triggered the running AI request, when the
+   * server reports it and it isn't the local user. `null` when no name is
+   * known or the local user is the one asking — the UI then shows a generic
+   * "AI is editing" chip instead of naming the requester.
+   */
+  aiEditingBy: string | null;
   /** The Yjs awareness instance — exposed for advanced consumers. */
   awareness: HocuspocusProvider['awareness'];
   /**
@@ -227,6 +234,13 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
   const [status, setStatus] = useState<CollabStatus>('connecting');
   const [peers, setPeers] = useState<CollabPeer[]>([]);
   const [aiIsEditing, setAiIsEditing] = useState(false);
+  const [aiEditingBy, setAiEditingBy] = useState<string | null>(null);
+
+  // Keep the latest local name reachable from the stateless handler
+  // (which is bound once, on `provider`) so we can filter out the local
+  // user without re-subscribing on every rename.
+  const userNameRef = useRef(user.name);
+  userNameRef.current = user.name;
 
   // Publish local-user identity into awareness so peers can render
   // avatars + remote cursors. Re-runs on rename / recolor without
@@ -260,9 +274,19 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
 
     const onStateless = ({ payload }: { payload: string }) => {
       try {
-        const msg = JSON.parse(payload) as { type?: string; status?: string };
+        const msg = JSON.parse(payload) as {
+          type?: string;
+          status?: string;
+          userName?: string;
+        };
         if (msg.type === 'ai-status') {
-          setAiIsEditing(msg.status === 'thinking');
+          const thinking = msg.status === 'thinking';
+          setAiIsEditing(thinking);
+          // Name the requester only when it's someone else — the local user
+          // already knows they kicked off the request.
+          const by =
+            thinking && msg.userName && msg.userName !== userNameRef.current ? msg.userName : null;
+          setAiEditingBy(by);
         }
       } catch {
         /* ignore non-JSON stateless messages */
@@ -295,6 +319,7 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
     status,
     peers,
     aiIsEditing,
+    aiEditingBy,
     awareness: provider.awareness,
     metaMap,
     footnotesMap,

--- a/docx-editor/packages/react/src/components/PresenceCluster.tsx
+++ b/docx-editor/packages/react/src/components/PresenceCluster.tsx
@@ -22,6 +22,7 @@
 
 import type { CSSProperties, ReactElement } from 'react';
 import { AvatarStack, Badge, Button, type BadgeTone } from '@schnsrw/design-system';
+import { useTranslation } from '../i18n';
 
 export interface PresencePeer {
   /** Display name — also seeds the avatar's deterministic colour + initials. */
@@ -37,6 +38,13 @@ export interface PresenceClusterProps {
   peers: PresencePeer[];
   /** Realtime room status → drives the status badge. Omit for non-collab docs. */
   status?: 'connecting' | 'connected' | 'disconnected';
+  /** True while an AI request is running for this room → shows an "AI is editing" chip. */
+  aiIsEditing?: boolean;
+  /**
+   * Display name of the peer who triggered the AI request. When set, the chip
+   * names them ("<name> is asking AI…"); otherwise it stays generic.
+   */
+  aiEditingBy?: string | null;
   /** Share action. When provided, renders a Share button after a divider. */
   onShare?: () => void;
   /** Max avatars before the rest collapse into a `+N` chip. Default 4. */
@@ -66,19 +74,44 @@ const dividerStyle: CSSProperties = {
   margin: '0 var(--space-1, 2px)',
 };
 
+const aiChipStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 'var(--space-1, 2px)',
+  padding: '2px var(--space-2, 4px)',
+  borderRadius: 'var(--radius-full, 999px)',
+  fontSize: 'var(--text-xs, 12px)',
+  color: 'var(--doc-accent, #6b3fd4)',
+  background: 'var(--doc-accent-subtle, rgba(107, 63, 212, 0.12))',
+  whiteSpace: 'nowrap',
+};
+
 export function PresenceCluster({
   peers,
   status,
   onShare,
   maxAvatars = 4,
+  aiIsEditing = false,
+  aiEditingBy = null,
 }: PresenceClusterProps): ReactElement | null {
+  const { t } = useTranslation();
   const hasPeers = peers.length > 0;
-  if (!hasPeers && !status && !onShare) return null;
+  if (!hasPeers && !status && !onShare && !aiIsEditing) return null;
 
   const s = status ? STATUS[status] : null;
+  const aiLabel = aiIsEditing
+    ? aiEditingBy
+      ? t('presence.askingAi', { name: aiEditingBy })
+      : t('presence.aiEditing')
+    : null;
 
   return (
     <div style={wrapStyle} data-testid="presence-cluster">
+      {aiLabel && (
+        <span style={aiChipStyle} data-testid="presence-ai-chip">
+          {aiLabel}
+        </span>
+      )}
       {hasPeers && (
         <AvatarStack
           size={26}


### PR DESCRIPTION
Surfaces who is asking the AI in the presence cluster (docs#266, client half).

useCollab captures `userName` from the server's `ai-status` broadcast and exposes it as `aiEditingBy` alongside the existing `aiIsEditing`, filtering out the local user. PresenceCluster renders a small title-bar chip — "<name> is asking AI…" when a peer triggered it, or a generic "AI is editing…" when the name is unknown or it's the local user — using the shared design tokens and i18n `t()`.