### PR TITLE
feat(sdk): ai prop to enable the DocOps assistant (no window global)

### DIFF
--- a/docx-editor/.changeset/ai-prop-docops.md
+++ b/docx-editor/.changeset/ai-prop-docops.md
@@ -1,0 +1,5 @@
+---
+'@eigenpal/docx-js-editor': minor
+---
+
+Add an `ai` prop to enable the built-in DocOps assistant. `ai={{ enabled: true }}` unlocks the assistant panel without the `window.__casualFeatures__.docops` global (kept as a deprecated fallback for one minor). `ai.transport` routes model calls and `ai.onAction` fires after each document write the assistant performs. Also forwarded from `CasualEditor`.

--- a/docx-editor/packages/react/src/components/CasualEditor.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.tsx
@@ -126,6 +126,12 @@ export interface CasualEditorProps {
   /** Forwarded to DocxEditor.onError. */
   onError?: DocxEditorProps['onError'];
   /**
+   * Built-in DocOps AI assistant. Forwarded to DocxEditor.ai — set
+   * `ai={{ enabled: true }}` to unlock the assistant panel (no window
+   * global). See DocxEditor's `ai` prop.
+   */
+  ai?: DocxEditorProps['ai'];
+  /**
    * Fires whenever a tick lands — host can render its own
    * "Saved 2 min ago" indicator without subscribing to the
    * underlying hook.
@@ -196,6 +202,7 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
       onSave,
       onSelectionChange,
       onError,
+      ai,
       onAutosaveState,
       onCollabState,
       onShare,
@@ -379,6 +386,7 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
         onError={onError}
         renderTitleBarRight={renderCollabPresence}
         docopsTransport={createDocOpsTransport({ collabWsUrl: backendUrl, room: docId })}
+        ai={ai}
         {...docxEditorProps}
       />
     );

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -74,6 +74,7 @@ import {
   API_KEY_STORAGE,
   type DocsBridgeActions,
 } from '../docops';
+import { withActionNotifier, type AiProp, type DocOpsAction } from '../docops/ai-prop';
 import { markdownToFragment } from '../lib/writer/markdownToFragment';
 import { AutosaveRestoreBanner } from './AutosaveRestoreBanner';
 import { writeAutosave, clearLegacyLocalStorageAutosave } from '../utils/autosave';
@@ -819,7 +820,19 @@ export interface DocxEditorProps {
    * stops the loop and tells the user. Defaults to 12.
    */
   docopsMaxToolRounds?: number;
+  /**
+   * Built-in DocOps AI assistant — the supported SDK surface (#269).
+   *
+   * `ai={{ enabled: true }}` unlocks the assistant panel without the legacy
+   * `window.__casualFeatures__.docops` global (kept as a deprecated fallback
+   * for one minor). `ai.transport` routes model calls (the explicit
+   * `docopsTransport` prop still wins when both are set), and `ai.onAction`
+   * fires after each document write the assistant performs.
+   */
+  ai?: AiProp;
 }
+
+export type { AiProp, DocOpsAction };
 
 /**
  * DocxEditor ref interface
@@ -1750,6 +1763,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     wordCompat = false,
     docopsTransport,
     docopsMaxToolRounds,
+    ai,
   },
   ref
 ) {
@@ -2826,6 +2840,23 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   useEffect(() => {
     docsBridgeRef.current?.setAiAuthor(author);
   }, [author]);
+
+  // DocOps AI availability. `ai.enabled` is the supported SDK switch (#269);
+  // the `window.__casualFeatures__.docops` global (read by `isDocOpsEnabled`)
+  // stays a deprecated fallback for one minor, alongside the desktop shell.
+  const docOpsEnabled = ai?.enabled === true || isDocOpsEnabled();
+
+  // Transport precedence: explicit `docopsTransport` prop → `ai.transport` →
+  // auto-selected. Resolved lazily at panel-mount time (see below).
+  const docOpsTransport = docopsTransport ?? ai?.transport;
+
+  // Wrap the bridge so `ai.onAction` fires after each write-tool run. The
+  // wrapper is a no-op passthrough when no callback is supplied.
+  const aiOnAction = ai?.onAction;
+  const notifyingBridge = useMemo<DocsBridge | null>(
+    () => (docsBridgeRef.current ? withActionNotifier(docsBridgeRef.current, aiOnAction) : null),
+    [aiOnAction]
+  );
 
   // Right-side panel mutex. Google Docs / Microsoft Word only ever
   // expose ONE right-edge panel at a time (Comments XOR Outline,
@@ -10450,14 +10481,15 @@ body { background: white; }
                     />
                   )}
 
-                  {/* DocOps AI panel — gated behind window.__casualFeatures__.docops.
+                  {/* DocOps AI panel — unlocked via the `ai` SDK prop (or the
+                      deprecated window.__casualFeatures__.docops global).
                       Uses the Anthropic API directly (user-supplied key) with the
                       JSON DocOps IR tool catalog. No WebLLM, no server inference. */}
-                  {showDocOpsPanel && isDocOpsEnabled() && docsBridgeRef.current && (
+                  {showDocOpsPanel && docOpsEnabled && notifyingBridge && (
                     <DocOpsPanel
-                      bridge={docsBridgeRef.current}
+                      bridge={notifyingBridge}
                       onClose={() => openRightPanel('none')}
-                      transport={docopsTransport ?? createDocOpsTransport()}
+                      transport={docOpsTransport ?? createDocOpsTransport()}
                       maxToolRounds={docopsMaxToolRounds}
                     />
                   )}
@@ -10485,9 +10517,9 @@ body { background: white; }
                       //   onToggleWriter={() => openRightPanel(showWritingAssistant ? 'none' : 'writer')}
                       //   chatVisible={showChatPanel}
                       //   onToggleChat={() => openRightPanel(showChatPanel ? 'none' : 'chat')}
-                      docopsVisible={isDocOpsEnabled() ? showDocOpsPanel : undefined}
+                      docopsVisible={docOpsEnabled ? showDocOpsPanel : undefined}
                       onToggleDocOps={
-                        isDocOpsEnabled()
+                        docOpsEnabled
                           ? () => openRightPanel(showDocOpsPanel ? 'none' : 'docops')
                           : undefined
                       }

--- a/docx-editor/packages/react/src/docops/ai-prop.ts
+++ b/docx-editor/packages/react/src/docops/ai-prop.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+import type { DocOpsResult } from '@casualoffice/docops';
+import type { DocsBridge } from './bridge';
+import type { DocOpsTransport } from './transport';
+
+/**
+ * A document action performed by the DocOps assistant — one successful run of
+ * a write tool (e.g. `rewrite_selection`, `insert_toc`, `set_paragraph_style`).
+ * Read-only tools (searches, stats, outline) never surface here.
+ */
+export interface DocOpsAction {
+  /** The DocOps tool that ran. */
+  type: string;
+  /** The arguments the assistant passed to the tool. */
+  args: Record<string, unknown>;
+  /** The tool's result. */
+  result: DocOpsResult;
+}
+
+/**
+ * Supported SDK surface for the built-in DocOps AI assistant.
+ *
+ * Passing `ai={{ enabled: true }}` unlocks the assistant panel — no
+ * `window.__casualFeatures__.docops` global required (that global remains a
+ * deprecated fallback for one minor).
+ */
+export interface AiProp {
+  /**
+   * Unlock the DocOps assistant panel. When omitted, the assistant is gated
+   * behind the deprecated `window.__casualFeatures__.docops` global (or the
+   * desktop shell).
+   */
+  enabled?: boolean;
+  /**
+   * LLM transport. Controls how model calls are routed:
+   *   - Omit → auto-selected via `createDocOpsTransport` (DesktopTransport in
+   *     Tauri, DirectTransport otherwise)
+   *   - `CollabTransport` → proxy through the collab server's /api/ai/chat
+   *   - Any `DocOpsTransport` implementation
+   * The explicit `docopsTransport` prop, when set, takes precedence.
+   */
+  transport?: DocOpsTransport;
+  /** Called after the assistant performs a document write action. */
+  onAction?: (action: DocOpsAction) => void;
+}
+
+/**
+ * DocOps tools that only inspect the document. Runs of these never fire
+ * `onAction`. New tools default to "mutating" so a consumer's `onAction` is
+ * notified unless a tool is explicitly listed here as read-only.
+ */
+const READ_ONLY_TOOLS = new Set<string>([
+  'get_outline',
+  'get_selection',
+  'get_doc_stats',
+  'get_block',
+  'search_document',
+  'search_workspace',
+  'list_styles',
+  'find_text',
+]);
+
+/**
+ * Wrap a {@link DocsBridge} so `onAction` fires after each successful write-tool
+ * run. Read-only tool runs are ignored. Returns the bridge unchanged when no
+ * callback is supplied.
+ *
+ * Implemented as a Proxy so the granular per-tool seam works without the
+ * DocOpsPanel needing to know about `onAction`.
+ */
+export function withActionNotifier(
+  bridge: DocsBridge,
+  onAction?: (action: DocOpsAction) => void
+): DocsBridge {
+  if (!onAction) return bridge;
+  return new Proxy(bridge, {
+    get(target, prop, receiver) {
+      if (prop === 'callTool') {
+        return async (name: string, args: Record<string, unknown>) => {
+          const result = await target.callTool(name, args);
+          if (result.ok && !READ_ONLY_TOOLS.has(name)) {
+            try {
+              onAction({ type: name, args, result });
+            } catch {
+              /* consumer callback threw — non-fatal, don't break the loop */
+            }
+          }
+          return result;
+        };
+      }
+      // Bind methods to the real bridge so private-field access keeps working
+      // (Proxy + private fields otherwise throws when `this` is the proxy).
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function'
+        ? (value as (...a: unknown[]) => unknown).bind(target)
+        : value;
+    },
+  });
+}


### PR DESCRIPTION
Promotes the built-in DocOps AI to a supported SDK prop (docs#269).

`ai={{ enabled: true }}` unlocks the assistant panel without the `window.__casualFeatures__.docops` global — the global stays as a deprecated fallback for one minor. `ai.transport` wires into the existing `docopsTransport` path (the explicit `docopsTransport` prop still takes precedence), and `ai.onAction` fires after each successful write-tool run via a bridge wrapper. Read-only tool runs don't fire it. Forwarded through `CasualEditor`; existing `docopsTransport` / `agentPanel` props are unchanged.