### PR TITLE
feat(sdk): cspNonce + documented --ce-* token surface for iframe isolation

### DIFF
--- a/docx-editor/.changeset/csp-nonce-ce-tokens.md
+++ b/docx-editor/.changeset/csp-nonce-ce-tokens.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': minor
+---
+
+Add a `cspNonce` prop to `CasualEditorIframe` for strict-CSP hosts. When set, the nonce is threaded through the iframe URL and stamped as the `nonce` attribute on every `<style>` / `<link rel="stylesheet">` in the same-origin iframe document (present at load and injected later), so hosts serving `style-src 'nonce-…'` don't have the editor's styles blocked. Also documents the iframe variant as the guaranteed style-isolation path and adds a stable public `--ce-*` CSS custom-property surface aliased over the internal `--doc-*` tokens.

--- a/docx-editor/packages/react/src/components/CasualEditorIframe.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditorIframe.tsx
@@ -6,6 +6,17 @@
  * CasualEditorIframe — the iframe-mounting variant of `<CasualEditor>`.
  * Doc 16 §5 + §6.
  *
+ * **This is the guaranteed style-isolation path** (doc 38 §8). Because the
+ * editor mounts inside a same-origin iframe, none of its styles, Tailwind
+ * utilities, design-system tokens, or fonts can leak onto the host page, and
+ * the host's CSS cannot bleed into the editor. Direct-mount `<CasualEditor>`
+ * shares the host's DOM/CSS scope; prefer this variant when strict isolation
+ * or strict-CSP compliance matters.
+ *
+ * For strict-CSP hosts (`style-src 'nonce-…'`), pass {@link
+ * CasualEditorIframeProps.cspNonce} — it is threaded through the iframe URL and
+ * stamped onto every stylesheet in the iframe document so none are blocked.
+ *
  * Public surface is intentionally identical to the existing
  * `<CasualEditor>` so v1.1's migration path is one component swap.
  * v1.2 will rename CasualEditorIframe → CasualEditor (and the
@@ -21,6 +32,7 @@ import {
   type MutableRefObject,
 } from 'react';
 
+import { applyCspNonce } from './cspNonce';
 import { EmbedHostTransport } from '../embed/EmbedHostTransport';
 import type {
   CasualApp,
@@ -50,6 +62,12 @@ export interface CasualEditorIframeProps {
   embedBasePath?: string;
   /** Default `docs`. Sheet SDK ships its own variant with `app: 'sheet'`. */
   app?: CasualApp;
+  /** CSP nonce for strict-CSP hosts (`style-src 'nonce-<value>'`). Pass the
+   *  same value used in the host's CSP header: it is threaded through the
+   *  iframe URL and stamped as the `nonce` attribute on every `<style>` /
+   *  `<link rel="stylesheet">` in the iframe document, so the editor's styles
+   *  aren't blocked. Omit when the host has no strict style-src policy. */
+  cspNonce?: string;
   onSelectionChanged?: (data: SelectionChangedData) => void;
   onTelemetry?: (data: TelemetryEventData) => void;
   onError?: (data: CasualErrorData) => void;
@@ -73,6 +91,7 @@ export const CasualEditorIframe = forwardRef<CasualEditorIframeRef, CasualEditor
       viewMode = 'editor',
       embedBasePath = '/embed/docs',
       app = 'docs',
+      cspNonce,
       onSelectionChanged,
       onTelemetry,
       onError,
@@ -83,6 +102,7 @@ export const CasualEditorIframe = forwardRef<CasualEditorIframeRef, CasualEditor
 
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
     const transportRef = useRef<EmbedHostTransport | null>(null);
+    const nonceCleanupRef = useRef<(() => void) | null>(null);
 
     // Latest fileSource via ref so the load/save handlers don't
     // rebuild the transport on every consumer re-render.
@@ -132,6 +152,10 @@ export const CasualEditorIframe = forwardRef<CasualEditorIframeRef, CasualEditor
     const onIframeLoad = useCallback(() => {
       const iframe = iframeRef.current;
       if (!iframe?.contentWindow) return;
+      // Stamp the CSP nonce onto the iframe document's stylesheets (present
+      // now and injected later) so strict-CSP hosts don't block them.
+      nonceCleanupRef.current?.();
+      nonceCleanupRef.current = cspNonce ? applyCspNonce(iframe.contentDocument, cspNonce) : null;
       transportRef.current?.destroy();
       const transport = new EmbedHostTransport({
         app,
@@ -150,7 +174,7 @@ export const CasualEditorIframe = forwardRef<CasualEditorIframeRef, CasualEditor
         },
       });
       transportRef.current = transport;
-    }, [app, onLoad, onSave, onSelectionChanged, onTelemetry, onError, viewMode]);
+    }, [app, cspNonce, onLoad, onSave, onSelectionChanged, onTelemetry, onError, viewMode]);
 
     // Push viewMode changes through the wire instead of re-mounting.
     useEffect(() => {
@@ -162,6 +186,8 @@ export const CasualEditorIframe = forwardRef<CasualEditorIframeRef, CasualEditor
       return () => {
         transportRef.current?.destroy();
         transportRef.current = null;
+        nonceCleanupRef.current?.();
+        nonceCleanupRef.current = null;
       };
     }, []);
 
@@ -178,7 +204,9 @@ export const CasualEditorIframe = forwardRef<CasualEditorIframeRef, CasualEditor
       `${embedBasePath}/embed.html` +
       `?app=${app}` +
       `&docId=${encodeURIComponent(docId)}` +
-      `&viewMode=${viewMode}`;
+      `&viewMode=${viewMode}` +
+      // Threaded so the embed runtime can also apply the nonce at parse time.
+      (cspNonce ? `&cspNonce=${encodeURIComponent(cspNonce)}` : '');
 
     return (
       <iframe

--- a/docx-editor/packages/react/src/components/cspNonce.ts
+++ b/docx-editor/packages/react/src/components/cspNonce.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * cspNonce — helper for strict-CSP (Content-Security-Policy) hosts.
+ *
+ * A host serving `style-src 'nonce-<value>'` blocks any `<style>` / `<link
+ * rel="stylesheet">` that doesn't carry a matching `nonce` attribute. The
+ * iframe-mounted editor (`<CasualEditorIframe>`) is the style-isolation path,
+ * so its stylesheets live in the same-origin iframe document. When the host
+ * passes the same nonce it put in its CSP header, we stamp it onto every
+ * stylesheet the iframe document contains — both the ones present at load and
+ * any injected later by the runtime — so the browser keeps them.
+ *
+ * Same-origin only: the embed document is served from the host origin and the
+ * iframe carries `allow-same-origin`, so `iframe.contentDocument` is reachable.
+ * If cross-origin access throws, we bail quietly — the nonce is also threaded
+ * through the iframe URL for the runtime to apply at parse time.
+ */
+
+/** Selector for the elements a CSP `style-src` nonce governs. */
+const STYLE_SELECTOR = 'style, link[rel="stylesheet"]';
+
+function stampElement(el: Element, nonce: string): void {
+  // `nonce` is an IDL attribute on HTMLStyleElement/HTMLLinkElement; setting
+  // the content attribute too covers older engines and querySelector matching.
+  if (el.getAttribute('nonce') === nonce) return;
+  el.setAttribute('nonce', nonce);
+  (el as HTMLElement & { nonce?: string }).nonce = nonce;
+}
+
+/**
+ * Stamp `nonce` onto every current and future stylesheet in `doc`.
+ *
+ * Returns a cleanup function that disconnects the observer watching for
+ * runtime-injected stylesheets. Safe to call with an empty nonce (no-op) and
+ * safe if `doc` is briefly inaccessible.
+ *
+ * @param doc   The iframe's `contentDocument`.
+ * @param nonce The CSP nonce value (without the `nonce-` prefix).
+ */
+export function applyCspNonce(doc: Document | null | undefined, nonce: string): () => void {
+  const noop = (): void => {};
+  if (!doc || !nonce) return noop;
+
+  const stampAll = (): void => {
+    doc.querySelectorAll(STYLE_SELECTOR).forEach((el) => stampElement(el, nonce));
+  };
+
+  try {
+    stampAll();
+  } catch {
+    return noop;
+  }
+
+  if (typeof MutationObserver === 'undefined' || !doc.head) return noop;
+
+  // Stylesheets can be injected after the document loads (e.g. the runtime's
+  // bundler emitting <style> tags). Watch the head and stamp new ones.
+  const observer = new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      m.addedNodes.forEach((node) => {
+        if (!(node instanceof Element)) return;
+        if (node.matches(STYLE_SELECTOR)) stampElement(node, nonce);
+        node.querySelectorAll?.(STYLE_SELECTOR).forEach((el) => stampElement(el, nonce));
+      });
+    }
+  });
+  observer.observe(doc.head, { childList: true, subtree: true });
+  return () => observer.disconnect();
+}

--- a/docx-editor/packages/react/src/styles/editor.css
+++ b/docx-editor/packages/react/src/styles/editor.css
@@ -159,6 +159,44 @@
   --doc-anim-fast: var(--motion-fast) var(--ease-out);
   --doc-anim-base: var(--motion-base) var(--ease-out);
   --doc-anim-slow: var(--motion-slow) var(--ease-out);
+
+  /* ========================================
+   * Public token surface — --ce-* (Casual Editor)
+   *
+   * SDK contract (doc 38 §8 "style isolation"). The internal chrome is
+   * themed with the --doc-* variables above; those names are an
+   * implementation detail and may be renamed. The --ce-* aliases below are
+   * the STABLE, PUBLIC surface a host reads (getComputedStyle) or overrides
+   * to blend the editor chrome with its own theme. They inherit into the
+   * iframe document too, so the same names work in either delivery mode.
+   *
+   * Aliases are one-way (--ce-* → --doc-*): setting a --ce-* var here is
+   * read-only relative to the internal system. To have a host override
+   * flow inward, a future --doc-x: var(--ce-x, <default>) indirection would
+   * be added per token; kept out of scope now to avoid churn.
+   *
+   * Public name        Internal source        Meaning
+   * --ce-bg            --doc-bg              desk behind the page
+   * --ce-page-paper    --doc-page-paper      default page fill (display-only)
+   * --ce-chrome        --doc-chrome          toolbar/title/status strips
+   * --ce-surface       --doc-surface         panel / dialog / dropdown bg
+   * --ce-text          --doc-text            primary text
+   * --ce-text-muted    --doc-text-muted      secondary text
+   * --ce-primary       --doc-primary         primary action / accent
+   * --ce-accent        --doc-accent          accent (alias of primary)
+   * --ce-border        --doc-border          standard borders
+   * --ce-link          --doc-link            hyperlinks
+   * ======================================== */
+  --ce-bg: var(--doc-bg);
+  --ce-page-paper: var(--doc-page-paper);
+  --ce-chrome: var(--doc-chrome);
+  --ce-surface: var(--doc-surface);
+  --ce-text: var(--doc-text);
+  --ce-text-muted: var(--doc-text-muted);
+  --ce-primary: var(--doc-primary);
+  --ce-accent: var(--doc-accent);
+  --ce-border: var(--doc-border);
+  --ce-link: var(--doc-link);
 }
 
 /* ============================================================================


### PR DESCRIPTION
Adds a cspNonce prop to CasualEditorIframe (stamped onto iframe stylesheets + threaded via URL) for strict-CSP hosts, documents the iframe variant as the isolation-guaranteed path, and adds a stable public --ce-* token alias over the internal --doc-* tokens (docs#274).