### PR TITLE
fix(release): correct 67 stale changesets to @casualoffice/docs (unblocks npm publish)

### DIFF
--- a/docx-editor/.changeset/agent-correctness.md
+++ b/docx-editor/.changeset/agent-correctness.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Agent loop correctness: a sub-task that calls no tool is now marked failed (not a false success); the executor uses native tool-calling instead of an XML convention it never parsed; the destructive create_document tool is excluded from sub-task executors; and reflection only accepts structured corrective tasks (no prose-to-task garbage) with dedup against existing steps.

--- a/docx-editor/.changeset/agent-planner-grounding.md
+++ b/docx-editor/.changeset/agent-planner-grounding.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 The agent planner can now be grounded with a document snapshot (AgentOptions.planningContext) so it decomposes a goal against real structure — the docs panel supplies the heading outline, preventing e.g. a "summarize" goal from being planned as edit sub-tasks.

--- a/docx-editor/.changeset/agent-repeated-call-guard.md
+++ b/docx-editor/.changeset/agent-repeated-call-guard.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 The agent's per-task loop now stops when the model repeats the identical tool call two rounds in a row, instead of burning the whole round budget re-calling the same tool with no progress — a common small-local-model failure.

--- a/docx-editor/.changeset/ai-edit-attribution.md
+++ b/docx-editor/.changeset/ai-edit-attribution.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Attribute AI-triggered document edits and comments to the initiating user (e.g. "Alice via AI") instead of a hardcoded "DocOps AI", so co-editors can tell who ran an AI action in a shared document.

--- a/docx-editor/.changeset/ai-prop-docops.md
+++ b/docx-editor/.changeset/ai-prop-docops.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': minor
+'@casualoffice/docs': minor
 ---
 
 Add an `ai` prop to enable the built-in DocOps assistant. `ai={{ enabled: true }}` unlocks the assistant panel without the `window.__casualFeatures__.docops` global (kept as a deprecated fallback for one minor). `ai.transport` routes model calls and `ai.onAction` fires after each document write the assistant performs. Also forwarded from `CasualEditor`.

--- a/docx-editor/.changeset/cjk-font-fallback-vf-harness.md
+++ b/docx-editor/.changeset/cjk-font-fallback-vf-harness.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Map CJK fonts (Microsoft JhengHei/YaHei, PMingLiU/MingLiU) to Noto + PingFang fallback stacks so Chinese/Japanese/Korean documents render in a proper CJK face with canonical 1em ideograph advances instead of an arbitrary browser fallback.

--- a/docx-editor/.changeset/clipboard-plain-paste-keydown.md
+++ b/docx-editor/.changeset/clipboard-plain-paste-keydown.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix `useClipboard` so paste-as-plain-text (⌘/Ctrl+Shift+V) works. The hook read `shiftKey` off the paste `ClipboardEvent`, which carries no keyboard-modifier state, so the flag was always false. The Shift state is now captured on the paste-initiating keydown (via the hook's `handleKeyDown`) and consumed in the paste handler.

--- a/docx-editor/.changeset/collab-transport-single-round.md
+++ b/docx-editor/.changeset/collab-transport-single-round.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': minor
+'@casualoffice/docs': minor
 ---
 
 CollabTransport is now single-round (drivesLoop=false): the collab server is a key-holding LLM proxy for one turn and the panel/agent drives the tool loop — so the plan→execute→reflect agent (and the flat chat loop) run on the web, not only on desktop. Previously the server drove the whole loop, which hid the Agent toggle on every web session.

--- a/docx-editor/.changeset/colorpicker-darkmode.md
+++ b/docx-editor/.changeset/colorpicker-darkmode.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix the color picker dropdown being unreadable in dark mode. Its section labels ("Theme Colors", "Standard Colors", "Custom Color"), the "Automatic" row, and borders used hardcoded light-mode grays (#666 / #333 / #d0d0d0) on a `--doc-surface` background that goes dark under `[data-theme="dark"]` — dark-grey-on-dark. They now use theme tokens (`--doc-text-muted`, `--doc-text-on-surface`, `--doc-border`) so the picker is legible in both themes.

--- a/docx-editor/.changeset/comment-mentionable-users.md
+++ b/docx-editor/.changeset/comment-mentionable-users.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Add a `mentionableUsers` prop so the host can supply the people directory for comment @-mentions. Previously the @-mention typeahead only knew about people who had already commented, so you couldn't mention a collaborator who hadn't participated yet. Hosts (e.g. Drive) can now pass the known users; they're merged into the suggestion list and deduped against historical authors.

--- a/docx-editor/.changeset/connector-line-render.md
+++ b/docx-editor/.changeset/connector-line-render.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Render grouped "Straight Connector" line shapes (prst="line") as a thin rule instead of a content-height filled box. A line shape with a fill (e.g. a gray divider under a header logo) was given an empty placeholder paragraph plus default text-box insets, inflating the ~1px line into a tall colored bar.

--- a/docx-editor/.changeset/copyright-headers.md
+++ b/docx-editor/.changeset/copyright-headers.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Add Casual Office copyright headers to first-party source files.

--- a/docx-editor/.changeset/dark-mode-dim-page.md
+++ b/docx-editor/.changeset/dark-mode-dim-page.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 In dark mode, dim the default white page to a soft off-white and deepen the desk behind it to near-black, so the page reads as a calm card instead of glaring. Display-only — documents with an explicit page color are unchanged, and export keeps the real colors.

--- a/docx-editor/.changeset/darkmode-content-surfaces.md
+++ b/docx-editor/.changeset/darkmode-content-surfaces.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix endnotes and footnote/endnote tooltips becoming unreadable in dark mode. Both rendered document text with a hardcoded dark color on a `--doc-surface` background, which swaps to a dark value under `[data-theme="dark"]` — black-on-dark, invisible. They now use the page's paper background, matching the document content they belong to.

--- a/docx-editor/.changeset/default-reconnect-banner.md
+++ b/docx-editor/.changeset/default-reconnect-banner.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': minor
+'@casualoffice/docs': minor
 ---
 
 CasualEditor now shows a default reconnecting/offline banner above the editor while a collab session is degraded. Driven by the live collab status, it renders an amber "Reconnecting…" strip when connecting and a red "You're offline — edits saved locally" strip when disconnected, and nothing once connected. Theme-token styled via `--doc-*` vars. Also exported as the standalone `ReconnectBanner` component for hosts that compose their own layout.

--- a/docx-editor/.changeset/desktop-agent-reachability.md
+++ b/docx-editor/.changeset/desktop-agent-reachability.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 The plan→execute→reflect agent now runs on the desktop local model. DesktopTransport was drivesLoop=true, which hid the Agent toggle (gated on !drivesLoop) so the agent only ever ran on the cloud key path. It now does a single model turn per call() — like DirectTransport — and the panel/agent drives the tool loop, matching the panel's existing "Direct / Desktop" flat-loop branch.

--- a/docx-editor/.changeset/editor-on-request-open.md
+++ b/docx-editor/.changeset/editor-on-request-open.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': minor
+'@casualoffice/docs': minor
 ---
 
 Add an `onRequestOpen` prop to `DocxEditor`. When provided, File → Open (and Ctrl/Cmd-O) calls it instead of opening the browser file picker, letting a host run its own open flow (e.g. a native dialog + "this window or a new window?" prompt). Falls back to the in-window browser picker when absent.

--- a/docx-editor/.changeset/file-version-history.md
+++ b/docx-editor/.changeset/file-version-history.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Add **File → Version history** to the menu bar (and the command palette). Version history already existed in the side rail, but Google-Docs users look for it under File — it was effectively undiscoverable there. The entry opens the existing version-history panel.

--- a/docx-editor/.changeset/find-match-highlight.md
+++ b/docx-editor/.changeset/find-match-highlight.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Find & Replace now highlights every match in the document (and marks the current match distinctly), matching Google Docs. Highlights clear when the find bar closes.

--- a/docx-editor/.changeset/find-replace-apply.md
+++ b/docx-editor/.changeset/find-replace-apply.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix Find & Replace: Replace and Replace All now actually change the document (and are undoable as one step). Previously the replacement was routed through the post-transaction change-notification path and never re-seeded the editor, so clicking Replace did nothing.

--- a/docx-editor/.changeset/find-replace-pm-native.md
+++ b/docx-editor/.changeset/find-replace-pm-native.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Find & Replace now searches and replaces inside table cells. The search is ProseMirror-native (it walks the document, including cells) instead of the old Document-model search that skipped tables; replacements are targeted, undoable transactions, and Find navigation selects each match.

--- a/docx-editor/.changeset/find-text-textblock.md
+++ b/docx-editor/.changeset/find-text-textblock.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 find_text now matches any textblock (headings, list items, …), not only paragraph nodes — consistent with get_block. It previously missed text in non-paragraph blocks, so the model could locate a block by other means and then get "not found" from find_text.

--- a/docx-editor/.changeset/fix-autolink-trailing-punct.md
+++ b/docx-editor/.changeset/fix-autolink-trailing-punct.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Auto-link no longer swallows trailing sentence punctuation: typing "see http://example.com." links the URL but leaves the period (and trailing `,;:!?` or an unbalanced `)]}`) as plain text, while keeping balanced parens like `…/Foo_(bar)` intact.

--- a/docx-editor/.changeset/fix-table-appearance-panel.md
+++ b/docx-editor/.changeset/fix-table-appearance-panel.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Table appearance controls (border, border color, border width, cell fill) now live in the Format (properties) panel instead of being appended to the formatting toolbar when the caret enters a table. The toolbar's table group keeps only the style gallery and the table-actions menu; the appearance pickers move to the panel — the single home for object appearance.

--- a/docx-editor/.changeset/format-painter-persistent.md
+++ b/docx-editor/.changeset/format-painter-persistent.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Format painter now supports Google-Docs-style persistent mode: double-click the paint-format button to apply the copied formatting to multiple selections in a row (until Escape or another click). A single click stays one-shot.

--- a/docx-editor/.changeset/gdocs-alignment-shortcuts.md
+++ b/docx-editor/.changeset/gdocs-alignment-shortcuts.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Add Google Docs paragraph-alignment shortcuts: Ctrl+Shift+L / E / R / J (left / center / right / justify) now work alongside the existing Word-style Ctrl+L / E / R / J.

--- a/docx-editor/.changeset/gdocs-indent-shortcut.md
+++ b/docx-editor/.changeset/gdocs-indent-shortcut.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Ctrl+] / Ctrl+[ now indent / outdent a plain paragraph (Google Docs), not just list items — they bump the list level inside a list and adjust the paragraph indent otherwise.

--- a/docx-editor/.changeset/grammar-check.md
+++ b/docx-editor/.changeset/grammar-check.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': minor
+'@casualoffice/docs': minor
 ---
 
 Add grammar checking (Tools → Grammar check). A pluggable `GrammarExtension` paints a blue squiggle under likely mistakes; right-clicking shows the reason plus a one-click fix. The default engine is an offline, dependency-free rule set (a/an, repeated words, lowercase "i", "could of" → "could have", space before punctuation) tuned for precision; the provider interface (`setGrammarChecker`) lets a server- or LLM-backed pass replace it without UI changes.

--- a/docx-editor/.changeset/grammar-debounce.md
+++ b/docx-editor/.changeset/grammar-debounce.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Keep grammar-check off the typing hot path. It used to re-scan the whole document on every keystroke (~12ms extra per edit on a 2,500-paragraph doc, enough to drop frames); now it maps existing decorations through each change and only re-scans ~350ms after typing pauses. Squiggles stay responsive without making large documents feel laggy to type in.

--- a/docx-editor/.changeset/header-edit-dark-surface.md
+++ b/docx-editor/.changeset/header-edit-dark-surface.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix the inline header/footer editor rendering on a dark app surface in dark mode. Double-clicking a header to edit it painted the overlay with `--doc-surface` (which is dark under `[data-theme="dark"]`) and inherited light text — so the header turned black, default text became invisible, and transparent logos showed only their opaque pixels. The overlay now uses the page's paper colors (`#fff` / `#000`), matching the body, in every theme.

--- a/docx-editor/.changeset/header-edit-divider-rule.md
+++ b/docx-editor/.changeset/header-edit-divider-rule.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix decorative divider rules rendering as thick black bars when editing a header/footer. In the inline header editor, a filled text box with no text (a hairline rule, common in letterheads) got the default text-box chrome — a content-growing min-height, 8px padding, and a 1px border — ballooning a thin rule into a black bar. Such rules now render at their declared thin height with no padding or border. (Phase 2 of the header-edit positioned-layout work.)

--- a/docx-editor/.changeset/header-edit-positioned-boxes.md
+++ b/docx-editor/.changeset/header-edit-positioned-boxes.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Render positioned header/footer content faithfully while editing. Previously, double-clicking a header with anchored text boxes or a floating logo (e.g. an SDS letterhead) linearized everything into inline flow — boxes stacked and the logo jumped to the wrong side. The inline editor now places those boxes and the logo at the positions the view already computed, by copying the (hidden but laid-out) view geometry through a scoped stylesheet. Simple headers and round-trip are unchanged; positioned content is faithful but not yet drag-editable.

--- a/docx-editor/.changeset/header-editor-end-key.md
+++ b/docx-editor/.changeset/header-editor-end-key.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix the `End` key swallowing the next keystrokes while editing a header/footer. In the inline header editor, native `End` desynced ProseMirror's selection from the DOM (in the clipped overlay) and silently dropped the following input — so a user who pressed End then typed lost their text. `End` now maps to a ProseMirror command that moves the caret to the end of the current textblock, keeping the selection valid; the overlay also no longer lets PM scroll its ancestors to reveal the selection.

--- a/docx-editor/.changeset/header-editor-pagedown.md
+++ b/docx-editor/.changeset/header-editor-pagedown.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix `PageDown` swallowing the next keystrokes while editing a header/footer (same class as the earlier `End` fix). Native `PageDown` in the clipped overlay desynced ProseMirror's selection and dropped the following input. `PageDown`/`PageUp` now move the caret to the end/start of the header content (there is no "page" in a header), keeping the selection valid.

--- a/docx-editor/.changeset/heading-shortcuts.md
+++ b/docx-editor/.changeset/heading-shortcuts.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Add Google Docs heading shortcuts: Ctrl/Cmd+Alt+1/2/3 apply Heading 1/2/3 and Ctrl/Cmd+Alt+0 reverts to Normal text.

--- a/docx-editor/.changeset/home-end-line-nav.md
+++ b/docx-editor/.changeset/home-end-line-nav.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix Home/End navigation. Home and End now move the caret to the start/end of the current visual line, and Ctrl/Cmd+Home/End move it to the document start/end (Shift extends the selection in both cases). Previously these were no-ops because the off-screen editing model's native Home/End didn't map to the paginated view.

--- a/docx-editor/.changeset/layout-skip-redundant-pagestyles.md
+++ b/docx-editor/.changeset/layout-skip-redundant-pagestyles.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Cut redundant page-shell style writes on every keystroke in large documents. Typing earlier in a document shifts every later page's content positions, which flagged all pages as "changed" and re-applied geometry styles to each (~5ms per keystroke on a 300-page doc). The incremental renderer now re-applies a page's size styles only when the size actually changed, and rewrites its page-number attribute only when it moved.

--- a/docx-editor/.changeset/mcp-persistence-auth.md
+++ b/docx-editor/.changeset/mcp-persistence-auth.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Configured MCP servers now persist across reloads (reconnected on mount) and the add-server UI accepts an optional auth token (sent as a Bearer header), so authenticated MCP servers are usable and don't need re-adding every session.

--- a/docx-editor/.changeset/mcp-streaming-transport.md
+++ b/docx-editor/.changeset/mcp-streaming-transport.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 MCP Streamable-HTTP transport now reads `text/event-stream` responses incrementally instead of buffering the whole body, so it no longer hangs against spec-compliant streaming MCP servers. Also captures the `Mcp-Session-Id` for stateful servers, sends the protocol-version header, follows `tools/list` pagination, and aborts in-flight requests on close.

--- a/docx-editor/.changeset/mcp-transport-proxy.md
+++ b/docx-editor/.changeset/mcp-transport-proxy.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 HttpMcpTransport gains a proxyUrl option: when set, MCP JSON-RPC is POSTed to a same-origin CORS proxy (e.g. the collab server's /api/mcp-proxy) as { url, headers, body } and forwarded server-side, so the web editor can reach external MCP servers that don't send CORS headers. Direct connections are unchanged.

--- a/docx-editor/.changeset/mcp-untrusted-output.md
+++ b/docx-editor/.changeset/mcp-untrusted-output.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Output from external MCP servers is now labeled as untrusted before it reaches the model, so a malicious server can't inject instructions that the agent would act on with real document tools. Built-in tool output is unaffected.

--- a/docx-editor/.changeset/mcp-web-proxy-wiring.md
+++ b/docx-editor/.changeset/mcp-web-proxy-wiring.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 The DocOps panel now routes external MCP connections through the same-origin /api/mcp-proxy when running on the web (browsers can't reach most MCP servers directly — no CORS); desktop connects directly. Completes the web-MCP path end to end.

--- a/docx-editor/.changeset/measure-cache-capacity.md
+++ b/docx-editor/.changeset/measure-cache-capacity.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix a large-document typing-latency cliff: the paragraph measure cache is now sized to the document's paragraph count instead of a fixed 5000 entries. Past ~5000 paragraphs the LRU thrashed on every keystroke (a full re-measure pass evicted entries it still needed), so measurement time jumped from ~1ms to ~100ms. A 309-page document now lays out in ~17ms per keystroke instead of ~112ms.

--- a/docx-editor/.changeset/pageup-pagedown-scroll.md
+++ b/docx-editor/.changeset/pageup-pagedown-scroll.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix PageUp / PageDown: they now scroll the editor viewport by ~one page (Google Docs behavior). Previously they did nothing, because the keys were delegated to the off-screen ProseMirror, which scrolls its hidden area rather than the visible paginated pages.

--- a/docx-editor/.changeset/para-tracker-fastpath.md
+++ b/docx-editor/.changeset/para-tracker-fastpath.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Stop the paragraph change-tracker from re-counting every paragraph on each keystroke. It now reuses its cached count for plain typing and only re-walks the document when an edit could change the paragraph count (Enter, paste, backspace-merge, doc load). Cuts another ~2.5ms per keystroke on a 2,500-paragraph document.

--- a/docx-editor/.changeset/paraid-typing-fastpath.md
+++ b/docx-editor/.changeset/paraid-typing-fastpath.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Stop re-scanning the whole document for paraId uniqueness on every keystroke. The allocator now only does its O(paragraphs) scan on the first edit and on structural edits (Enter, paste, doc load) — plain typing can't add or duplicate a paragraph, so it skips the walk. On a 2,500-paragraph document this cut per-keystroke transaction cost from ~7ms to ~0.1ms, removing typing lag in large documents (independent of spell/grammar).

--- a/docx-editor/.changeset/rag-bm25-retrieval.md
+++ b/docx-editor/.changeset/rag-bm25-retrieval.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': minor
+'@casualoffice/docs': minor
 ---
 
 Add local-first RAG: a BM25 retrieval layer and a `search_document` tool that returns the passages most relevant to a query (with their blockIds). `get_doc_stats` no longer dumps the full document text, which previously overflowed the local model's context on long documents and silently truncated summaries.

--- a/docx-editor/.changeset/search-workspace-tool.md
+++ b/docx-editor/.changeset/search-workspace-tool.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': minor
+'@casualoffice/docs': minor
 ---
 
 Add the search_workspace tool + DocsBridge.setWorkspaceDocs() API: the host (desktop shell) can push plain text from the user's local folder into the bridge, and the AI can then retrieve and cite passages across ALL those files — on-device, no cloud. Gracefully unavailable until a workspace is provided.

--- a/docx-editor/.changeset/share-dialog-roles.md
+++ b/docx-editor/.changeset/share-dialog-roles.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': minor
+'@casualoffice/docs': minor
 ---
 
 Add a built-in ShareDialog to CasualEditor's collab presence cluster: the title-bar Share button now opens a dialog with a room link, a view/comment/edit role selector, and a copy button. Shown only when collab is active; a host-supplied `onShare` still overrides it. Exported `ShareDialog` and `buildShareUrl` for hosts that want to render it themselves.

--- a/docx-editor/.changeset/shift-click-extend.md
+++ b/docx-editor/.changeset/shift-click-extend.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix Shift+Click: it now extends the selection from the existing anchor to the clicked point, instead of collapsing the selection to the click. A subsequent drag keeps extending from that anchor.

--- a/docx-editor/.changeset/skip-pure-selection-rerender.md
+++ b/docx-editor/.changeset/skip-pure-selection-rerender.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Skip the DecorationLayer re-sync bump on pure local selection changes (clicks / arrow keys). Only doc edits and meta-only transactions (e.g. collaboration cursor awareness) can change decorations, so bumping on every selection forced a needless PagedEditor + DecorationLayer re-render on every cursor placement — visible as flicker, especially without collaboration. The selection overlay still updates on every selection change.

--- a/docx-editor/.changeset/smart-chip-dark-tokens.md
+++ b/docx-editor/.changeset/smart-chip-dark-tokens.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Theme the smart-chip "@" menu with design tokens so it renders correctly in dark mode (it previously hardcoded a white background).

--- a/docx-editor/.changeset/smart-chip-escape-dismiss.md
+++ b/docx-editor/.changeset/smart-chip-escape-dismiss.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix Escape not dismissing the smart-chip "@" menu. The handler updated state with a no-op (`setActive(i => i)`), which React bails out of, so the menu stayed open; it now tracks the dismissed trigger in state so Escape reliably closes it.

--- a/docx-editor/.changeset/smart-chip-zoom-fix.md
+++ b/docx-editor/.changeset/smart-chip-zoom-fix.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix the smart-chip "@" menu drifting away from the caret above 100% zoom. It multiplied the already zoom-transformed caret coordinates by the zoom factor again; it now anchors to the caret at any zoom.

--- a/docx-editor/.changeset/smart-chips-date.md
+++ b/docx-editor/.changeset/smart-chips-date.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': minor
+'@casualoffice/docs': minor
 ---
 
 Add a Google-Docs-style smart-chip "@" menu in the body: typing `@` opens a caret-anchored menu, and choosing "Date" inserts a DATE field. Also fixes a measure-cache collision where a field inserted as a paragraph's trailing run (e.g. Insert > Date) stayed invisible until the next keystroke.

--- a/docx-editor/.changeset/spellcheck-debounce.md
+++ b/docx-editor/.changeset/spellcheck-debounce.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Keep spell-check off the typing hot path on large documents. Like the matching grammar change, it now maps existing decorations through each edit and runs the full word re-scan ~350ms after typing pauses, instead of walking the whole document on every keystroke.

--- a/docx-editor/.changeset/table-cell-delete-clears.md
+++ b/docx-editor/.changeset/table-cell-delete-clears.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Delete/Backspace over a multi-cell table selection now clears the selected cells' contents and keeps the table, matching Word and Google Docs. Previously selecting the whole table and pressing Delete removed the entire table.

--- a/docx-editor/.changeset/table-insert-caret.md
+++ b/docx-editor/.changeset/table-insert-caret.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix caret placement after inserting a table: the cursor now lands inside the first cell's paragraph (inline content) instead of on the cell boundary, so you can type into the table immediately. Also removes the "TextSelection endpoint not pointing into a node with inline content" console warning.

--- a/docx-editor/.changeset/table-tab-adds-row.md
+++ b/docx-editor/.changeset/table-tab-adds-row.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Pressing Tab in the last cell of a table now adds a new row and moves the cursor into it, matching Word and Google Docs, instead of inserting a literal tab character.

--- a/docx-editor/.changeset/table-vertical-nav.md
+++ b/docx-editor/.changeset/table-vertical-nav.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix ArrowUp/ArrowDown navigation inside tables: vertical arrows now move to the cell directly above/below in the same column instead of jumping sideways into the neighbouring cell. The caret is placed on the nearest visual row in the arrow direction, then at the column closest to the sticky X.

--- a/docx-editor/.changeset/textbox-overflow-clip.md
+++ b/docx-editor/.changeset/textbox-overflow-clip.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix text boxes clipping multi-line content. A text box whose declared shape height was shorter than its text (common in CJK SDS headers, where 2–3 line boxes declared a ~1-line height) lost the trailing lines to `overflow: hidden`. Text boxes now match Word's fit behavior: `spAutoFit` boxes grow to fit their text, and fixed-size boxes let the text overflow visibly instead of clipping. Decorative divider rules and spacers (no real text) are unchanged.

--- a/docx-editor/.changeset/toolbar-separator-token.md
+++ b/docx-editor/.changeset/toolbar-separator-token.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Use the shared border token for `ToolbarSeparator` instead of a hardcoded `slate` color, so it stays visually consistent with the rest of the toolbar (and with the group dividers) across light/dark themes and any theme retint.

--- a/docx-editor/.changeset/version-history-clarity.md
+++ b/docx-editor/.changeset/version-history-clarity.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': minor
+'@casualoffice/docs': minor
 ---
 
 Rework version history to match Google Docs. The panel is now a single auto-saved timeline (the separate "Activity" / recent-edits tab is gone), and a version is also captured on every explicit save (Ctrl+S / File → Save) in addition to the idle interval. Each entry shows who captured it; auto snapshots read as "Auto-saved" with the time alongside. The in-canvas preview gains up/down controls to step between changes, and the panel states up front that versions save automatically (so the optional "Save version…" reads as name-only).

--- a/docx-editor/.changeset/version-preview-pinned-banner.md
+++ b/docx-editor/.changeset/version-preview-pinned-banner.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 
 Fix the version-preview banner ("Viewing … / Restore this version") scrolling away with the document. It now stays pinned to the viewport (portaled into a viewport-height column wrapping the scroll area), so the cue that you're viewing a past version is always visible; the version list stays visible beside the preview.

--- a/docx-editor/.changeset/workspace-embed-command.md
+++ b/docx-editor/.changeset/workspace-embed-command.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': minor
+'@casualoffice/docs': minor
 ---
 
 Add the casual.command.set.workspace embed command + host API (EmbedHostTransport.sendSetWorkspace) so a host can push plain text from the user's local folder into a shared on-device workspace index; the AI's search_workspace tool then retrieves and cites across those files. Nothing leaves the machine.

--- a/docx-editor/.changeset/workspace-panel-button.md
+++ b/docx-editor/.changeset/workspace-panel-button.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': minor
+'@casualoffice/docs': minor
 ---
 
 DocOps AI panel: on the desktop app, a "Folder" button indexes a local folder for on-device workspace RAG (picks a folder, extracts text via the native shell, populates the workspace index the AI's search_workspace tool searches + cites). Shows an "N indexed" chip; click to clear. Adds a folder icon. Hidden on web/iframe (no desktop shell).

--- a/docx-editor/.changeset/workspace-rag-core.md
+++ b/docx-editor/.changeset/workspace-rag-core.md
@@ -1,5 +1,5 @@
 ---
-'@eigenpal/docx-js-editor': minor
+'@casualoffice/docs': minor
 ---
 
 Add WorkspaceIndex — on-device BM25 retrieval across many documents, returning per-source citations. The reusable core for local "workspace RAG": the host feeds it plain text extracted from local files, and it retrieves relevant passages across all of them without anything leaving the machine.

--- a/docx-editor/CLAUDE.md
+++ b/docx-editor/CLAUDE.md
@@ -346,7 +346,7 @@ Hotfixes → `0.x`. Everything else → `main`.
 
 | Package                        | Path                 | Published?             |
 | ------------------------------ | -------------------- | ---------------------- |
-| `@eigenpal/docx-js-editor`     | `packages/react`     | ✅                     |
+| `@casualoffice/docs`     | `packages/react`     | ✅                     |
 | `@eigenpal/docx-editor-agents` | `packages/agent-use` | ✅                     |
 | `@eigenpal/docx-core`          | `packages/core`      | ❌ private             |
 | `@eigenpal/docx-editor-vue`    | `packages/vue`       | ❌ private / community |
@@ -369,11 +369,11 @@ The frontmatter must use the **full npm package name**, not the repo name or a g
 
 ```markdown
 ---
-'@eigenpal/docx-js-editor': patch
+'@casualoffice/docs': patch
 ---
 ```
 
-Only `@eigenpal/docx-js-editor` needs to be listed — the fixed group in `.changeset/config.json` auto-bumps `@eigenpal/docx-editor-agents` to match. Always run `bun changeset` rather than hand-writing the file; the interactive prompt picks valid names from the workspace. A wrong name (e.g. bare `docx-editor`) does not fail the PR's CI but **crashes the post-merge Release workflow** with `Found changeset X for package Y which is not in the workspace`, blocking all releases until someone edits the bad changeset.
+Only `@casualoffice/docs` needs to be listed — the fixed group in `.changeset/config.json` auto-bumps `@eigenpal/docx-editor-agents` to match. Always run `bun changeset` rather than hand-writing the file; the interactive prompt picks valid names from the workspace. A wrong name (e.g. bare `docx-editor`) does not fail the PR's CI but **crashes the post-merge Release workflow** with `Found changeset X for package Y which is not in the workspace`, blocking all releases until someone edits the bad changeset.
 
 #### Bump levels (semver)
 
@@ -390,7 +390,7 @@ The summary you write (`Add foo prop to DocxEditor`) goes verbatim into `CHANGEL
 1. **Look for an open PR titled `chore: release`** on `main`. The bot opens it automatically the first time a changeset lands; subsequent changeset-bearing PRs update the same PR with the latest bumps and CHANGELOG entries.
 2. **Review the PR.** It shows: version bumps in `package.json`s, new CHANGELOG sections, and the `.md` files being drained from `.changeset/`. Treat it like any other PR — CI runs on it.
 3. **Merge it.** Standard merge. No bypass, no manual workflow trigger needed.
-4. **Wait ~3 minutes.** The post-merge workflow run sees an empty changeset queue, runs `changeset publish` against npm via OIDC Trusted Publishing (no `NPM_TOKEN`), creates per-package git tags (`@eigenpal/docx-js-editor@X.Y.Z`), and creates a GitHub Release with the new CHANGELOG section.
+4. **Wait ~3 minutes.** The post-merge workflow run sees an empty changeset queue, runs `changeset publish` against npm via OIDC Trusted Publishing (no `NPM_TOKEN`), creates per-package git tags (`@casualoffice/docs@X.Y.Z`), and creates a GitHub Release with the new CHANGELOG section.
 
 That's the entire release. One PR merge.
 
@@ -412,7 +412,7 @@ That's the entire release. One PR merge.
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | npmjs.com                | Trusted Publisher configured for both packages → repo `eigenpal/docx-editor`, workflow `release.yml`                                        |
 | `package.json`           | `"publishConfig": { "access": "public" }` on each published package (already set)                                                           |
-| `.changeset/config.json` | `"access": "public"`; `fixed: [["@eigenpal/docx-js-editor", "@eigenpal/docx-editor-agents"]]` (already set)                                 |
+| `.changeset/config.json` | `"access": "public"`; `fixed: [["@casualoffice/docs", "@eigenpal/docx-editor-agents"]]` (already set)                                 |
 | GitHub perms             | Settings → Actions → General → Workflow permissions = **Read and write**, **Allow GitHub Actions to create and approve pull requests** = on |
 | GitHub secrets           | `SLACK_WEBHOOK_URL` (optional — release notifications)                                                                                      |
 


### PR DESCRIPTION
The react package was renamed `@eigenpal/docx-js-editor` → `@casualoffice/docs`, but 67 of 97 pending changesets still used the old name (not in the workspace). That crashes the post-merge Release workflow — confirmed: the last two Release runs failed, and 97 changesets have piled up undrained. This renames all stale changesets + fixes the CLAUDE.md instruction that caused it. No code change; releases unblock on merge.

Follow-up (not in this PR): the CLAUDE.md 'fixed group' / `@eigenpal/docx-editor-agents` references are also stale (config is `fixed: []`, agents package purged).