### PR TITLE
feat(sdk): disabled features veto their command, not just the button

### DIFF
--- a/docx-editor/.changeset/feature-command-veto.md
+++ b/docx-editor/.changeset/feature-command-veto.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Disabling a feature now vetoes its command, not just its toolbar button. When `features={{ bold: false }}` (and likewise italic/underline/strikethrough), the keyboard shortcut (e.g. Ctrl+B) is a no-op and `DocxEditorRef.executeCommand('bold' | 'toggleBold')` returns `false` without mutating the document — matching the hidden button.

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -456,6 +456,8 @@ import {
   DisabledFeaturesContext,
   disabledFeatureSet,
   isFeatureEnabled,
+  isCommandVetoed,
+  createFeatureVetoPlugin,
   type FeatureMap,
 } from './features';
 import { resolveEditorExtensionPlugins, type EditorExtension } from './editorExtensions';
@@ -2053,6 +2055,13 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // (which already encodes the `chrome` preset). `disabledFeatures` drives
   // per-button hiding via context.
   const disabledFeatures = useMemo(() => disabledFeatureSet(features), [features]);
+  // Mirror the live disabled set into a ref so the command layer (keymap veto
+  // plugin + executeCommand) can consult it without re-creating editor state
+  // when `features` changes (docs#289).
+  const disabledFeaturesRef = useRef(disabledFeatures);
+  useEffect(() => {
+    disabledFeaturesRef.current = disabledFeatures;
+  }, [disabledFeatures]);
   const showToolbarEffective = isFeatureEnabled(features, 'toolbar', showToolbar);
   const showPanelRailEffective = isFeatureEnabled(features, 'panelRail', showPanelRail);
   const showStatusBarEffective = isFeatureEnabled(features, 'statusBar', showStatusBar);
@@ -2466,6 +2475,15 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     () => createSuggestionModePlugin(editingMode === 'suggesting', author),
     [] // eslint-disable-line react-hooks/exhaustive-deps
   );
+  // Feature-veto keymap (docs#289): swallows a disabled feature's keyboard
+  // shortcut (e.g. Ctrl+B when `features={{ bold: false }}`). Built once and
+  // reads the live disabled set through the ref, so it never rebuilds editor
+  // state. External plugins run before the extension keymaps, so a vetoed key
+  // is consumed before the real formatting command sees it.
+  const featureVetoPlugin = useMemo(
+    () => createFeatureVetoPlugin(() => disabledFeaturesRef.current),
+    []
+  );
   // Markdown heading shortcut: "# " / "## " / "### " at the start of a plain
   // paragraph applies Heading 1/2/3. Lives at the React layer because applying
   // a heading needs the document's RESOLVED style formatting (font/size/bold)
@@ -2542,6 +2560,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
       // low-level `externalPlugins` escape hatch — a single merged plugin stack.
       resolveEditorExtensionPlugins(
         [
+          featureVetoPlugin,
           suggestionPlugin,
           markdownHeadingPlugin,
           findHighlightPlugin,
@@ -2551,6 +2570,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         editorExtensions
       ),
     [
+      featureVetoPlugin,
       suggestionPlugin,
       markdownHeadingPlugin,
       findHighlightPlugin,
@@ -8915,6 +8935,10 @@ body { background: white; }
       undo: () => pagedEditorRef.current?.undo() ?? false,
       redo: () => pagedEditorRef.current?.redo() ?? false,
       executeCommand: async (id, params) => {
+        // A disabled feature vetoes its command, not just its button (docs#289).
+        // Accepts either the feature id (`bold`) or the command name
+        // (`toggleBold`); returns false without mutating.
+        if (isCommandVetoed(disabledFeaturesRef.current, id)) return false;
         const view = pagedEditorRef.current?.getView();
         if (!view) return false;
         // Route through the same command registry the toolbar/keymap use.

--- a/docx-editor/packages/react/src/components/features.ts
+++ b/docx-editor/packages/react/src/components/features.ts
@@ -17,6 +17,8 @@
  */
 
 import { createContext } from 'react';
+import { keymap } from 'prosemirror-keymap';
+import type { Command, Plugin } from 'prosemirror-state';
 
 /**
  * The published DocxEditor feature-id catalog. Split into coarse chrome regions
@@ -83,3 +85,79 @@ export const EMPTY_DISABLED_FEATURES: ReadonlySet<string> = new Set<string>();
  * buttons exist. Default is the empty set (everything enabled).
  */
 export const DisabledFeaturesContext = createContext<ReadonlySet<string>>(EMPTY_DISABLED_FEATURES);
+
+/**
+ * Feature ids that gate an editing *command*, not just a toolbar button. Each
+ * entry lists the command-registry names (what `DocxEditorRef.executeCommand`
+ * routes through) and the keyboard shortcut keys (what the PM keymap binds) the
+ * feature owns. Disabling the feature must veto BOTH — otherwise hiding the
+ * button still leaves Ctrl+B and `executeCommand('bold')` live (docs#289).
+ *
+ * Only features with a real command/keymap appear here; a UI-only feature such
+ * as `paintFormat` (format painter lives entirely in React) has nothing to
+ * veto and is intentionally absent.
+ */
+export const FEATURE_COMMAND_BINDINGS: Record<
+  string,
+  { readonly commands: readonly string[]; readonly keys: readonly string[] }
+> = {
+  bold: { commands: ['toggleBold'], keys: ['Mod-b'] },
+  italic: { commands: ['toggleItalic'], keys: ['Mod-i'] },
+  underline: { commands: ['toggleUnderline'], keys: ['Mod-u'] },
+  strikethrough: { commands: ['toggleStrike'], keys: ['Mod-Shift-x'] },
+};
+
+/** Reverse index: command-registry name → the feature id that governs it. */
+const COMMAND_TO_FEATURE: ReadonlyMap<string, string> = (() => {
+  const map = new Map<string, string>();
+  for (const [featureId, { commands }] of Object.entries(FEATURE_COMMAND_BINDINGS)) {
+    for (const command of commands) map.set(command, featureId);
+  }
+  return map;
+})();
+
+/**
+ * Whether a command should be vetoed because its feature is disabled. Accepts
+ * either the feature id itself (`bold`) or a command-registry name
+ * (`toggleBold`), so both `executeCommand('bold')` and the canonical
+ * `executeCommand('toggleBold')` are covered.
+ */
+export function isCommandVetoed(
+  disabled: ReadonlySet<string>,
+  commandOrFeatureId: string
+): boolean {
+  if (disabled.size === 0) return false;
+  if (disabled.has(commandOrFeatureId)) return true;
+  const featureId = COMMAND_TO_FEATURE.get(commandOrFeatureId);
+  return featureId != null && disabled.has(featureId);
+}
+
+/**
+ * Build the key → veto-command map for {@link createFeatureVetoPlugin}. Each
+ * binding returns `true` to consume the key as a no-op while its feature is
+ * disabled, or `false` to fall through to the real formatting command when
+ * enabled. Exposed for unit testing the veto contract without a live view.
+ */
+export function buildFeatureVetoBindings(
+  getDisabled: () => ReadonlySet<string>
+): Record<string, Command> {
+  const bindings: Record<string, Command> = {};
+  for (const [featureId, { keys }] of Object.entries(FEATURE_COMMAND_BINDINGS)) {
+    const veto: Command = () => getDisabled().has(featureId);
+    for (const key of keys) bindings[key] = veto;
+  }
+  return bindings;
+}
+
+/**
+ * A ProseMirror keymap plugin that swallows a feature's keyboard shortcut while
+ * that feature is disabled. Bindings read the live disabled set through
+ * `getDisabled` (a ref-backed getter) so the plugin — and therefore the editor
+ * state — stays stable across `features` prop changes.
+ *
+ * Placed ahead of the extension keymaps (external plugins run first), a vetoed
+ * key is consumed before the real formatting command sees it.
+ */
+export function createFeatureVetoPlugin(getDisabled: () => ReadonlySet<string>): Plugin {
+  return keymap(buildFeatureVetoBindings(getDisabled));
+}

--- a/docx-editor/packages/react/src/components/sdkCustomization.test.ts
+++ b/docx-editor/packages/react/src/components/sdkCustomization.test.ts
@@ -11,7 +11,14 @@
 import { describe, expect, it } from 'bun:test';
 import type { Plugin } from 'prosemirror-state';
 
-import { disabledFeatureSet, isFeatureEnabled } from './features';
+import type { Command, EditorState } from 'prosemirror-state';
+
+import {
+  disabledFeatureSet,
+  isFeatureEnabled,
+  isCommandVetoed,
+  buildFeatureVetoBindings,
+} from './features';
 import { resolveEditorExtensionPlugins, type EditorExtension } from './editorExtensions';
 
 // Lightweight stand-ins — resolveEditorExtensionPlugins only moves references.
@@ -47,6 +54,52 @@ describe('features flag-map (docs#272)', () => {
   it('an empty / missing map disables nothing', () => {
     expect(disabledFeatureSet(undefined).size).toBe(0);
     expect(disabledFeatureSet({}).size).toBe(0);
+  });
+});
+
+describe('disabled features veto their command (docs#289)', () => {
+  it('vetoes by feature id and by command name; enabled commands pass', () => {
+    const disabled = disabledFeatureSet({ bold: false, italic: true });
+    // Feature id form (executeCommand('bold')).
+    expect(isCommandVetoed(disabled, 'bold')).toBe(true);
+    // Command-registry name form (executeCommand('toggleBold')).
+    expect(isCommandVetoed(disabled, 'toggleBold')).toBe(true);
+    // An enabled feature is untouched, by either name.
+    expect(isCommandVetoed(disabled, 'italic')).toBe(false);
+    expect(isCommandVetoed(disabled, 'toggleItalic')).toBe(false);
+    // Unknown ids are never vetoed.
+    expect(isCommandVetoed(disabled, 'someOtherCommand')).toBe(false);
+  });
+
+  it('an empty disabled set vetoes nothing', () => {
+    expect(isCommandVetoed(new Set(), 'bold')).toBe(false);
+    expect(isCommandVetoed(new Set(), 'toggleBold')).toBe(false);
+  });
+
+  it('the keymap binding no-ops (returns true, never dispatches) when disabled, else falls through', () => {
+    const disabled = new Set<string>(['bold']);
+    const bindings = buildFeatureVetoBindings(() => disabled);
+    const veto = bindings['Mod-b'] as Command;
+    expect(veto).toBeDefined();
+
+    // Disabled → command consumes the key as a no-op: returns true, no dispatch.
+    let dispatched = false;
+    const dispatch = () => {
+      dispatched = true;
+    };
+    expect(veto({} as EditorState, dispatch)).toBe(true);
+    expect(dispatched).toBe(false);
+
+    // Enabled (feature removed from the live set) → falls through: returns false
+    // so the real formatting command downstream runs.
+    disabled.delete('bold');
+    expect(veto({} as EditorState, dispatch)).toBe(false);
+    expect(dispatched).toBe(false);
+  });
+
+  it('binds a key for every feature that owns a keyboard shortcut', () => {
+    const bindings = buildFeatureVetoBindings(() => new Set());
+    expect(Object.keys(bindings).sort()).toEqual(['Mod-Shift-x', 'Mod-b', 'Mod-i', 'Mod-u'].sort());
   });
 });
 


### PR DESCRIPTION
Follow-up to #289. A disabled feature (`features={{ bold: false }}`) hid its toolbar button but its command still fired — Ctrl+B and `executeCommand('bold')` both mutated the doc.

Now a disabled feature also vetoes its command:
- A ref-backed keymap plugin (placed ahead of the extension keymaps) swallows the shortcut (Mod-b/i/u, Mod-Shift-x) as a no-op while the feature is disabled, and falls through to the real command when enabled.
- `DocxEditorRef.executeCommand` returns `false` without mutating for a disabled feature, accepting either the feature id (`bold`) or the command name (`toggleBold`).

The live disabled set is mirrored into a ref so `features` changes never rebuild editor state. Covers bold/italic/underline/strikethrough (the features with a command/keymap); `paintFormat` is UI-only with nothing to veto.

Unit tests in `sdkCustomization.test.ts` prove the veto contract for both paths.