### PR TITLE
feat(sdk): declarative collab object + full imperative handle from renderAsync (reconcile doc 38)

### DIFF
--- a/docx-editor/.changeset/sdk-contract-reconcile.md
+++ b/docx-editor/.changeset/sdk-contract-reconcile.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': minor
+---
+
+Reconcile the SDK surface with the unified contract (doc 38). `CasualEditor` gains a declarative `collab` object — `collab={{ server, room, user }}` — matching the shape Casual Sheets ships; it drives the collab session (`server` is the WS URL, `room` the room id, `user` the presence identity) and wins over the now-`@deprecated` `backendUrl`/`user` pair when both are given. `collab.password`/`token`/`role` are accepted for cross-SDK parity but reserved (not yet wired). The `renderAsync` imperative handle now also exposes the unified surface — `on`/`off`, `executeCommand`, `getContent`/`setContent`, `undo`/`redo`, and `setDocumentMode` — delegating to the underlying editor so the vanilla mount matches the React ref. All additive; existing methods and props are unchanged.

--- a/docx-editor/packages/react/src/components/CasualEditor.test.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.test.tsx
@@ -12,7 +12,7 @@
  */
 import { describe, expect, it } from 'bun:test';
 
-import type { CasualEditorRef } from './CasualEditor';
+import type { CasualEditorProps, CasualEditorRef } from './CasualEditor';
 
 describe('CasualEditor SDK shape', () => {
   it('CasualEditorRef declares the SDK-level methods', () => {
@@ -39,6 +39,43 @@ describe('CasualEditor SDK shape', () => {
       r.off('dirtyChange', () => {});
     };
     expect(typeof _expectShape).toBe('function');
+  });
+
+  it('accepts the declarative collab object (doc 38 §6) with server + room + user', () => {
+    // Type-level: the wrapper takes the same `collab` shape sheets ships.
+    // Field names must match Sheets (server / room / user) so the "one
+    // contract" claim holds. server + room are the wired fields.
+    const withCollab: CasualEditorProps = {
+      fileSource: {} as CasualEditorProps['fileSource'],
+      docId: 'doc-1',
+      collab: {
+        server: 'wss://collab.example/yjs',
+        room: 'room-42',
+        user: { name: 'Ada', color: '#f00' },
+      },
+    };
+    expect(withCollab.collab?.server).toBe('wss://collab.example/yjs');
+    expect(withCollab.collab?.room).toBe('room-42');
+    expect(withCollab.collab?.user?.name).toBe('Ada');
+
+    // Reserved-for-parity fields are accepted by the type (not yet wired).
+    const reserved: NonNullable<CasualEditorProps['collab']> = {
+      server: 'wss://x/yjs',
+      room: 'r',
+      password: 'pw',
+      token: 'tok',
+      role: 'view',
+    };
+    expect(reserved.role).toBe('view');
+
+    // `backendUrl` still works as the deprecated alias.
+    const legacy: CasualEditorProps = {
+      fileSource: {} as CasualEditorProps['fileSource'],
+      docId: 'doc-1',
+      backendUrl: 'wss://collab.example/yjs',
+      user: { name: 'Ada', color: '#f00' },
+    };
+    expect(legacy.backendUrl).toBe('wss://collab.example/yjs');
   });
 
   it("collabStatus returns 'standalone' when collab is off (sentinel value, not undefined)", () => {

--- a/docx-editor/packages/react/src/components/CasualEditor.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.tsx
@@ -92,12 +92,58 @@ export interface CasualEditorProps {
    * the wrapper enables Yjs collab — the editor renders with
    * `externalPlugins` from `useCollab` and `externalContent` true.
    * When omitted, the editor runs standalone (no collab plugins).
+   *
+   * @deprecated Use {@link collab} (doc 38 §6) — the declarative collab
+   * object shared with Casual Sheets. `backendUrl` stays as an alias:
+   * `backendUrl='wss://…'` is equivalent to `collab={{ server: 'wss://…',
+   * room: docId }}`. When both are given, `collab` wins.
    */
   backendUrl?: string;
+  /**
+   * Declarative collab config (doc 38 §6) — the single shape shared with
+   * Casual Sheets' `collab` prop. When present it drives the collab setup:
+   * `collab.server` is the WS/backend URL, `collab.room` is the room id
+   * (used instead of `docId` for presence / DocOps / the Share link), and
+   * `collab.user` is the presence identity. Omit for single-user.
+   *
+   * Takes precedence over the deprecated `backendUrl` / `user` pair when both
+   * are supplied. Byte load + autosave still key off `docId`; only the live
+   * collab room keys off `collab.room`.
+   */
+  collab?: {
+    /** Base WebSocket URL of the collab server, e.g. `wss://host/yjs`. */
+    server: string;
+    /** Room / document id for the live session. Falls back to `docId` when omitted upstream. */
+    room: string;
+    /** Presence identity for collab awareness (display name + cursor color). */
+    user?: { name: string; color: string };
+    /**
+     * Room password.
+     * @remarks Reserved for cross-SDK parity with Casual Sheets' `collab.password`
+     * (doc 38 §6). NOT yet wired — docs' `useCollab` path has no password handshake.
+     * TODO(docs#267): thread through once the docs collab client supports it.
+     */
+    password?: string;
+    /**
+     * Auth token for the Hocuspocus handshake.
+     * @remarks Reserved for parity with Sheets' `collab.token` (doc 38 §6). NOT yet
+     * wired in docs. TODO(docs#267): thread through the WS preflight.
+     */
+    token?: string;
+    /**
+     * `'view'` joins read-only; default `'write'`.
+     * @remarks Reserved for parity with Sheets' `collab.role` (doc 38 §6). NOT yet
+     * wired in docs. TODO(docs#267): map to the read-only document mode.
+     */
+    role?: 'view' | 'write';
+  };
   /**
    * Local user identity for collab awareness. Required when
    * `backendUrl` is set; ignored otherwise. Drive supplies the
    * signed-in user's display name + a per-user color.
+   *
+   * @deprecated Prefer `collab.user` (doc 38 §6). Still honored for the
+   * `backendUrl` path; `collab.user` wins when both are given.
    */
   user?: { name: string; color: string };
   /**
@@ -211,6 +257,7 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
       fileSource,
       docId,
       backendUrl,
+      collab,
       user,
       autosave = false,
       autosaveInterval = 30000,
@@ -268,15 +315,23 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
     // Collab — opt-in via backendUrl
     // ---------------------------------------------------------------
 
+    // Reconcile the declarative `collab` object (doc 38 §6) with the legacy
+    // `backendUrl` / `user` pair. `collab` wins when both are supplied; the
+    // room defaults to `docId` so the byte-load path (which keys off `docId`)
+    // and the live session stay aligned unless the host overrides the room.
+    const collabBackend = collab?.server ?? backendUrl;
+    const collabRoom = collab?.room ?? docId;
+    const collabUser = collab?.user ?? user;
+
     // The hook MUST be called unconditionally to obey rules-of-hooks;
     // we pass sentinel values when collab is off and ignore the
     // returned plugins. The destructured plugins are an empty array
     // in standalone mode because we never wire them to DocxEditor.
     const collabState = useCollabSafe({
-      enabled: !!backendUrl,
-      backend: backendUrl ?? '',
-      room: docId,
-      user: user ?? { name: 'Anonymous', color: '#94a3b8' },
+      enabled: !!collabBackend,
+      backend: collabBackend ?? '',
+      room: collabRoom,
+      user: collabUser ?? { name: 'Anonymous', color: '#94a3b8' },
     });
 
     useEffect(() => {
@@ -411,7 +466,7 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
         features={features}
         editorExtensions={editorExtensions}
         renderTitleBarRight={renderCollabPresence}
-        docopsTransport={createDocOpsTransport({ collabWsUrl: backendUrl, room: docId })}
+        docopsTransport={createDocOpsTransport({ collabWsUrl: collabBackend, room: collabRoom })}
         ai={ai}
         {...docxEditorProps}
       />
@@ -436,7 +491,7 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
     // positioned, so it never disturbs the editor layout when closed.
     const shareDialog =
       collabState && !onShare ? (
-        <ShareDialog isOpen={shareOpen} onClose={() => setShareOpen(false)} roomId={docId} />
+        <ShareDialog isOpen={shareOpen} onClose={() => setShareOpen(false)} roomId={collabRoom} />
       ) : null;
 
     // In collab mode, show the default reconnecting/offline banner

--- a/docx-editor/packages/react/src/renderAsync.test.ts
+++ b/docx-editor/packages/react/src/renderAsync.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Bun smoke tests for the renderAsync imperative handle. The real mount
+ * needs a DOM + createRoot, which bun-test isn't the harness for; these
+ * tests pin the handle's SDK contract at the type level so the vanilla
+ * mount stays at parity with the React DocxEditorRef (doc 38 §4).
+ */
+import { describe, expect, it } from 'bun:test';
+
+import type { DocxEditorHandle } from './renderAsync';
+
+describe('renderAsync handle shape', () => {
+  it('exposes the unified imperative surface (on/off/executeCommand/...)', () => {
+    // Type-level check — if renderAsync ever stops surfacing these, this
+    // file won't compile.
+    const _expectShape = (h: DocxEditorHandle) => {
+      // Pre-existing slim handle
+      void h.save();
+      h.focus();
+      h.getDocument();
+      h.setZoom(1.5);
+      h.scrollToParaId('1A2B3C4D');
+      h.scrollToPosition(42);
+      h.destroy();
+      // Unified imperative surface (doc 38 §4) — new on renderAsync.
+      const off = h.on('change', () => {});
+      off();
+      h.off('dirtyChange', () => {});
+      void h.executeCommand('toggleBold');
+      const doc = h.getContent();
+      if (doc) h.setContent(doc);
+      h.undo();
+      h.redo();
+      h.setDocumentMode('viewing');
+    };
+    expect(typeof _expectShape).toBe('function');
+  });
+});

--- a/docx-editor/packages/react/src/renderAsync.ts
+++ b/docx-editor/packages/react/src/renderAsync.ts
@@ -27,7 +27,14 @@
 
 import React from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { DocxEditor, type DocxEditorProps, type DocxEditorRef } from './components/DocxEditor';
+import {
+  DocxEditor,
+  type DocxEditorProps,
+  type DocxEditorRef,
+  type DocxEditorEventName,
+  type DocxEditorEvents,
+  type EditorMode,
+} from './components/DocxEditor';
 import type { DocxInput } from '@eigenpal/docx-core/utils';
 import type { Document } from '@eigenpal/docx-core/types/document';
 import type { EditorHandle } from '@eigenpal/docx-core';
@@ -40,7 +47,10 @@ export type RenderAsyncOptions = Omit<DocxEditorProps, 'documentBuffer' | 'docum
 
 /**
  * React-specific handle that extends the framework-agnostic EditorHandle
- * with zoom control.
+ * with zoom control plus the unified imperative surface (doc 38 §4) so the
+ * vanilla `renderAsync` mount reaches parity with the React `DocxEditorRef`:
+ * the `.on()/.off()` emitter, `executeCommand`, `getContent`/`setContent`,
+ * `undo`/`redo`, and `setDocumentMode`.
  */
 export interface DocxEditorHandle extends EditorHandle {
   /** Set zoom level (1.0 = 100%). */
@@ -49,6 +59,28 @@ export interface DocxEditorHandle extends EditorHandle {
   scrollToParaId: (paraId: string) => boolean;
   /** Scroll to a raw ProseMirror document position. */
   scrollToPosition: (pmPos: number) => void;
+  /**
+   * Subscribe to a canonical editor event (doc 38 §3). Returns a disposer that
+   * removes the listener. Mirrors {@link DocxEditorRef.on}.
+   */
+  on: <K extends DocxEditorEventName>(name: K, handler: DocxEditorEvents[K]) => () => void;
+  /** Remove a listener previously registered with {@link on}. */
+  off: <K extends DocxEditorEventName>(name: K, handler: DocxEditorEvents[K]) => void;
+  /**
+   * Execute a registered editor command by id (e.g. `'toggleBold'`). Resolves to
+   * whether the command applied; unknown ids resolve to `false`.
+   */
+  executeCommand: (id: string, params?: unknown) => Promise<boolean>;
+  /** Get the current document, or null before the editor has mounted. */
+  getContent: () => Document | null;
+  /** Replace the document with a pre-parsed one. */
+  setContent: (content: Document) => void;
+  /** Undo the last edit. Returns whether anything was undone. */
+  undo: () => boolean;
+  /** Redo the last undone edit. Returns whether anything was redone. */
+  redo: () => boolean;
+  /** Switch the document mode (`'editing'` | `'suggesting'` | `'viewing'`). */
+  setDocumentMode: (mode: EditorMode) => void;
 }
 
 /**
@@ -88,6 +120,18 @@ export function renderAsync(
       setZoom: (z) => ref.current?.setZoom(z),
       scrollToParaId: (paraId: string) => ref.current?.scrollToParaId(paraId) ?? false,
       scrollToPosition: (pmPos: number) => ref.current?.scrollToPosition(pmPos),
+      // Unified imperative surface (doc 38 §4) — delegate to the underlying ref
+      // so the vanilla mount matches the React DocxEditorRef. Each method
+      // no-ops with a safe default when the editor hasn't mounted yet.
+      on: (name, handler) => ref.current?.on(name, handler) ?? (() => {}),
+      off: (name, handler) => ref.current?.off(name, handler),
+      executeCommand: (id, params) =>
+        ref.current?.executeCommand(id, params) ?? Promise.resolve(false),
+      getContent: () => ref.current?.getContent() ?? null,
+      setContent: (content) => ref.current?.setContent(content),
+      undo: () => ref.current?.undo() ?? false,
+      redo: () => ref.current?.redo() ?? false,
+      setDocumentMode: (mode) => ref.current?.setDocumentMode(mode),
       destroy: () => {
         root?.unmount();
         root = null;


### PR DESCRIPTION
Closes the two API-reconciliation gaps the SDK consumer guide (#290) surfaced between the shipped docs SDK and doc 38, so the "one contract, both editors, both mount styles" claim holds.

**Gap 1 — declarative `collab` object.** `CasualEditor` gains `collab={{ server, room, user }}`, matching the shape Casual Sheets ships. When present it drives the collab setup: `collab.server` is the WS/backend URL, `collab.room` is the live-session room id (used for presence, DocOps, and the Share link instead of `docId`), and `collab.user` is the presence identity. `backendUrl`/`user` still work and are marked `@deprecated`; `collab` wins when both are given. Byte load + autosave continue to key off `docId`. `collab.password`/`token`/`role` are accepted for cross-SDK field-name parity but reserved — docs' `useCollab` path has no password/token/role handshake, so they are documented as not-yet-wired (TODO), not silently ignored plumbing.

**Gap 2 — unified handle from `renderAsync`.** The imperative mount handle now exposes `on`/`off`, `executeCommand`, `getContent`/`setContent`, `undo`/`redo`, and `setDocumentMode`, delegating to the underlying editor ref so the vanilla mount reaches parity with the React `DocxEditorRef`. Existing slim-handle methods are unchanged.

Additive + deprecated-alias only; no existing export removed or renamed. Includes a `minor` changeset and focused type-level tests for both gaps.