### PR TITLE
fix(ci): amd64-only Docker build on release tags; multi-arch on-demand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,16 @@ on:
     tags:
       - 'v*.*.*'
       - 'v*.*.*-*'
+  # Manual re-build of an already-released tag. A tag push builds amd64
+  # only (fast); dispatch this with the tag input to rebuild that tag as
+  # full multi-arch (amd64+arm64) on-demand, so arm64 never blocks a
+  # release: gh workflow run release.yml -f tag=v0.0.4
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build for multi-arch, e.g. v0.0.4'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -35,6 +45,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          # On a manual dispatch GITHUB_REF_NAME is the branch, so check
+          # out the requested tag; on a tag push this resolves to the tag.
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
           # Design-system tokens (submodule) ride into the Docker build
           # context for the editor's CSS build.
           submodules: recursive
@@ -42,7 +55,9 @@ jobs:
       - name: Resolve version
         id: ver
         run: |
-          tag="${GITHUB_REF_NAME}"
+          # Prefer the dispatched `tag` input (manual multi-arch rebuild);
+          # fall back to the pushed tag ref for the normal release path.
+          tag="${{ github.event.inputs.tag || github.ref_name }}"
           version="${tag#v}"
           if [[ "$tag" == *-* ]]; then
             prerelease=true
@@ -77,7 +92,10 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          # Tag push → amd64 only (fast; arm64 under QEMU adds ~60 min and
+          # was blocking releases). Manual dispatch → full multi-arch, so
+          # arm64 is available on-demand without gating the release.
+          platforms: ${{ github.event_name == 'workflow_dispatch' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -110,6 +128,9 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: docker
+    # Only on the tag-push release path. A manual dispatch is just an
+    # on-demand multi-arch image rebuild; the GitHub Release already exists.
+    if: github.event_name != 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Problem

arm64-under-QEMU multi-arch Docker builds take ~60 min and were blocking releases on every tag push.

## Change

- Tag push -> amd64 only (fast).
- Manual workflow_dispatch with a `tag` input -> full multi-arch (amd64+arm64), on-demand, so arm64 never gates a release.

The build step platforms are now conditional:

```yaml
platforms: ${{ github.event_name == 'workflow_dispatch' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
```

To publish an arm64 manifest for a released tag: `gh workflow run release.yml -f tag=vX.Y.Z`.

`release.yml` was previously tag-push only, so this PR also:
- adds a `workflow_dispatch` with an optional `tag` input (description: "Tag to build for multi-arch, e.g. v0.0.4"),
- makes the checkout `ref` and the version-resolve prefer that tag when dispatched (falls back to the pushed tag ref on the normal release path),
- guards the `github-release` job to skip on dispatch (the GitHub Release already exists; a dispatch is just an on-demand image rebuild).

YAML validated with `yaml.safe_load`. Diff is minimal and surgical; the existing tag-push release path and the Docker Hub description sync are unchanged.