### PR TITLE
feat(sdk): wire collab.token through to the Hocuspocus handshake

### DIFF
--- a/docx-editor/.changeset/collab-token-wiring.md
+++ b/docx-editor/.changeset/collab-token-wiring.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': minor
+---
+
+CasualEditor now threads `collab.token` through to the Hocuspocus handshake (previously reserved/unwired). Hosts with a JWT-protected collab server — e.g. Drive minting a per-file room token — can pass `collab={{ server, room, user, token }}` and the token reaches the provider's onAuthenticate hook.

--- a/docx-editor/packages/react/src/components/CasualEditor.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.tsx
@@ -125,9 +125,9 @@ export interface CasualEditorProps {
      */
     password?: string;
     /**
-     * Auth token for the Hocuspocus handshake.
-     * @remarks Reserved for parity with Sheets' `collab.token` (doc 38 §6). NOT yet
-     * wired in docs. TODO(docs#267): thread through the WS preflight.
+     * Auth token for the Hocuspocus handshake — passed to the provider's
+     * `onAuthenticate` hook. Hosts with a JWT-protected collab server (e.g.
+     * Drive mints a per-file room token) supply it here.
      */
     token?: string;
     /**
@@ -322,6 +322,7 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
     const collabBackend = collab?.server ?? backendUrl;
     const collabRoom = collab?.room ?? docId;
     const collabUser = collab?.user ?? user;
+    const collabToken = collab?.token;
 
     // The hook MUST be called unconditionally to obey rules-of-hooks;
     // we pass sentinel values when collab is off and ignore the
@@ -332,6 +333,7 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
       backend: collabBackend ?? '',
       room: collabRoom,
       user: collabUser ?? { name: 'Anonymous', color: '#94a3b8' },
+      token: collabToken,
     });
 
     useEffect(() => {
@@ -541,6 +543,7 @@ function useCollabSafe(args: {
   backend: string;
   room: string;
   user: { name: string; color: string };
+  token?: string;
 }): CollabState | null {
   if (!args.enabled) {
     // Hook order is fixed for the lifetime of the component — if
@@ -549,7 +552,12 @@ function useCollabSafe(args: {
     return null;
   }
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  return useCollab({ backend: args.backend, room: args.room, user: args.user });
+  return useCollab({
+    backend: args.backend,
+    room: args.room,
+    user: args.user,
+    token: args.token,
+  });
 }
 
 // Flex-column wrapper used only when the reconnect banner is visible,


### PR DESCRIPTION
useCollab already supported a token (→ HocuspocusProvider); CasualEditor's declarative collab.token was reserved/unwired. Thread it through so JWT-protected collab hosts (e.g. Drive's per-file room token) work via collab={{server,room,user,token}}. Unblocks the doc-hub native collab integration.