### PR TITLE
feat(sdk): chrome:'embedded' — formatting toolbar only, no app shell

### DIFF
--- a/docx-editor/.changeset/embedded-chrome.md
+++ b/docx-editor/.changeset/embedded-chrome.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': minor
+---
+
+Add `chrome="embedded"` — a formatting-toolbar-only surface for hosts that render their own app shell. It keeps the editing UI (formatting toolbar, panel rail, zoom, ruler) but hides the app shell: logo, document-name row, menu bar, and the About / Help / File menus that live inside them. Cmd/Ctrl+O and Cmd/Ctrl+N are suppressed (the host owns open/new); Cmd/Ctrl+S still routes to `onSave` when provided. The shell rows can also be toggled independently of the toolbar via the new `features.titleBar` / `features.menuBar` ids.

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -458,6 +458,7 @@ import {
   isFeatureEnabled,
   isCommandVetoed,
   createFeatureVetoPlugin,
+  resolveChromeVisibility,
   type FeatureMap,
 } from './features';
 import { resolveEditorExtensionPlugins, type EditorExtension } from './editorExtensions';
@@ -639,12 +640,20 @@ export interface DocxEditorProps {
    *   - `"full"` (default): batteries-included shell — toolbar + status bar +
    *     panel rail + zoom. For 3rd-party hosts.
    *   - `"minimal"`: lean editing surface — toolbar + zoom only.
+   *   - `"embedded"`: formatting-toolbar-only surface for hosts that render
+   *     their own app shell (doc 39 — embedded-mode contract). Same editing UI
+   *     as `"full"` (formatting toolbar, panel rail, zoom, ruler) but the app
+   *     shell — logo, document-name row, menu bar, and therefore the About /
+   *     Help / File menus — is hidden, so the host's chrome is the only shell.
+   *     Cmd/Ctrl+O and Cmd/Ctrl+N are suppressed (the host owns open/new);
+   *     Cmd/Ctrl+S still routes to `onSave` when provided.
    *   - `"none"`: bare editing canvas, no built-in chrome — the host brings its
    *     own shell and consumes the editor core.
    * Any explicit `showToolbar` / `showStatusBar` / `showPanelRail` /
-   * `showZoomControl` prop overrides the preset.
+   * `showZoomControl` prop overrides the preset; `features.titleBar` /
+   * `features.menuBar` override the shell visibility independently.
    */
-  chrome?: 'none' | 'minimal' | 'full';
+  chrome?: 'none' | 'minimal' | 'embedded' | 'full';
   /**
    * Per-control on/off map (docs#272, doc 38 §5a) — the shared shape the sister
    * sheet SDK uses. Each key is a control id (see `DOCX_FEATURE_IDS`); `false`
@@ -2062,7 +2071,26 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   useEffect(() => {
     disabledFeaturesRef.current = disabledFeatures;
   }, [disabledFeatures]);
-  const showToolbarEffective = isFeatureEnabled(features, 'toolbar', showToolbar);
+  // App-shell rows (title bar + menu bar) sit above the formatting toolbar and
+  // are gated independently of the toolbar so an embedding host can hide its own
+  // second shell while keeping the formatting toolbar (doc 39). `chrome:"embedded"`
+  // defaults the shell off; `features.titleBar` / `features.menuBar` override in
+  // any preset.
+  const {
+    toolbar: showToolbarEffective,
+    titleBar: showTitleBarEffective,
+    menuBar: showMenuBarEffective,
+    appShellHidden,
+  } = resolveChromeVisibility(chrome, features, showToolbar);
+  // When the app shell is hidden the host owns file identity/lifecycle, so the
+  // file-management keybindings (Cmd/Ctrl+O open, Cmd/Ctrl+N new) are suppressed
+  // (doc 39, issue #301). Mirrored into a ref so the stable keydown listener can
+  // read it without re-subscribing. Cmd/Ctrl+S is untouched — it already routes
+  // to `onSave` when set.
+  const appShellHiddenRef = useRef(appShellHidden);
+  useEffect(() => {
+    appShellHiddenRef.current = appShellHidden;
+  }, [appShellHidden]);
   const showPanelRailEffective = isFeatureEnabled(features, 'panelRail', showPanelRail);
   const showStatusBarEffective = isFeatureEnabled(features, 'statusBar', showStatusBar);
   const showZoomControlEffective = isFeatureEnabled(features, 'zoomControl', showZoomControl);
@@ -4109,15 +4137,20 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
           e.preventDefault();
           shortcutActionsRef.current.print?.();
         } else if (e.key.toLowerCase() === 'n') {
-          // Mod+N: New document. Only honor if the host opted in via onNew.
-          if (shortcutActionsRef.current.new) {
+          // Mod+N: New document. Suppressed when the app shell is hidden
+          // (embedded) — the host owns new. Otherwise only honor if the host
+          // opted in via onNew.
+          if (!appShellHiddenRef.current && shortcutActionsRef.current.new) {
             e.preventDefault();
             shortcutActionsRef.current.new();
           }
         } else if (e.key.toLowerCase() === 'o') {
-          // Mod+O: Open file picker
-          e.preventDefault();
-          shortcutActionsRef.current.open?.();
+          // Mod+O: Open file picker. Suppressed when the app shell is hidden
+          // (embedded) — the host owns open, so leave the event for it.
+          if (!appShellHiddenRef.current) {
+            e.preventDefault();
+            shortcutActionsRef.current.open?.();
+          }
         } else if (e.key === '\\') {
           // Mod+\\: Clear formatting (Google Docs convention)
           const view = pagedEditorRef.current?.getView();
@@ -9848,22 +9881,24 @@ body { background: white; }
                         tableContext={state.pmTableContext}
                         onTableAction={handleTableAction}
                       >
-                        <EditorToolbar.TitleBar>
-                          {renderLogo && <EditorToolbar.Logo>{renderLogo()}</EditorToolbar.Logo>}
-                          {documentName !== undefined && (
-                            <EditorToolbar.DocumentName
-                              value={documentName}
-                              onChange={onDocumentNameChange}
-                              editable={documentNameEditable}
-                            />
-                          )}
-                          {renderTitleBarRight && (
-                            <EditorToolbar.TitleBarRight>
-                              {renderTitleBarRight()}
-                            </EditorToolbar.TitleBarRight>
-                          )}
-                          <EditorToolbar.MenuBar />
-                        </EditorToolbar.TitleBar>
+                        {showTitleBarEffective && (
+                          <EditorToolbar.TitleBar>
+                            {renderLogo && <EditorToolbar.Logo>{renderLogo()}</EditorToolbar.Logo>}
+                            {documentName !== undefined && (
+                              <EditorToolbar.DocumentName
+                                value={documentName}
+                                onChange={onDocumentNameChange}
+                                editable={documentNameEditable}
+                              />
+                            )}
+                            {renderTitleBarRight && (
+                              <EditorToolbar.TitleBarRight>
+                                {renderTitleBarRight()}
+                              </EditorToolbar.TitleBarRight>
+                            )}
+                            {showMenuBarEffective && <EditorToolbar.MenuBar />}
+                          </EditorToolbar.TitleBar>
+                        )}
                         <EditorToolbar.FormattingBar>{toolbarChildren}</EditorToolbar.FormattingBar>
                       </EditorToolbar>
                     </div>

--- a/docx-editor/packages/react/src/components/features.ts
+++ b/docx-editor/packages/react/src/components/features.ts
@@ -29,6 +29,14 @@ import type { Command, Plugin } from 'prosemirror-state';
 export const DOCX_FEATURE_IDS = [
   // ── Coarse chrome regions (deprecated show* booleans map to these) ──
   'toolbar',
+  // The app-shell rows that sit above the formatting toolbar. Gated
+  // independently of `toolbar` so an embedding host can hide the shell
+  // (logo + document name + menus + About/Help) while keeping the
+  // formatting toolbar (doc 39 — embedded-mode contract). `titleBar` is the
+  // whole top row (logo/name/menus); `menuBar` is just the File/Edit/… menus
+  // inside it, so a host can keep the title row but drop the menus.
+  'titleBar',
+  'menuBar',
   'panelRail',
   'statusBar',
   'zoomControl',
@@ -63,6 +71,48 @@ export function isFeatureEnabled(
     return features[id];
   }
   return fallback;
+}
+
+/**
+ * Resolved visibility of the top chrome rows for a `chrome` preset + `features`
+ * overrides (doc 39 — embedded-mode contract). The formatting toolbar and the
+ * app shell (title bar + menu bar) are gated *independently*: the `"embedded"`
+ * preset hides the shell by default while keeping the toolbar, so an embedding
+ * host renders one shell (its own) plus the editor's formatting toolbar — not
+ * the "two shells" that a shared `toolbar` gate produced. Centralized here so
+ * the DocxEditor render gate and its unit tests share one source of truth.
+ */
+export interface ChromeVisibility {
+  /** The formatting toolbar (bold/italic/font/…). Hidden only by `chrome:"none"`. */
+  toolbar: boolean;
+  /** The top row: logo + document name + menu bar. Hidden by `chrome:"embedded"`. */
+  titleBar: boolean;
+  /** The File/Edit/… menus inside the title row. Hidden by `chrome:"embedded"`. */
+  menuBar: boolean;
+  /**
+   * True when the whole app shell (title bar + menu bar) is gone — the host owns
+   * file identity/lifecycle, so the SDK suppresses Cmd/Ctrl+O and Cmd/Ctrl+N.
+   */
+  appShellHidden: boolean;
+}
+
+/**
+ * Resolve {@link ChromeVisibility} from the `chrome` preset and `features` map.
+ * `showToolbarFallback` is the toolbar default the preset/`showToolbar` prop
+ * already encoded. `features.titleBar` / `features.menuBar` override the shell
+ * in any preset, so a host can also opt into the bare surface without the
+ * preset (`features={{ titleBar: false, menuBar: false }}`).
+ */
+export function resolveChromeVisibility(
+  chrome: string | undefined,
+  features: FeatureMap | undefined,
+  showToolbarFallback: boolean
+): ChromeVisibility {
+  const toolbar = isFeatureEnabled(features, 'toolbar', showToolbarFallback);
+  const shellShownByDefault = chrome !== 'embedded';
+  const titleBar = isFeatureEnabled(features, 'titleBar', shellShownByDefault);
+  const menuBar = isFeatureEnabled(features, 'menuBar', shellShownByDefault);
+  return { toolbar, titleBar, menuBar, appShellHidden: !titleBar && !menuBar };
 }
 
 /** The set of feature ids explicitly disabled (`features[id] === false`). */

--- a/docx-editor/packages/react/src/components/sdkCustomization.test.ts
+++ b/docx-editor/packages/react/src/components/sdkCustomization.test.ts
@@ -18,6 +18,7 @@ import {
   isFeatureEnabled,
   isCommandVetoed,
   buildFeatureVetoBindings,
+  resolveChromeVisibility,
 } from './features';
 import { resolveEditorExtensionPlugins, type EditorExtension } from './editorExtensions';
 
@@ -54,6 +55,65 @@ describe('features flag-map (docs#272)', () => {
   it('an empty / missing map disables nothing', () => {
     expect(disabledFeatureSet(undefined).size).toBe(0);
     expect(disabledFeatureSet({}).size).toBe(0);
+  });
+});
+
+describe('embedded chrome — toolbar without the app shell (doc 39)', () => {
+  // Mirrors the `showToolbar` default the DocxEditor prop destructure encodes
+  // (`chrome === 'none' ? false : true`) so the fallback matches the component.
+  const toolbarFallback = (chrome: string | undefined) => chrome !== 'none';
+
+  it('chrome:"embedded" shows the formatting toolbar but hides title bar + menu bar', () => {
+    const v = resolveChromeVisibility('embedded', undefined, toolbarFallback('embedded'));
+    expect(v.toolbar).toBe(true); // formatting toolbar stays
+    expect(v.titleBar).toBe(false); // logo + document name + menus gone
+    expect(v.menuBar).toBe(false); // File/Edit/… menus (and About/Help) gone
+    expect(v.appShellHidden).toBe(true); // → suppress Cmd+O / Cmd+N
+  });
+
+  it('chrome:"full" (and default) keeps the whole shell', () => {
+    for (const chrome of ['full', undefined] as const) {
+      const v = resolveChromeVisibility(chrome, undefined, toolbarFallback(chrome));
+      expect(v.toolbar).toBe(true);
+      expect(v.titleBar).toBe(true);
+      expect(v.menuBar).toBe(true);
+      expect(v.appShellHidden).toBe(false);
+    }
+  });
+
+  it('chrome:"minimal" keeps the shell (only "embedded" hides it)', () => {
+    const v = resolveChromeVisibility('minimal', undefined, toolbarFallback('minimal'));
+    expect(v.titleBar).toBe(true);
+    expect(v.menuBar).toBe(true);
+    expect(v.appShellHidden).toBe(false);
+  });
+
+  it('features={{ titleBar:false, menuBar:false }} hides the shell in any preset, toolbar stays', () => {
+    const v = resolveChromeVisibility('full', { titleBar: false, menuBar: false }, true);
+    expect(v.toolbar).toBe(true);
+    expect(v.titleBar).toBe(false);
+    expect(v.menuBar).toBe(false);
+    expect(v.appShellHidden).toBe(true);
+  });
+
+  it('features can keep the title row but drop only the menus (title bar shown, appShell not "hidden")', () => {
+    const v = resolveChromeVisibility('full', { menuBar: false }, true);
+    expect(v.titleBar).toBe(true);
+    expect(v.menuBar).toBe(false);
+    // Title row still present → not the full embedded shell, so Cmd+O/N stay.
+    expect(v.appShellHidden).toBe(false);
+  });
+
+  it('features override the embedded default — a host can force the shell back on', () => {
+    const v = resolveChromeVisibility('embedded', { titleBar: true, menuBar: true }, true);
+    expect(v.titleBar).toBe(true);
+    expect(v.menuBar).toBe(true);
+    expect(v.appShellHidden).toBe(false);
+  });
+
+  it('chrome:"none" also hides the toolbar (unchanged behavior)', () => {
+    const v = resolveChromeVisibility('none', undefined, toolbarFallback('none'));
+    expect(v.toolbar).toBe(false);
   });
 });
 


### PR DESCRIPTION
Adds a `chrome="embedded"` preset (and `features.titleBar` / `features.menuBar` ids) that render the formatting toolbar without the SDK's app shell — no logo, document-name row, menu bar, or the About/Help/File menus inside them. Previously the app shell and the formatting toolbar shared one gate (`showToolbarEffective`), so a host couldn't hide its second shell without losing the toolbar (doc 39, the "two shells" problem).

The title bar and menu bar are now resolved independently of the toolbar via `resolveChromeVisibility()`. In embedded mode the panel rail, zoom, and ruler stay (editing UI). When the app shell is hidden the host owns file identity, so Cmd/Ctrl+O and Cmd/Ctrl+N no-op; Cmd/Ctrl+S is unchanged (still routes to `onSave`).

Additive: `full`/`minimal`/`none` and existing `features` are unchanged.