### PR TITLE
fix(editor): coalesce font-load relayout (click flicker + Linux OOM) + caret size

### DIFF
--- a/docx-editor/.changeset/font-relayout-caret.md
+++ b/docx-editor/.changeset/font-relayout-caret.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix click-time canvas flicker and Linux out-of-memory caused by font loading. Each font `loadingdone` event previously triggered a synchronous, cache-clearing full relayout; a document pulling in many `@font-face` subsets plus the icon font produced a burst of full re-measures (visible as flicker on click, and an OOM on Linux). Font-load relayouts are now coalesced through the existing rAF scheduler with a trailing debounce and gated to the families the document actually uses. Also size the text caret to the run's font metrics (~1.2× font-size, centered) instead of the full line-box height, so the caret is no longer 1.5–2× too tall at increased line spacing.

--- a/docx-editor/e2e/font-relayout-storm.spec.ts
+++ b/docx-editor/e2e/font-relayout-storm.spec.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Empirical repro for issue #303.
+ *
+ * BUG 1 — font-load relayout storm: every FontFaceSet `loadingdone` event (one
+ * per @font-face variant, plus the Material Symbols icon font and UI-chrome
+ * fonts) used to trigger a synchronous, cache-nuking full relayout that rebuilt
+ * the page DOM. K font faces = K page rebuilds (O(K×N)) — visible as click-time
+ * flicker and, on Linux, an OOM. The fix coalesces a burst of *relevant* events
+ * into a single relayout and gates out icon/UI-font events entirely.
+ *
+ * We measure page rebuilds directly with a MutationObserver on
+ * `.paged-editor__pages` (each full relayout repaints its subtree). The load
+ * cascade is simulated deterministically by dispatching `loadingdone` events on
+ * `document.fonts`, so the assertion doesn't depend on network/font timing:
+ *
+ *   - K synthetic events with no faces (always pass the relevance gate) must
+ *     collapse to a small, bounded number of relayout batches (1–2), NOT K.
+ *   - K synthetic events for a font the document does NOT use must produce ZERO
+ *     relayouts (the relevance gate drops icon/UI-font events).
+ *   - At steady state, clicking must cause ZERO page rebuilds (the pre-existing
+ *     pure-selection-change guard must keep working).
+ *
+ * BUG 2 — caret sized to the full line box: at line-spacing > 1 the caret was
+ * 1.5–2× too tall. We assert the caret height tracks the run's font-size, not
+ * the line box, at 1.5 line spacing.
+ */
+
+import { test, expect } from '@playwright/test';
+import { EditorPage } from './helpers';
+
+const SYNTHETIC_EVENTS = 15;
+
+// Install a MutationObserver that counts page-rebuild "batches" (observer
+// callbacks that add/remove page or line nodes under `.paged-editor__pages`).
+// Each full relayout repaints the subtree → one batch. Returns raw record and
+// batch counters plus reset/read hooks on window.__RELAYOUT_PROBE__.
+async function installProbe(page: import('@playwright/test').Page): Promise<void> {
+  await page.evaluate(() => {
+    const container = document.querySelector('.paged-editor__pages');
+    if (!container) throw new Error('.paged-editor__pages not found');
+    const state = { records: 0, batches: 0 };
+    const touchesPages = (n: Node): boolean => {
+      const el = n as HTMLElement;
+      if (!el.classList) return false;
+      return (
+        el.classList.contains('layout-page') ||
+        el.classList.contains('layout-line') ||
+        !!el.querySelector?.('.layout-page, .layout-line')
+      );
+    };
+    const observer = new MutationObserver((records) => {
+      let batchTouched = false;
+      for (const r of records) {
+        if (r.type !== 'childList') continue;
+        const added = Array.from(r.addedNodes).some(touchesPages);
+        const removed = Array.from(r.removedNodes).some(touchesPages);
+        if (added || removed) {
+          state.records += 1;
+          batchTouched = true;
+        }
+      }
+      if (batchTouched) state.batches += 1;
+    });
+    observer.observe(container, { childList: true, subtree: true });
+    (window as unknown as { __RELAYOUT_PROBE__: unknown }).__RELAYOUT_PROBE__ = {
+      reset: () => {
+        state.records = 0;
+        state.batches = 0;
+      },
+      read: () => ({ ...state }),
+    };
+  });
+}
+
+async function readProbe(page: import('@playwright/test').Page): Promise<{
+  records: number;
+  batches: number;
+}> {
+  return page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __RELAYOUT_PROBE__: { read: () => { records: number; batches: number } };
+        }
+      ).__RELAYOUT_PROBE__.read()
+  );
+}
+
+async function resetProbe(page: import('@playwright/test').Page): Promise<void> {
+  await page.evaluate(() =>
+    (window as unknown as { __RELAYOUT_PROBE__: { reset: () => void } }).__RELAYOUT_PROBE__.reset()
+  );
+}
+
+test.describe('issue #303 — font-load relayout storm + caret size', () => {
+  test('load cascade coalesces to a bounded relayout count, gates UI fonts, and clicks stay 0', async ({
+    page,
+  }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.loadDocxFile('fixtures/complex-styles.docx');
+    await editor.waitForReady();
+    // Ensure any real font-load activity has fully settled before measuring.
+    await page.evaluate(() => document.fonts.ready);
+    await page.waitForTimeout(300);
+
+    await installProbe(page);
+
+    // (a) Steady-state click must cause ZERO page rebuilds (pure-selection guard).
+    await resetProbe(page);
+    const box = await page.locator('.layout-page').first().boundingBox();
+    if (box) {
+      await page.mouse.click(box.x + box.width / 2, box.y + box.height / 3);
+    }
+    await page.waitForTimeout(250);
+    const afterClick = await readProbe(page);
+    expect(afterClick.batches, 'steady-state click page rebuilds').toBe(0);
+
+    // (b) Relevance gate: K events for a font the doc does NOT use → 0 relayouts.
+    await resetProbe(page);
+    await page.evaluate((n) => {
+      for (let i = 0; i < n; i++) {
+        const e = new Event('loadingdone');
+        Object.defineProperty(e, 'fontfaces', {
+          value: [{ family: '__NotADocumentFont__' }],
+        });
+        document.fonts.dispatchEvent(e);
+      }
+    }, SYNTHETIC_EVENTS);
+    await page.waitForTimeout(400);
+    const gated = await readProbe(page);
+    expect(gated.batches, 'gated (irrelevant-font) relayouts').toBe(0);
+
+    // (c) Coalescing: K relevant events (no faces → always pass gate) → 1 relayout.
+    await resetProbe(page);
+    await page.evaluate((n) => {
+      for (let i = 0; i < n; i++) {
+        // A plain event has no `fontfaces`, so the relevance gate treats the
+        // faces as unknown and relays out — exactly the pre-fix trigger path.
+        document.fonts.dispatchEvent(new Event('loadingdone'));
+      }
+    }, SYNTHETIC_EVENTS);
+    await page.waitForTimeout(400);
+    const coalesced = await readProbe(page);
+
+    // Pre-fix: each of the K events ran a synchronous relayout → ~K batches.
+    // Post-fix: the burst collapses into a single trailing relayout.
+    expect(
+      coalesced.batches,
+      `coalesced relayouts for ${SYNTHETIC_EVENTS} font events`
+    ).toBeGreaterThan(0);
+    expect(
+      coalesced.batches,
+      `coalesced relayouts for ${SYNTHETIC_EVENTS} font events`
+    ).toBeLessThanOrEqual(2);
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[#303 repro] ${SYNTHETIC_EVENTS} synthetic font-load events → ` +
+        `${coalesced.batches} relayout batch(es), ${coalesced.records} page-mutation record(s); ` +
+        `gated events → ${gated.batches}; steady-state click → ${afterClick.batches}`
+    );
+  });
+
+  test('caret height tracks the run font, not the line box, at 1.5 line spacing', async ({
+    page,
+  }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.loadDocxFile('fixtures/complex-styles.docx');
+    await editor.waitForReady();
+
+    // Apply 1.5 line spacing to the whole document so the line box is clearly
+    // taller than the glyph height — the case that used to make the caret 1.5×
+    // too tall.
+    await page.keyboard.press('Control+a');
+    await editor.setLineSpacing('1.5');
+    await page.waitForTimeout(200);
+
+    // Place the caret inside a painted text run.
+    const runBox = await page.locator('.layout-page .layout-run').first().boundingBox();
+    expect(runBox).not.toBeNull();
+    if (!runBox) return;
+    await page.mouse.click(runBox.x + 2, runBox.y + runBox.height / 2);
+    await page.waitForTimeout(150);
+
+    const measured = await page.evaluate(() => {
+      const caret = document.querySelector('[data-testid="caret"]') as HTMLElement | null;
+      if (!caret) return null;
+      const caretHeight = parseFloat(caret.style.height);
+      // The run nearest the caret x/y — read its rendered font-size and its line
+      // box height for comparison.
+      const runs = Array.from(
+        document.querySelectorAll('.layout-page .layout-run')
+      ) as HTMLElement[];
+      const cr = caret.getBoundingClientRect();
+      let best: HTMLElement | null = null;
+      let bestDist = Infinity;
+      for (const r of runs) {
+        const rr = r.getBoundingClientRect();
+        const dx = Math.max(rr.left - cr.left, cr.left - rr.right, 0);
+        const dy = Math.max(rr.top - cr.top, cr.top - rr.bottom, 0);
+        const d = dx + dy;
+        if (d < bestDist) {
+          bestDist = d;
+          best = r;
+        }
+      }
+      if (!best) return null;
+      const fontSize = parseFloat(getComputedStyle(best).fontSize);
+      const lineEl = best.closest('.layout-line') as HTMLElement | null;
+      const lineHeight = lineEl ? lineEl.offsetHeight : 0;
+      return { caretHeight, fontSize, lineHeight };
+    });
+
+    expect(measured).not.toBeNull();
+    if (!measured) return;
+    const { caretHeight, fontSize, lineHeight } = measured;
+
+    // Caret ≈ 1.2× the run font-size (≈ ascent + descent), NOT the full line box.
+    expect(caretHeight).toBeGreaterThan(fontSize * 0.9);
+    expect(caretHeight).toBeLessThan(fontSize * 1.6);
+    // With 1.5 line spacing the line box is meaningfully taller than the caret.
+    expect(caretHeight).toBeLessThan(lineHeight);
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[#303 caret] fontSize=${fontSize.toFixed(1)}px caretHeight=${caretHeight.toFixed(
+        1
+      )}px lineHeight=${lineHeight.toFixed(1)}px (ratio caret/font=${(caretHeight / fontSize).toFixed(
+        2
+      )})`
+    );
+  });
+});

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -115,7 +115,7 @@ import {
   type CaretPosition,
 } from '@eigenpal/docx-core/layout-bridge';
 import { findWordBoundaries } from '@eigenpal/docx-core/utils';
-import { emuToPixels, pixelsToEmu } from '@eigenpal/docx-core/utils';
+import { emuToPixels, pixelsToEmu, getGoogleFontEquivalent } from '@eigenpal/docx-core/utils';
 
 // Layout painter
 import { LayoutPainter, type BlockLookup } from '@eigenpal/docx-core/layout-painter';
@@ -1437,6 +1437,117 @@ function isWithinSidebar(target: EventTarget | null): boolean {
   return !!(el?.closest('.docx-comments-sidebar') || el?.closest('.docx-unified-sidebar'));
 }
 
+// =============================================================================
+// FONT-LOAD RELAYOUT (issue #303)
+// =============================================================================
+
+/**
+ * Trailing debounce for coalescing a burst of font `loadingdone` events into a
+ * single relayout. A document that pulls in ~20 @font-face subsets plus the
+ * Material Symbols icon font fires many events over a second or two; without
+ * coalescing each one triggered a synchronous, cache-nuking full relayout
+ * (O(K×N) — visible as click-time flicker, and an OOM on Linux where the font
+ * set is larger and the Google CDN is disabled so subsets keep retrying).
+ */
+const FONT_RELAYOUT_DEBOUNCE_MS = 150;
+
+/** Caret height as a multiple of the run's font-size (≈ ascent + descent). */
+const CARET_HEIGHT_RATIO = 1.2;
+
+/** Fallback caret font-size in px (12pt) when none can be read from the DOM. */
+const DEFAULT_CARET_FONT_PX = 16;
+
+/** Normalise a font family for set membership: strip quotes, trim, lowercase. */
+function normalizeFamily(name: string): string {
+  return name.replace(/['"]/g, '').trim().toLowerCase();
+}
+
+/**
+ * Collect the set of font families the document can actually paint — the
+ * original DOCX names plus their bundled/Google equivalents (e.g. Calibri and
+ * Carlito). Used to gate the font-load relayout so icon/UI-chrome font events
+ * (Material Symbols, app UI) — which never affect body-text measurement — don't
+ * trigger a relayout. Walks tables recursively.
+ */
+function collectDocFontFamilies(blocks: FlowBlock[]): Set<string> {
+  const set = new Set<string>();
+  const add = (fam?: string) => {
+    if (!fam) return;
+    const norm = normalizeFamily(fam);
+    if (!norm) return;
+    set.add(norm);
+    set.add(normalizeFamily(getGoogleFontEquivalent(fam)));
+  };
+  const walk = (bs: FlowBlock[]): void => {
+    for (const block of bs) {
+      if (block.kind === 'paragraph') {
+        add(block.attrs?.defaultFontFamily);
+        for (const run of block.runs) {
+          if ('fontFamily' in run) add(run.fontFamily);
+        }
+      } else if (block.kind === 'table') {
+        for (const row of block.rows) {
+          for (const cell of row.cells) walk(cell.blocks);
+        }
+      }
+    }
+  };
+  walk(blocks);
+  return set;
+}
+
+/**
+ * True when at least one just-loaded font face belongs to a family the document
+ * uses. When the document set is empty (initial load, before blocks exist) or
+ * the faces can't be identified, returns true so we stay correct and relayout.
+ */
+function facesAffectDocument(
+  faces: ReadonlyArray<FontFace> | undefined,
+  docFamilies: Set<string>
+): boolean {
+  if (docFamilies.size === 0) return true;
+  if (!faces || faces.length === 0) return true;
+  for (const face of faces) {
+    if (docFamilies.has(normalizeFamily(face.family))) return true;
+  }
+  return false;
+}
+
+/** Read a rendered font-size (px, pre-transform) from an element. */
+function readFontSizePx(el: Element | null, fallback: number = DEFAULT_CARET_FONT_PX): number {
+  if (!el) return fallback;
+  const view = el.ownerDocument?.defaultView;
+  if (!view) return fallback;
+  const px = parseFloat(view.getComputedStyle(el).fontSize);
+  return Number.isFinite(px) && px > 0 ? px : fallback;
+}
+
+/**
+ * Caret geometry sized to the run at the caret, not the full line box. At
+ * line-spacing > 1 the line box is 1.5–2× the glyph height, and a line can hold
+ * a taller neighbouring run — using `lineEl.offsetHeight` for the caret height
+ * made the caret that much too tall (issue #303). Height ≈ 1.2× the caret run's
+ * font-size; the caret is vertically centred within the line box. All values in
+ * layout (pre-zoom-transform) px, matching the existing overlay coordinate space.
+ */
+function caretYAndHeight(
+  fallbackTopClient: number,
+  lineEl: HTMLElement | null,
+  overlayRect: DOMRect,
+  currentZoom: number,
+  fontSizePx: number
+): { y: number; height: number } {
+  const height = fontSizePx * CARET_HEIGHT_RATIO;
+  if (lineEl) {
+    const lineRect = lineEl.getBoundingClientRect();
+    const lineTop = (lineRect.top - overlayRect.top) / currentZoom;
+    // offsetHeight is the untransformed layout height, already in layout px.
+    const lineHeight = lineEl.offsetHeight;
+    return { y: lineTop + Math.max(0, lineHeight - height) / 2, height };
+  }
+  return { y: (fallbackTopClient - overlayRect.top) / currentZoom, height };
+}
+
 /**
  * PagedEditor - Main paginated editing component.
  */
@@ -2407,13 +2518,19 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               const spanRect = spanEl.getBoundingClientRect();
               const pageEl = spanEl.closest('.layout-page');
               const pageIndex = pageEl ? Number((pageEl as HTMLElement).dataset.pageNumber) - 1 : 0;
-              const lineEl = spanEl.closest('.layout-line');
-              const lineHeight = lineEl ? (lineEl as HTMLElement).offsetHeight : 16;
+              const lineEl = spanEl.closest('.layout-line') as HTMLElement | null;
+              const { y, height } = caretYAndHeight(
+                spanRect.top,
+                lineEl,
+                overlayRect,
+                currentZoom,
+                readFontSizePx(spanEl)
+              );
 
               return {
                 x: (spanRect.left - overlayRect.left) / currentZoom,
-                y: (spanRect.top - overlayRect.top) / currentZoom,
-                height: lineHeight,
+                y,
+                height,
                 pageIndex,
               };
             }
@@ -2442,14 +2559,20 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             const pageEl = spanEl.closest('.layout-page');
             const pageIndex = pageEl ? Number((pageEl as HTMLElement).dataset.pageNumber) - 1 : 0;
 
-            // Get line height from the line element or use default
-            const lineEl = spanEl.closest('.layout-line');
-            const lineHeight = lineEl ? (lineEl as HTMLElement).offsetHeight : 16;
+            // Caret height tracks the run's font, not the full line box.
+            const lineEl = spanEl.closest('.layout-line') as HTMLElement | null;
+            const { y, height } = caretYAndHeight(
+              rangeRect.top,
+              lineEl,
+              overlayRect,
+              currentZoom,
+              readFontSizePx(spanEl)
+            );
 
             return {
               x: (rangeRect.left - overlayRect.left) / currentZoom,
-              y: (rangeRect.top - overlayRect.top) / currentZoom,
-              height: lineHeight,
+              y,
+              height,
               pageIndex,
             };
           }
@@ -2468,13 +2591,22 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             const runRect = emptyRun.getBoundingClientRect();
             const pageEl = paragraph.closest('.layout-page');
             const pageIndex = pageEl ? Number((pageEl as HTMLElement).dataset.pageNumber) - 1 : 0;
-            const lineEl = emptyRun.closest('.layout-line');
-            const lineHeight = lineEl ? (lineEl as HTMLElement).offsetHeight : 16;
+            const lineEl = emptyRun.closest('.layout-line') as HTMLElement | null;
+            // Empty paragraph: size the caret to the paragraph's resolved run
+            // font (from the empty run, falling back to the paragraph), not 16px.
+            const fontSizePx = readFontSizePx(emptyRun, readFontSizePx(paragraph));
+            const { y, height } = caretYAndHeight(
+              runRect.top,
+              lineEl,
+              overlayRect,
+              currentZoom,
+              fontSizePx
+            );
 
             return {
               x: (runRect.left - overlayRect.left) / currentZoom,
-              y: (runRect.top - overlayRect.top) / currentZoom,
-              height: lineHeight,
+              y,
+              height,
               pageIndex,
             };
           }
@@ -4513,25 +4645,61 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       [runLayoutPipeline, updateSelectionOverlay, readOnly]
     );
 
-    // Re-layout when web fonts finish loading to fix measurements that were
-    // computed against fallback fonts during initial render.
-    // Uses FontFaceSet.onloadingdone to detect when new fonts complete loading.
+    // Latest scheduleLayout + the document's font-family set, read from the
+    // long-lived font-load listener below without re-subscribing on every
+    // render (the effect deps must stay [] so we don't tear down/re-add the
+    // listener mid-session and miss lazily-loaded weight/style variants).
+    const scheduleLayoutRef = useRef(scheduleLayout);
+    const docFontFamiliesRef = useRef<Set<string>>(new Set());
     useEffect(() => {
-      const handleFontsLoaded = () => {
+      scheduleLayoutRef.current = scheduleLayout;
+    }, [scheduleLayout]);
+    useEffect(() => {
+      docFontFamiliesRef.current = collectDocFontFamilies(blocks);
+    }, [blocks]);
+
+    // Re-layout when web fonts finish loading, so measurements computed against
+    // fallback fonts during initial render are corrected once the real glyphs
+    // decode. FontFaceSet fires `loadingdone` once per completed batch of faces
+    // — for EVERY font: the ~20 @font-face body-font variants, the Material
+    // Symbols icon font, and UI-chrome fonts, plus each weight/style variant
+    // separately. The previous handler ran a synchronous, cache-nuking full
+    // relayout per event: K faces = K re-measures + K page rebuilds (O(K×N)),
+    // visible as click-time flicker and, on Linux (larger font set + Google CDN
+    // disabled so subsets keep retrying), an OOM (issue #303).
+    //
+    // Instead: (1) gate out faces the document doesn't use — drops all
+    // icon/UI-font events; (2) coalesce a burst of relevant events into a single
+    // trailing relayout via debounce + rAF; (3) clear caches once per flush, not
+    // per event. Kept as a session-long subscription (not a one-shot
+    // `fonts.ready`) because bold/italic variants load lazily the first time
+    // such a run is painted, well after the initial settle.
+    useEffect(() => {
+      let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const flush = () => {
+        debounceTimer = null;
         const view = hiddenPMRef.current?.getView();
-        if (view) {
-          // Clear all cached measurements — font metrics have changed
-          resetCanvasContext();
-          clearAllCaches();
-          runLayoutPipeline(view.state);
-          updateSelectionOverlay(view.state);
-        }
+        if (!view) return;
+        // Font metrics changed — drop cached measurements once, then re-measure.
+        resetCanvasContext();
+        clearAllCaches();
+        // scheduleLayout coalesces via rAF; the layout→overlay effect refreshes
+        // the caret/selection against fresh geometry once the pipeline runs.
+        scheduleLayoutRef.current(view.state);
       };
 
-      // Listen for font loading completion events
+      const handleFontsLoaded = (event: Event) => {
+        const faces = (event as FontFaceSetLoadEvent).fontfaces;
+        if (!facesAffectDocument(faces, docFontFamiliesRef.current)) return;
+        if (debounceTimer !== null) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(flush, FONT_RELAYOUT_DEBOUNCE_MS);
+      };
+
       window.document.fonts.addEventListener('loadingdone', handleFontsLoaded);
       return () => {
         window.document.fonts.removeEventListener('loadingdone', handleFontsLoaded);
+        if (debounceTimer !== null) clearTimeout(debounceTimer);
       };
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);


### PR DESCRIPTION
Fixes #303. Clicking the canvas triggered a re-render storm — each font `loadingdone` fired a synchronous, cache-nuking full relayout, so a doc pulling in ~20 @font-face subsets + the icon font produced K full re-measures (flicker; OOM on Linux where the set is larger and the CDN is disabled). Now coalesced through the existing rAF scheduler + a 150ms trailing debounce, gated to the document's own font families. Separately, the caret was sized to the full line-box height (1.5–2× too tall at line-spacing>1); now sized to the run's font metrics (~1.2× font-size, centered). typecheck + 410 unit tests green.