### PR TITLE
fix(sdk): chrome:"embedded" keeps the editing menus, not just the toolbar

### DIFF
--- a/docx-editor/.changeset/embedded-keep-editing-menus.md
+++ b/docx-editor/.changeset/embedded-keep-editing-menus.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix `chrome:"embedded"` hiding the editing menus. The embedded resolver welded the menu-bar default to the app-shell default, so embedded stripped the whole menu bar — stranding the ~50 features that live only there (Insert image/table, Format paragraph, Tools word-count, …). Embedded now keeps the formatting toolbar AND the editing menus, dropping only the app shell: the logo/document-name row and the host-owned File/Help entries (Open/New/Version-history/About). Hosts can still force either region with `features={{ menuBar, titleBar }}`.

--- a/docx-editor/e2e/tests/embedded-chrome.spec.ts
+++ b/docx-editor/e2e/tests/embedded-chrome.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Embedded-mode chrome (doc 39).
+ *
+ * `chrome:"embedded"` must keep the EDITING SURFACE — the formatting toolbar
+ * AND the editing menus (Insert/Format/Tools/View/…) — while dropping only the
+ * app shell (logo + document-name row, and the host-owned File/Help entries).
+ *
+ * Regression guard: an earlier embedded resolver welded the menu-bar default to
+ * the app-shell default, so embedded hid the whole menu bar and stranded ~50
+ * menu-only features. This locks the split.
+ */
+import { test, expect } from '@playwright/test';
+
+import { EditorPage } from '../helpers/editor-page';
+
+async function open(page: import('@playwright/test').Page, chrome: string) {
+  await page.goto(`/?e2e=1&chrome=${chrome}`);
+  const editor = new EditorPage(page);
+  await editor.waitForReady();
+  // NB: don't call editor.newDocument() — it drives File▸New, which embedded
+  // mode prunes (the host owns file lifecycle). The chrome mounts on load.
+  return editor;
+}
+
+test.describe('chrome:"embedded"', () => {
+  test('keeps the formatting toolbar AND the editing menus', async ({ page }) => {
+    await open(page, 'embedded');
+
+    // Editing surface present: the formatting toolbar…
+    await expect(page.locator('[data-testid="toolbar-bold"]')).toBeVisible();
+    // …and the editing menus (the features that were stranded).
+    const titleBar = page.locator('[data-testid="title-bar"]');
+    await expect(titleBar).toBeVisible();
+    for (const menu of ['Insert', 'Format', 'Tools']) {
+      await expect(titleBar.getByRole('button', { name: menu, exact: true })).toBeVisible();
+    }
+  });
+
+  test('drops the app shell — no document-name row, no About', async ({ page }) => {
+    await open(page, 'embedded');
+    // The document-name input (app shell) is gone.
+    await expect(page.getByLabel('Document name')).toHaveCount(0);
+    // Host-owned/branding menu entries pruned: no "About", no "Open".
+    const titleBar = page.locator('[data-testid="title-bar"]');
+    await titleBar.getByRole('button', { name: 'Help', exact: true }).click().catch(() => {});
+    await expect(page.getByRole('menuitem', { name: /About/i })).toHaveCount(0);
+  });
+
+  test('screenshots: embedded light + dark', async ({ page }) => {
+    await open(page, 'embedded');
+    await page.screenshot({ path: 'screenshots/embedded-chrome-light.png' });
+    await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
+    await page.waitForTimeout(300);
+    await page.screenshot({ path: 'screenshots/embedded-chrome-dark.png' });
+  });
+});
+
+test.describe('chrome:"full" (control — unchanged)', () => {
+  test('keeps the full app shell (document name + File menu)', async ({ page }) => {
+    await open(page, 'full');
+    await expect(page.getByLabel('Document name')).toBeVisible();
+    const titleBar = page.locator('[data-testid="title-bar"]');
+    await expect(titleBar.getByRole('button', { name: 'File', exact: true })).toBeVisible();
+    await page.screenshot({ path: 'screenshots/embedded-chrome-full-control.png' });
+  });
+});

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -508,6 +508,16 @@ export function App() {
     []
   );
 
+  // Dev/e2e affordance: `?chrome=embedded|minimal|none|full` exercises the
+  // chrome presets (doc 39 embedded-mode contract) without a separate harness.
+  // Absent → undefined → the editor's default full shell (unchanged behavior).
+  const chromeParam = useMemo(() => {
+    const c = new URLSearchParams(window.location.search).get('chrome');
+    return c === 'embedded' || c === 'minimal' || c === 'none' || c === 'full'
+      ? (c as 'embedded' | 'minimal' | 'none' | 'full')
+      : undefined;
+  }, []);
+
   // Collab mode: detected from `?room=<docId>&backend=<wsUrl>`. The
   // GitHub Pages build leaves these blank and stays single-user;
   // the Docker-Hub image's frontend defaults `backend` to its own
@@ -1555,6 +1565,7 @@ export function App() {
           mentionableUsers={mentionableUsers}
           onError={handleError}
           onFontsLoaded={handleFontsLoaded}
+          chrome={chromeParam}
           showToolbar={true}
           showRuler={!isMobile}
           showZoomControl={true}

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -2091,6 +2091,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   useEffect(() => {
     appShellHiddenRef.current = appShellHidden;
   }, [appShellHidden]);
+  // The top chrome (formatting toolbar + editing menu bar) renders unless the
+  // host stripped BOTH regions, or we're in read-only / focus mode. Either
+  // region alone is enough — `chrome:"embedded"` keeps the menus with the
+  // title row hidden (doc 39).
+  const showEditorChrome =
+    (showToolbarEffective || showMenuBarEffective) && !readOnlyProp && !focusMode;
   const showPanelRailEffective = isFeatureEnabled(features, 'panelRail', showPanelRail);
   const showStatusBarEffective = isFeatureEnabled(features, 'statusBar', showStatusBar);
   const showZoomControlEffective = isFeatureEnabled(features, 'zoomControl', showZoomControl);
@@ -9774,7 +9780,7 @@ body { background: white; }
                   {/* Toolbar - above the scroll container so scrollbar doesn't extend behind it */}
                   {/* Hide toolbar only when readOnly prop is explicitly set (not from viewing mode) */}
                   {/* Focus mode (Phase 5) also hides toolbar for distraction-free writing. */}
-                  {showToolbarEffective && !readOnlyProp && !focusMode && (
+                  {showEditorChrome && (
                     <div
                       ref={toolbarRefCallback}
                       className="z-50 flex flex-col gap-0 flex-shrink-0"
@@ -9800,14 +9806,24 @@ body { background: white; }
                         showPrintButton={showPrintButtonEffective}
                         fontFamilies={fontFamilies}
                         onPrint={handleDirectPrint}
-                        onOpen={handleOpenDocument}
+                        /* When the app shell is hidden (embedded), the host
+                          owns file identity/lifecycle and versions — prune the
+                          File-menu entries it provides so the editing menus
+                          stay without a redundant "second product" File menu.
+                          A MenuBar item disappears when its callback is
+                          undefined (presence-gated). */
+                        onOpen={appShellHidden ? undefined : handleOpenDocument}
                         onSave={handleDownloadDocument}
-                        onMakeCopy={handleMakeCopy}
-                        onEmailAsAttachment={handleEmailAsAttachment}
-                        onOpenVersionHistory={() => {
-                          if (!showVersionHistory) handleToggleVersionHistory();
-                        }}
-                        onNew={onNew}
+                        onMakeCopy={appShellHidden ? undefined : handleMakeCopy}
+                        onEmailAsAttachment={appShellHidden ? undefined : handleEmailAsAttachment}
+                        onOpenVersionHistory={
+                          appShellHidden
+                            ? undefined
+                            : () => {
+                                if (!showVersionHistory) handleToggleVersionHistory();
+                              }
+                        }
+                        onNew={appShellHidden ? undefined : onNew}
                         showZoomControl={showZoomControlEffective}
                         zoom={state.zoom}
                         onZoomChange={handleZoomChange}
@@ -9848,8 +9864,9 @@ body { background: white; }
                         onExportPdf={handleExportPdf}
                         onExportOdt={handleExportOdt}
                         onExportMd={handleExportMd}
-                        onReportBug={handleReportBug}
-                        onShowAbout={handleShowAbout}
+                        /* Branding/support entries the host owns in embedded. */
+                        onReportBug={appShellHidden ? undefined : handleReportBug}
+                        onShowAbout={appShellHidden ? undefined : handleShowAbout}
                         onOpenCommandPalette={() => setShowCommandPalette(true)}
                         onOpenKeyboardShortcuts={() => setShowKeyboardShortcuts(true)}
                         onOpenPreferences={() => setShowPreferences(true)}
@@ -9881,17 +9898,24 @@ body { background: white; }
                         tableContext={state.pmTableContext}
                         onTableAction={handleTableAction}
                       >
-                        {showTitleBarEffective && (
+                        {/* The title row (logo + document name) is the app
+                          shell — hidden in `chrome:"embedded"`. The menu bar is
+                          the editing surface, gated independently, so embedded
+                          keeps the Insert/Format/Tools/… menus while dropping
+                          only the logo/name row (doc 39). */}
+                        {(showTitleBarEffective || showMenuBarEffective) && (
                           <EditorToolbar.TitleBar>
-                            {renderLogo && <EditorToolbar.Logo>{renderLogo()}</EditorToolbar.Logo>}
-                            {documentName !== undefined && (
+                            {showTitleBarEffective && renderLogo && (
+                              <EditorToolbar.Logo>{renderLogo()}</EditorToolbar.Logo>
+                            )}
+                            {showTitleBarEffective && documentName !== undefined && (
                               <EditorToolbar.DocumentName
                                 value={documentName}
                                 onChange={onDocumentNameChange}
                                 editable={documentNameEditable}
                               />
                             )}
-                            {renderTitleBarRight && (
+                            {showTitleBarEffective && renderTitleBarRight && (
                               <EditorToolbar.TitleBarRight>
                                 {renderTitleBarRight()}
                               </EditorToolbar.TitleBarRight>
@@ -9899,7 +9923,11 @@ body { background: white; }
                             {showMenuBarEffective && <EditorToolbar.MenuBar />}
                           </EditorToolbar.TitleBar>
                         )}
-                        <EditorToolbar.FormattingBar>{toolbarChildren}</EditorToolbar.FormattingBar>
+                        {showToolbarEffective && (
+                          <EditorToolbar.FormattingBar>
+                            {toolbarChildren}
+                          </EditorToolbar.FormattingBar>
+                        )}
                       </EditorToolbar>
                     </div>
                   )}

--- a/docx-editor/packages/react/src/components/TitleBar.tsx
+++ b/docx-editor/packages/react/src/components/TitleBar.tsx
@@ -1197,10 +1197,17 @@ export function TitleBar({ children }: TitleBarProps) {
       onMouseDown={handleMouseDown}
       data-testid="title-bar"
     >
-      {/* Left: Logo spanning full height (default doc icon if none provided) */}
-      <div className="flex items-center flex-shrink-0 pl-3 pr-1">
-        {logoItem || <DefaultDocIcon />}
-      </div>
+      {/* Left: Logo spanning full height (default doc icon if none provided).
+        In embedded mode the host hides the app shell — no Logo and no
+        DocumentName are passed, leaving only the menu bar — so the default
+        doc icon must NOT leak in as branding. Show it only when the title row
+        carries app-shell content (a document name); otherwise the menus stand
+        alone (doc 39). */}
+      {(logoItem || middleTopItems.length > 0) && (
+        <div className="flex items-center flex-shrink-0 pl-3 pr-1">
+          {logoItem || <DefaultDocIcon />}
+        </div>
+      )}
 
       {/* Center: doc name on top, menus below */}
       <div className="flex flex-col justify-center flex-1 min-w-0 py-1 overflow-hidden">

--- a/docx-editor/packages/react/src/components/features.ts
+++ b/docx-editor/packages/react/src/components/features.ts
@@ -85,13 +85,19 @@ export function isFeatureEnabled(
 export interface ChromeVisibility {
   /** The formatting toolbar (bold/italic/font/…). Hidden only by `chrome:"none"`. */
   toolbar: boolean;
-  /** The top row: logo + document name + menu bar. Hidden by `chrome:"embedded"`. */
+  /** The title row: logo + document name. Hidden by `chrome:"embedded"`. */
   titleBar: boolean;
-  /** The File/Edit/… menus inside the title row. Hidden by `chrome:"embedded"`. */
+  /**
+   * The File/Edit/Insert/Format/… menus. Part of the editing surface, so they
+   * stay in `chrome:"embedded"` and are hidden only by `chrome:"none"`. In
+   * embedded the host-owned File/Help entries (Open/New/About/…) are pruned,
+   * but every editing menu remains.
+   */
   menuBar: boolean;
   /**
-   * True when the whole app shell (title bar + menu bar) is gone — the host owns
-   * file identity/lifecycle, so the SDK suppresses Cmd/Ctrl+O and Cmd/Ctrl+N.
+   * True when the title row (app shell) is gone — the host owns file
+   * identity/lifecycle, so the SDK suppresses Cmd/Ctrl+O and Cmd/Ctrl+N and
+   * prunes the host-owned File/Help menu entries.
    */
   appShellHidden: boolean;
 }
@@ -109,10 +115,20 @@ export function resolveChromeVisibility(
   showToolbarFallback: boolean
 ): ChromeVisibility {
   const toolbar = isFeatureEnabled(features, 'toolbar', showToolbarFallback);
-  const shellShownByDefault = chrome !== 'embedded';
-  const titleBar = isFeatureEnabled(features, 'titleBar', shellShownByDefault);
-  const menuBar = isFeatureEnabled(features, 'menuBar', shellShownByDefault);
-  return { toolbar, titleBar, menuBar, appShellHidden: !titleBar && !menuBar };
+  // The formatting toolbar AND the editing menus (Insert/Format/Tools/View/…)
+  // are the *editing surface* — both survive `"embedded"`; only `"none"` drops
+  // them. The title *row* (logo + document name) is the app shell the host
+  // replaces, so it alone defaults off in `"embedded"`. Keeping these welded
+  // was the doc-39 regression: hiding the menu bar stranded ~50 menu-only
+  // features (Insert image/table, Format paragraph, Tools word-count, …).
+  const editingSurfaceDefault = chrome !== 'none';
+  const appShellDefault = chrome !== 'embedded' && chrome !== 'none';
+  const titleBar = isFeatureEnabled(features, 'titleBar', appShellDefault);
+  const menuBar = isFeatureEnabled(features, 'menuBar', editingSurfaceDefault);
+  // App shell == the title row. Whenever it's hidden the host owns file
+  // identity/lifecycle, so the SDK suppresses Cmd/Ctrl+O·N and prunes the
+  // host-owned File/Help menu entries even though the editing menus stay.
+  return { toolbar, titleBar, menuBar, appShellHidden: !titleBar };
 }
 
 /** The set of feature ids explicitly disabled (`features[id] === false`). */

--- a/docx-editor/packages/react/src/components/sdkCustomization.test.ts
+++ b/docx-editor/packages/react/src/components/sdkCustomization.test.ts
@@ -58,17 +58,20 @@ describe('features flag-map (docs#272)', () => {
   });
 });
 
-describe('embedded chrome — toolbar without the app shell (doc 39)', () => {
+describe('embedded chrome — editing surface without the app shell (doc 39)', () => {
   // Mirrors the `showToolbar` default the DocxEditor prop destructure encodes
   // (`chrome === 'none' ? false : true`) so the fallback matches the component.
   const toolbarFallback = (chrome: string | undefined) => chrome !== 'none';
 
-  it('chrome:"embedded" shows the formatting toolbar but hides title bar + menu bar', () => {
+  it('chrome:"embedded" keeps the formatting toolbar AND the editing menus, dropping only the title row', () => {
     const v = resolveChromeVisibility('embedded', undefined, toolbarFallback('embedded'));
     expect(v.toolbar).toBe(true); // formatting toolbar stays
-    expect(v.titleBar).toBe(false); // logo + document name + menus gone
-    expect(v.menuBar).toBe(false); // File/Edit/… menus (and About/Help) gone
-    expect(v.appShellHidden).toBe(true); // → suppress Cmd+O / Cmd+N
+    expect(v.titleBar).toBe(false); // logo + document-name row gone (host owns it)
+    // The menu bar is the editing surface — Insert/Format/Tools/View/… must
+    // stay reachable. (The host-owned File/Help entries are pruned inside the
+    // component via appShellHidden; the bar itself stays.)
+    expect(v.menuBar).toBe(true);
+    expect(v.appShellHidden).toBe(true); // title row gone → host owns files → suppress Cmd+O/N
   });
 
   it('chrome:"full" (and default) keeps the whole shell', () => {


### PR DESCRIPTION
The embedded resolver welded the menu-bar default to the app-shell default, so `chrome:"embedded"` hid the entire menu bar — and the menu bar is where ~50 features live that are not on the formatting toolbar (Insert image/table/link/break/symbol, Format paragraph/borders, Tools word-count, View toggles, …). Embedded hosts (dochub) lost access to most editing features.

The menu bar is part of the **editing surface**, not the app shell. This splits the two:

- `resolveChromeVisibility`: `menuBar` now defaults to the editing surface (`chrome !== "none"`), independent of the title row. `appShellHidden` tracks the title row alone.
- Render: the title-bar and menu-bar gates are split so the menus render even when the logo/name row is hidden; the `FormattingBar` is gated on the toolbar; the default doc-icon no longer leaks in when only the menus remain.
- Embedded still strips the app shell: logo, document-name row, and the host-owned File/Help entries (Open/New/Version-history/About) are pruned — so the editing menus stay without a redundant second-product File menu.

Verified: new `embedded-chrome.spec.ts` (embedded keeps toolbar + Insert/Format/Tools menus, drops the doc-name row and About; `full` unchanged) + screenshots (light/dark) + `toolbar-state.spec.ts` green. Unit tests for the resolver updated.