### PR TITLE
fix(collab): gate autosave on Y.Doc sync (blank-doc overwrite)

### DIFF
--- a/docx-editor/.changeset/autosave-sync-gate.md
+++ b/docx-editor/.changeset/autosave-sync-gate.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Data-loss fix: gate FileSource autosave on collab initial sync. In collaborative mode the editor mounts with an empty seed document while the real content arrives over Yjs; autosave could serialize and push that empty seed before sync completed, overwriting the stored `.docx` with a blank document. `useCollab` now exposes a `synced` flag and `useFileSourceAutoSave` accepts an `isReady` gate so no save runs (and the editor is never even serialized) until the document is ready.

--- a/docx-editor/.changeset/personal-etag-concurrency.md
+++ b/docx-editor/.changeset/personal-etag-concurrency.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Data-loss fix: thread the etag through personal-mode autosave. The etag from `FileSource.open()` is now seeded into `useFileSourceAutoSave`, sent as `If-Match` on every save, and refreshed from each save result. A concurrent host-side change (or a second tab) now surfaces as a 412 conflict instead of a silent last-write-wins overwrite.

--- a/docx-editor/.changeset/wopi-409-conflict.md
+++ b/docx-editor/.changeset/wopi-409-conflict.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Data-loss fix: handle save version conflicts instead of retrying forever. On a WOPI 409 the source now adopts the host's current version (so the stale `X-WOPI-ItemVersion` isn't re-sent on every tick), and the autosave hook treats a conflict (WOPI 409 / personal 412) as a durable, non-auto-clearing state that pauses the auto-loop and hide-flush — surfaced via a new `conflict` flag — so it can't silently lose edits or overwrite the other writer. An explicit `flush()` clears the pause as a deliberate overwrite.

--- a/docx-editor/packages/react/src/collab/useCollab.ts
+++ b/docx-editor/packages/react/src/collab/useCollab.ts
@@ -48,6 +48,13 @@ export interface CollabState {
   plugins: Plugin[];
   /** Connection state from the Yjs provider. */
   status: CollabStatus;
+  /**
+   * True once the provider has completed its initial server sync — the Y.Doc
+   * now holds the room's real content. Consumers that persist serialized bytes
+   * (autosave) must gate on this so they never overwrite stored content with
+   * the empty seed the editor mounts with before sync arrives.
+   */
+  synced: boolean;
   /** Live snapshot of who's connected, including the local user. */
   peers: CollabPeer[];
   /** True while the server-side AI orchestrator is running a tool loop for this room. */
@@ -232,6 +239,12 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
     }, [room, backend, token]);
 
   const [status, setStatus] = useState<CollabStatus>('connecting');
+  // True once the provider has completed its INITIAL sync with the server —
+  // i.e. the Y.Doc now holds the room's real content, not the empty seed the
+  // editor mounts with. Autosave MUST wait for this before pushing serialized
+  // bytes to the FileSource, or it would overwrite the stored .docx with a
+  // blank document (audit 2026-07-19: collab-autosave-blank-overwrite).
+  const [synced, setSynced] = useState(false);
   const [peers, setPeers] = useState<CollabPeer[]>([]);
   const [aiIsEditing, setAiIsEditing] = useState(false);
   const [aiEditingBy, setAiEditingBy] = useState<string | null>(null);
@@ -272,6 +285,12 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
 
     const onStatus = (e: { status: CollabStatus }) => setStatus(e.status);
 
+    // A fresh provider starts unsynced; reflect its current state, then track
+    // the 'synced' event. HocuspocusProvider fires `synced` with `{ state }`.
+    setSynced(provider.synced === true);
+    const onSynced = (e?: { state?: boolean }) => setSynced(e?.state ?? true);
+    provider.on('synced', onSynced);
+
     const onStateless = ({ payload }: { payload: string }) => {
       try {
         const msg = JSON.parse(payload) as {
@@ -300,6 +319,7 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
 
     return () => {
       provider.off('status', onStatus);
+      provider.off('synced', onSynced);
       provider.off('stateless', onStateless);
       awareness.off('change', refreshPeers);
     };
@@ -317,6 +337,7 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
   return {
     plugins,
     status,
+    synced,
     peers,
     aiIsEditing,
     aiEditingBy,

--- a/docx-editor/packages/react/src/components/CasualEditor.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.tsx
@@ -404,12 +404,21 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
     // Autosave — opt-in via autosave={true}
     // ---------------------------------------------------------------
 
+    // Autosave must not push serialized bytes until the source of truth is
+    // ready. In collab mode the editor mounts with an empty `blankDoc()` seed
+    // and the real content arrives over Yjs — saving before that sync completes
+    // would overwrite the stored .docx with a blank document (audit 2026-07-19).
+    // Non-collab docs are always ready (the FileSource load is the content).
+    const collabSynced = !collabState || collabState.synced === true;
+    const isSaveReady = useCallback(() => collabSynced, [collabSynced]);
+
     const autosaveState = useFileSourceAutoSave({
       fileSource,
       docId,
       editorRef,
       interval: autosaveInterval,
       enabled: autosave,
+      isReady: isSaveReady,
     });
 
     useEffect(() => {

--- a/docx-editor/packages/react/src/components/CasualEditor.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.tsx
@@ -289,7 +289,7 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
 
     const [loadState, setLoadState] = useState<
       | { kind: 'loading' }
-      | { kind: 'ready'; buffer: ArrayBuffer; fileName: string }
+      | { kind: 'ready'; buffer: ArrayBuffer; fileName: string; etag?: string }
       | { kind: 'error'; err: Error }
     >({ kind: 'loading' });
 
@@ -300,7 +300,12 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
         try {
           const result = await fileSource.open(docId);
           if (cancelled) return;
-          setLoadState({ kind: 'ready', buffer: result.bytes, fileName: result.name });
+          setLoadState({
+            kind: 'ready',
+            buffer: result.bytes,
+            fileName: result.name,
+            etag: result.etag,
+          });
         } catch (err) {
           if (cancelled) return;
           setLoadState({ kind: 'error', err: err instanceof Error ? err : new Error(String(err)) });
@@ -419,6 +424,7 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
       interval: autosaveInterval,
       enabled: autosave,
       isReady: isSaveReady,
+      initialEtag: loadState.kind === 'ready' ? loadState.etag : undefined,
     });
 
     useEffect(() => {

--- a/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.test.ts
+++ b/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'bun:test';
 
-import { performAutoSave, type AutoSaveEditorRef } from './useFileSourceAutoSave';
+import { performAutoSave, isConflictError, type AutoSaveEditorRef } from './useFileSourceAutoSave';
 import type { FileEntry, FileSource } from './types';
 
 /**
@@ -230,5 +230,21 @@ describe('performAutoSave', () => {
     expect(result.kind).toBe('ok');
     // The refreshed etag is returned so the caller can advance the chain.
     if (result.kind === 'ok') expect(result.etag).toBe('v2');
+  });
+});
+
+describe('isConflictError', () => {
+  it('recognises WOPI 409 and personal 412 conflicts', () => {
+    expect(isConflictError({ name: 'WopiSaveConflictError' })).toBe(true);
+    expect(isConflictError({ name: 'PersonalFileSourceError', status: 412 })).toBe(true);
+    expect(isConflictError({ status: 409 })).toBe(true);
+  });
+
+  it('does not treat ordinary errors or non-objects as conflicts', () => {
+    expect(isConflictError(new Error('gateway down'))).toBe(false);
+    expect(isConflictError({ status: 500 })).toBe(false);
+    expect(isConflictError(null)).toBe(false);
+    expect(isConflictError(undefined)).toBe(false);
+    expect(isConflictError('nope')).toBe(false);
   });
 });

--- a/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.test.ts
+++ b/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.test.ts
@@ -166,4 +166,40 @@ describe('performAutoSave', () => {
     expect(result.kind).toBe('ok');
     expect(fs.saveCalls[0].size).toBe(0);
   });
+
+  it('skips with reason "not-ready" and never serializes when isReady() is false', async () => {
+    const fs = fakeFileSource();
+    let serialized = false;
+    const ref: AutoSaveEditorRef = {
+      save: async () => {
+        serialized = true;
+        return new Uint8Array([1]).buffer;
+      },
+    };
+    const result = await performAutoSave({
+      getRef: () => ref,
+      fileSource: fs,
+      docId: 'd',
+      isReady: () => false,
+    });
+    expect(result.kind).toBe('skip');
+    if (result.kind === 'skip') expect(result.reason).toBe('not-ready');
+    // Critical: the editor is never serialized and the store is never touched,
+    // so a blank pre-sync doc can't overwrite the persisted document.
+    expect(serialized).toBe(false);
+    expect(fs.saveCalls.length).toBe(0);
+  });
+
+  it('proceeds normally when isReady() is true', async () => {
+    const fs = fakeFileSource();
+    const bytes = new Uint8Array([0x50, 0x4b]).buffer;
+    const result = await performAutoSave({
+      getRef: () => fakeRef(bytes),
+      fileSource: fs,
+      docId: 'd',
+      isReady: () => true,
+    });
+    expect(result.kind).toBe('ok');
+    expect(fs.saveCalls.length).toBe(1);
+  });
 });

--- a/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.test.ts
+++ b/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.test.ts
@@ -202,4 +202,33 @@ describe('performAutoSave', () => {
     expect(result.kind).toBe('ok');
     expect(fs.saveCalls.length).toBe(1);
   });
+
+  it('forwards the etag to FileSource.save as If-Match (optimistic concurrency)', async () => {
+    let seenEtag: string | undefined = 'not-called';
+    const fs: FileSource = {
+      kind: 'personal',
+      label: 'T',
+      list: async () => [],
+      open: async () => ({ bytes: new ArrayBuffer(0), name: 'x', etag: 'v1' }),
+      save: async (_id, _bytes, opts) => {
+        seenEtag = opts?.etag;
+        return { id: 'd', etag: 'v2' };
+      },
+      rename: async () => undefined,
+      delete: async () => undefined,
+      watchRecent: () => () => undefined,
+      rememberLastOpened: async () => undefined,
+      lastOpened: async () => null,
+    };
+    const result = await performAutoSave({
+      getRef: () => fakeRef(new Uint8Array([1]).buffer),
+      fileSource: fs,
+      docId: 'd',
+      etag: 'v1',
+    });
+    expect(seenEtag).toBe('v1');
+    expect(result.kind).toBe('ok');
+    // The refreshed etag is returned so the caller can advance the chain.
+    if (result.kind === 'ok') expect(result.etag).toBe('v2');
+  });
 });

--- a/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.ts
+++ b/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.ts
@@ -79,6 +79,13 @@ export interface PerformAutoSaveDeps {
   docId: string;
   name?: string;
   /**
+   * Last-known etag for optimistic concurrency. Threaded into
+   * `FileSource.save(...)` as `If-Match` so a concurrent host-side change
+   * surfaces as a 412/conflict instead of silently clobbering the other
+   * writer. Undefined on first save.
+   */
+  etag?: string;
+  /**
    * Optional readiness gate. When it returns `false` the tick is SKIPPED
    * before the editor is even serialized — used to refuse saving before a
    * collab Y.Doc has completed its initial sync, which would otherwise push
@@ -110,7 +117,10 @@ export async function performAutoSave(deps: PerformAutoSaveDeps): Promise<AutoSa
     if (!bytes) {
       return { kind: 'err', err: new Error('Document serialization returned no bytes') };
     }
-    const result = await deps.fileSource.save(deps.docId, bytes, { name: deps.name });
+    const result = await deps.fileSource.save(deps.docId, bytes, {
+      name: deps.name,
+      etag: deps.etag,
+    });
     return { kind: 'ok', etag: result.etag, savedAt: new Date() };
   } catch (err) {
     return { kind: 'err', err };
@@ -157,6 +167,13 @@ export interface UseFileSourceAutoSaveOptions {
    * → always ready.
    */
   isReady?: () => boolean;
+  /**
+   * Etag captured from `FileSource.open()`. Seeds the optimistic-concurrency
+   * chain: it's sent as `If-Match` on the next save and refreshed from every
+   * save result, so a concurrent host-side change surfaces as a conflict
+   * instead of a silent last-write-wins overwrite. Reseeds when `docId` changes.
+   */
+  initialEtag?: string;
   /**
    * Optional file-name to attach on first-save (when docId is null
    * — see save() below). The hook doesn't watch this for changes;
@@ -207,6 +224,7 @@ export function useFileSourceAutoSave(
     enabled = true,
     name,
     isReady,
+    initialEtag,
     onSaved,
     onError,
   } = opts;
@@ -233,6 +251,13 @@ export function useFileSourceAutoSave(
   // save has actually run, even if another save was in flight when they
   // called (audit: autosave-pagehide-no-await coupling).
   const inFlightPromiseRef = useRef<Promise<void> | null>(null);
+  // Last-known etag for optimistic concurrency. Seeded from open() via
+  // initialEtag, refreshed from each successful save, and reseeded whenever the
+  // doc changes so a stale etag can't leak across documents.
+  const lastEtagRef = useRef<string | undefined>(initialEtag);
+  useEffect(() => {
+    lastEtagRef.current = initialEtag;
+  }, [docId, initialEtag]);
 
   // Callbacks captured via ref so the tick effect doesn't restart
   // when the host passes a fresh arrow on every render. Same trick
@@ -280,11 +305,15 @@ export function useFileSourceAutoSave(
           docId: cfg.docId,
           name: cfg.name,
           isReady: cfg.isReady,
+          etag: lastEtagRef.current,
         }),
         timeout,
       ]);
       switch (result.kind) {
         case 'ok':
+          // Advance the concurrency chain so the NEXT save's If-Match matches
+          // the version we just wrote.
+          lastEtagRef.current = result.etag;
           setLastSavedAt(result.savedAt);
           setStatus('saved');
           setLastError(null);

--- a/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.ts
+++ b/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.ts
@@ -68,7 +68,7 @@ const SAVE_TIMEOUT_MS = 30000;
  * returned; `err` carries the throw.
  */
 export type AutoSaveTickResult =
-  | { kind: 'skip'; reason: 'no-ref' | 'no-bytes' | 'in-flight' }
+  | { kind: 'skip'; reason: 'no-ref' | 'no-bytes' | 'in-flight' | 'not-ready' }
   | { kind: 'ok'; etag: string; savedAt: Date }
   | { kind: 'err'; err: unknown };
 
@@ -78,6 +78,14 @@ export interface PerformAutoSaveDeps {
   fileSource: FileSource;
   docId: string;
   name?: string;
+  /**
+   * Optional readiness gate. When it returns `false` the tick is SKIPPED
+   * before the editor is even serialized — used to refuse saving before a
+   * collab Y.Doc has completed its initial sync, which would otherwise push
+   * the empty mount-time seed over the stored document (data-loss). Absent →
+   * always ready (single-user / non-collab).
+   */
+  isReady?: () => boolean;
 }
 
 /**
@@ -89,6 +97,10 @@ export interface PerformAutoSaveDeps {
 export async function performAutoSave(deps: PerformAutoSaveDeps): Promise<AutoSaveTickResult> {
   const ref = deps.getRef();
   if (!ref) return { kind: 'skip', reason: 'no-ref' };
+  // Refuse to serialize/push before the source of truth is ready (e.g. collab
+  // still syncing). Guards against overwriting stored content with the empty
+  // seed the editor mounts with.
+  if (deps.isReady && !deps.isReady()) return { kind: 'skip', reason: 'not-ready' };
   try {
     const bytes = await ref.save({ selective: true });
     // When the editor ref is mounted, a null return means serialization
@@ -139,6 +151,13 @@ export interface UseFileSourceAutoSaveOptions {
   /** Hard-off switch. Default true. */
   enabled?: boolean;
   /**
+   * Readiness gate evaluated fresh on every tick. Return `false` to skip the
+   * save (e.g. while a collab Y.Doc is still syncing) so autosave never
+   * overwrites stored content with the editor's empty mount-time seed. Absent
+   * → always ready.
+   */
+  isReady?: () => boolean;
+  /**
    * Optional file-name to attach on first-save (when docId is null
    * — see save() below). The hook doesn't watch this for changes;
    * the host should call FileSource.rename() for that.
@@ -187,6 +206,7 @@ export function useFileSourceAutoSave(
     interval = 30000,
     enabled = true,
     name,
+    isReady,
     onSaved,
     onError,
   } = opts;
@@ -226,10 +246,10 @@ export function useFileSourceAutoSave(
 
   // Snapshot of the host-controlled deps inside a ref so the timing
   // effect can read fresh values without re-firing on every change.
-  const cfgRef = useRef({ fileSource, docId, editorRef, name });
+  const cfgRef = useRef({ fileSource, docId, editorRef, name, isReady });
   useEffect(() => {
-    cfgRef.current = { fileSource, docId, editorRef, name };
-  }, [fileSource, docId, editorRef, name]);
+    cfgRef.current = { fileSource, docId, editorRef, name, isReady };
+  }, [fileSource, docId, editorRef, name, isReady]);
 
   /**
    * Performs exactly one save round-trip and reflects the outcome in
@@ -241,6 +261,9 @@ export function useFileSourceAutoSave(
    */
   const executeOne = useCallback(async (): Promise<void> => {
     const cfg = cfgRef.current;
+    // Not-ready (e.g. collab still syncing): skip silently without flashing a
+    // 'saving' status every tick, and never touch the stored document.
+    if (cfg.isReady && !cfg.isReady()) return;
     setStatus('saving');
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<AutoSaveTickResult>((resolve) => {
@@ -256,6 +279,7 @@ export function useFileSourceAutoSave(
           fileSource: cfg.fileSource,
           docId: cfg.docId,
           name: cfg.name,
+          isReady: cfg.isReady,
         }),
         timeout,
       ]);

--- a/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.ts
+++ b/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.ts
@@ -55,6 +55,20 @@ import type { FileSource } from './types';
  */
 const SAVE_TIMEOUT_MS = 30000;
 
+/**
+ * A save error is a *conflict* when the store rejected the write because our
+ * version is stale — someone else changed the doc (WOPI 409, personal 412).
+ * These must never be retried on the auto-loop: retrying a WOPI 409 re-sends the
+ * same stale version and fails forever (silent loss), and blindly re-saving
+ * would clobber the other writer. Instead the hook pauses and surfaces it, and
+ * only an explicit user-initiated `flush()` (a deliberate overwrite) retries.
+ */
+export function isConflictError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { name?: string; status?: number };
+  return e.name === 'WopiSaveConflictError' || e.status === 412 || e.status === 409;
+}
+
 // ---------------------------------------------------------------
 // Pure controller — extracted so it's bun-unit-testable without a
 // React renderer. The hook below is a thin wrapper that exposes the
@@ -202,9 +216,16 @@ export interface UseFileSourceAutoSaveReturn {
   /** Last error caught — kept for status='error' rendering. */
   lastError: unknown;
   /**
-   * Force a save right now (bypassing the interval). Returns when
-   * the save round-trip finishes. Useful for "Save & close" buttons
-   * or beforeunload handlers the host owns.
+   * True while a version conflict is unresolved. The auto-loop is paused (it
+   * won't overwrite or re-conflict); the host should prompt the user to reload
+   * the current stored version or force-save. Calling `flush()` clears this and
+   * retries as an explicit overwrite.
+   */
+  conflict: boolean;
+  /**
+   * Force a save right now (bypassing the interval), clearing any conflict
+   * pause — i.e. a deliberate overwrite. Returns when the round-trip finishes.
+   * Useful for "Save & close" buttons or a "Save anyway" conflict action.
    */
   flush: () => Promise<void>;
 }
@@ -232,6 +253,11 @@ export function useFileSourceAutoSave(
   const [status, setStatus] = useState<AutoSaveStatus>('idle');
   const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
   const [lastError, setLastError] = useState<unknown>(null);
+  // Unresolved version conflict. While true, auto-ticks and hide-flushes are
+  // suppressed so we never silently re-conflict or overwrite the other writer;
+  // an explicit flush() clears it.
+  const [conflict, setConflict] = useState(false);
+  const conflictRef = useRef(false);
 
   // Ref for "is a save currently in flight" — guarding setState
   // doesn't help because React batches updates; a plain mutable ref
@@ -322,6 +348,19 @@ export function useFileSourceAutoSave(
           onSavedRef.current?.(result.savedAt, result.etag);
           break;
         case 'err':
+          if (isConflictError(result.err)) {
+            // Durable conflict: pause the auto-loop and surface it until the
+            // user resolves it. Deliberately NOT auto-cleared — a hidden
+            // conflict means every further edit is silently lost.
+            conflictRef.current = true;
+            setConflict(true);
+            setStatus('error');
+            setLastError(result.err);
+            clearTimeout(errorClearTimerRef.current);
+            errorClearTimerRef.current = undefined;
+            onErrorRef.current?.(result.err);
+            break;
+          }
           setStatus('error');
           setLastError(result.err);
           // Auto-clear the error badge after 60 s so a one-off failure
@@ -378,13 +417,24 @@ export function useFileSourceAutoSave(
     return drain;
   }, [executeOne]);
 
+  // Public save entry point. Unlike the interval/hide callers, this clears an
+  // active conflict pause first — it represents a deliberate user decision to
+  // overwrite (the WopiFileSource has already adopted the host's current
+  // version, so this save succeeds rather than re-conflicting).
+  const flush = useCallback((): Promise<void> => {
+    conflictRef.current = false;
+    setConflict(false);
+    return runSave();
+  }, [runSave]);
+
   // Interval ticker. Re-arms when `enabled` or `interval` change;
   // every other dep is read via ref so the timer survives parent
-  // re-renders.
+  // re-renders. Suppressed while a conflict is unresolved so we don't
+  // silently re-conflict (WOPI) or overwrite the other writer.
   useEffect(() => {
     if (!enabled || interval <= 0) return;
     const id = setInterval(() => {
-      void runSave();
+      if (!conflictRef.current) void runSave();
     }, interval);
     return () => clearInterval(id);
   }, [enabled, interval, runSave]);
@@ -404,8 +454,9 @@ export function useFileSourceAutoSave(
   useEffect(() => {
     if (!enabled) return;
     const flushOnHide = () => {
-      // Don't await — the page may be going away.
-      void runSave();
+      // Don't await — the page may be going away. Skip while a conflict is
+      // unresolved: a hide-flush must not silently overwrite the other writer.
+      if (!conflictRef.current) void runSave();
     };
     const onVisibility = () => {
       if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
@@ -432,8 +483,9 @@ export function useFileSourceAutoSave(
       status,
       lastSavedAt,
       lastError,
-      flush: runSave,
+      conflict,
+      flush,
     }),
-    [status, lastSavedAt, lastError, runSave]
+    [status, lastSavedAt, lastError, conflict, flush]
   );
 }

--- a/docx-editor/packages/react/src/file-source/wopi.ts
+++ b/docx-editor/packages/react/src/file-source/wopi.ts
@@ -203,6 +203,12 @@ export class WopiFileSource implements FileSource {
     );
     if (res.status === 409) {
       const body = (await res.json().catch(() => ({}))) as { expected?: string; actual?: string };
+      // Adopt the host's current version so we STOP re-sending the stale
+      // X-WOPI-ItemVersion on every retry (which would 409 forever). The
+      // conflict still throws; a subsequent user-initiated save now carries the
+      // host's version and succeeds as an explicit overwrite, rather than the
+      // autosave loop silently losing every edit against a stale version.
+      if (body.actual) this.version = body.actual;
       throw new WopiSaveConflictError(body.expected, body.actual);
     }
     if (!res.ok) {


### PR DESCRIPTION
First of the data-loss release gates (tracker 27). Autosave in collab mode could serialize the empty mount-time seed and push it to the FileSource before the Y.Doc synced, overwriting the stored .docx with a blank document.

- `useCollab` exposes `synced` (tracks the provider's `synced` event)
- `useFileSourceAutoSave` gains an `isReady()` gate; the editor is never serialized until it returns true
- `CasualEditor` passes `isReady = !collab || collab.synced`

Follow-ups on this branch: personal-mode etag (If-Match) + WOPI 409 conflict handling. Tests: `useFileSourceAutoSave.test.ts` (14 pass).