### PR TITLE
fix(ux): surface save failures + kill false 'Saved' after a failed autosave

### DIFF
--- a/docs/internal/27-production-grade-tracker.md
+++ b/docs/internal/27-production-grade-tracker.md
@@ -21,13 +21,18 @@ artifact; the concrete gates and their status are tracked here.
 | 1 | Collab autosave overwrites the stored `.docx` with a blank doc before Y.Doc sync | critical | **Fixed 2026-07-19** — `useCollab` exposes `synced`; `useFileSourceAutoSave` gains an `isReady()` gate; editor is never serialized pre-sync (`useFileSourceAutoSave.test.ts`) |
 | 2 | Two stored/paste XSS vectors (unvalidated hyperlink href + `innerHTML` on live paste) | high | **Fixed 2026-07-19** — `safeUrl()` scheme allow-list at every href sink + inert `DOMParser` paste (`safeUrl.test.ts`) |
 | 3 | WOPI `access_token` leaks in the visible URL + bug-report links; empty-origin embed msgs trusted | medium | **Fixed 2026-07-19** — `stripAccessTokenFromUrl()` on boot; origin+pathname-only report URLs; strict embed origin gate |
-| 4 | Personal-mode optimistic concurrency (If-Match) unwired → silent last-write-wins | critical | **Open** — thread etag end-to-end (`personal.ts`, `useFileSourceAutoSave.ts`) |
-| 5 | WOPI 409 conflict wedges autosave into permanent silent edit loss | high | **Open** — catch `WopiSaveConflictError`, refresh version, durable conflict UX |
+| 4 | Personal-mode optimistic concurrency (If-Match) unwired → silent last-write-wins | critical | **Fixed 2026-07-19 (PR #311)** — etag threaded through `useFileSourceAutoSave`; conflict now 412s instead of clobbering |
+| 5 | WOPI 409 conflict wedges autosave into permanent silent edit loss | high | **Fixed 2026-07-19 (PR #311)** — 409 adopts host version; hook enters a durable conflict pause instead of infinite stale-retry |
 | 6 | Share permissions are an unenforced client-side `?role=` hint; no access UI | high | **Open (Next)** — server-enforced share tokens + collaborator management (overlaps P1.7/P1.9) |
 | 7 | Offline edits volatile despite banner promising "saved locally" | high | **Open (Next)** — add `y-indexeddb` (overlaps P1.6) or correct the banner copy |
 
-Feedback follow-ups (audit quick-wins): false "Saved X ago" after a failed autosave, silent
-manual-save failure, unconfirmed comment-thread delete — tracked in the feedback batch.
+Feedback follow-ups: **Fixed 2026-07-19 (PR #313)** — manual-save failure toast + no false
+"Saved X ago" after a failed autosave (`pendingError` → "Unsaved changes"). Remaining audit
+quick-win: unconfirmed comment-thread delete.
+
+**Now-phase status:** all 6 release gates that block a multi-user/WOPI production release are
+closed (PRs #310–#313). Remaining hardening is the Next/Later roadmap (share-token
+enforcement, offline persistence, incremental layout, `DocxEditor.tsx` decomposition).
 
 ### Status reconciliations (2026-07-19)
 

--- a/docx-editor/.changeset/feedback-save-honesty.md
+++ b/docx-editor/.changeset/feedback-save-honesty.md
@@ -1,0 +1,8 @@
+---
+'@casualoffice/docs': patch
+---
+
+Feedback fixes so a failed save can't look like a successful one:
+
+- Manual save (Ctrl+S / File → Save) now shows a toast on failure — both when serialization returns no bytes and when the save throws — instead of failing silently.
+- The autosave indicator no longer reverts to a stale "Saved X ago" after a failed autosave: a new `pendingError` flag (kept until the next successful save, surviving the error-badge auto-clear) makes it show "Unsaved changes" instead.

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -7749,7 +7749,14 @@ body { background: white; }
     setIsSaving(true);
     try {
       const buffer = await handleSave();
-      if (!buffer) return;
+      if (!buffer) {
+        // Serialization failed silently — don't leave the user believing the
+        // save worked (audit: manual Save failed with no feedback).
+        toast.error(
+          "Couldn't save — the document failed to serialize. Your edits are still here; try again."
+        );
+        return;
+      }
       // Checkpoint a version on explicit save (Google-Docs parity). No-op
       // when nothing changed since the last capture, so repeated saves don't
       // pile up identical entries.
@@ -7776,10 +7783,15 @@ body { background: white; }
       setTimeout(() => URL.revokeObjectURL(url), 0);
       markDirty(false);
       toast.success(`Saved ${fileName}`);
+    } catch (err) {
+      // A throw from serialization / blob / download must surface — otherwise
+      // Ctrl+S silently fails and the user loses work believing it saved.
+      toast.error("Couldn't save the document. Your edits are still here; try again.");
+      emitError(err instanceof Error ? err : new Error(String(err)));
     } finally {
       setIsSaving(false);
     }
-  }, [handleSave, documentName, markDirty, onSave, versionCapture]);
+  }, [handleSave, documentName, markDirty, onSave, versionCapture, emitError]);
 
   // Autosave to IndexedDB (sheet parity). A periodic interval polls the
   // dirty flag every 30s; if dirty, it serializes and writes the buffer.

--- a/docx-editor/packages/react/src/file-source/AutosaveStatus.tsx
+++ b/docx-editor/packages/react/src/file-source/AutosaveStatus.tsx
@@ -49,17 +49,21 @@ export function AutosaveStatus({
     return () => clearInterval(id);
   }, [state.lastSavedAt]);
 
-  const label = render(state.status, state.lastSavedAt, formatLastSaved);
+  const label = render(state.status, state.lastSavedAt, state.pendingError, formatLastSaved);
   if (label === null) return null;
+
+  // A failed save (even after its badge auto-clears) is a problem state — never
+  // paint it in the neutral "saved" color.
+  const isProblem = state.status === 'error' || state.pendingError;
 
   return (
     <span
       className={className}
       data-testid={testId}
-      data-status={state.status}
+      data-status={isProblem && state.status !== 'error' ? 'unsaved' : state.status}
       aria-live="polite"
       aria-atomic="true"
-      style={state.status === 'error' ? errorStyle : baseStyle}
+      style={isProblem ? errorStyle : baseStyle}
     >
       {state.status === 'saving' && (
         <span aria-hidden="true" data-testid={`${testId}-spinner`} style={spinnerStyle} />
@@ -72,6 +76,7 @@ export function AutosaveStatus({
 function render(
   status: AutoSaveStatus,
   lastSavedAt: Date | null,
+  pendingError: boolean,
   formatLastSaved: (d: Date) => string
 ): string | null {
   switch (status) {
@@ -82,6 +87,10 @@ function render(
     case 'saved':
       return lastSavedAt ? `Saved ${formatLastSaved(lastSavedAt)}` : 'Saved';
     case 'idle':
+      // If the last save FAILED (and none has succeeded since), the badge has
+      // auto-cleared but the doc is NOT saved — say so rather than lying with a
+      // stale "Saved X ago".
+      if (pendingError) return 'Unsaved changes';
       // After at least one successful save, keep showing "Saved X
       // ago" so the indicator doesn't go dark between ticks. Before
       // any save, render nothing.

--- a/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.ts
+++ b/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.ts
@@ -223,6 +223,12 @@ export interface UseFileSourceAutoSaveReturn {
    */
   conflict: boolean;
   /**
+   * True when the last save attempt failed and none has succeeded since — even
+   * after the transient error badge auto-clears. Consumers use this to avoid
+   * showing a stale "Saved" while edits are actually un-persisted.
+   */
+  pendingError: boolean;
+  /**
    * Force a save right now (bypassing the interval), clearing any conflict
    * pause — i.e. a deliberate overwrite. Returns when the round-trip finishes.
    * Useful for "Save & close" buttons or a "Save anyway" conflict action.
@@ -257,6 +263,11 @@ export function useFileSourceAutoSave(
   // suppressed so we never silently re-conflict or overwrite the other writer;
   // an explicit flush() clears it.
   const [conflict, setConflict] = useState(false);
+  // True while the most recent save attempt FAILED and no successful save has
+  // landed since. Survives the 60 s error-badge auto-clear, so the UI never
+  // reverts to a lying "Saved X ago" with a pre-failure timestamp while edits
+  // are actually un-persisted (audit: false 'Saved' after a failed autosave).
+  const [pendingError, setPendingError] = useState(false);
   const conflictRef = useRef(false);
 
   // Ref for "is a save currently in flight" — guarding setState
@@ -343,6 +354,7 @@ export function useFileSourceAutoSave(
           setLastSavedAt(result.savedAt);
           setStatus('saved');
           setLastError(null);
+          setPendingError(false);
           clearTimeout(errorClearTimerRef.current);
           errorClearTimerRef.current = undefined;
           onSavedRef.current?.(result.savedAt, result.etag);
@@ -356,6 +368,7 @@ export function useFileSourceAutoSave(
             setConflict(true);
             setStatus('error');
             setLastError(result.err);
+            setPendingError(true);
             clearTimeout(errorClearTimerRef.current);
             errorClearTimerRef.current = undefined;
             onErrorRef.current?.(result.err);
@@ -363,6 +376,7 @@ export function useFileSourceAutoSave(
           }
           setStatus('error');
           setLastError(result.err);
+          setPendingError(true);
           // Auto-clear the error badge after 60 s so a one-off failure
           // doesn't haunt the title bar forever (autosave-stale-error-status).
           clearTimeout(errorClearTimerRef.current);
@@ -484,8 +498,9 @@ export function useFileSourceAutoSave(
       lastSavedAt,
       lastError,
       conflict,
+      pendingError,
       flush,
     }),
-    [status, lastSavedAt, lastError, conflict, flush]
+    [status, lastSavedAt, lastError, conflict, pendingError, flush]
   );
 }


### PR DESCRIPTION
Last of the audit's Now-phase gates (tracker 27).

- Manual Save (Ctrl+S) now toasts on failure — both null-buffer and throw paths — instead of failing silently.
- Autosave indicator no longer reverts to a stale "Saved X ago" after a failed save: a `pendingError` flag (survives the 60s error-badge auto-clear) makes it show "Unsaved changes" until a real save lands.

Typecheck clean; autosave unit tests green; existing autosave-indicator e2e assertions unaffected (the new `unsaved` state only appears in the error→idle path they don't cover).