### PR TITLE
ci(fidelity): watch the react paged editor in the visual-fidelity gate

### DIFF
--- a/.github/workflows/visual-fidelity.yml
+++ b/.github/workflows/visual-fidelity.yml
@@ -20,11 +20,17 @@ on:
     branches: [main]
     paths:
       - 'docx-editor/packages/core/**'
+      # The visible pages are driven by the React paged editor, so a change
+      # there (e.g. PagedEditor.tsx) can move rendered fidelity too — watch it.
+      - 'docx-editor/packages/react/src/paged-editor/**'
+      - 'docx-editor/packages/react/src/**/*.css'
       - 'docx-editor/scripts/visual-fidelity/**'
       - 'docx-editor/e2e/fixtures/repr-*.docx'
   pull_request:
     paths:
       - 'docx-editor/packages/core/**'
+      - 'docx-editor/packages/react/src/paged-editor/**'
+      - 'docx-editor/packages/react/src/**/*.css'
       - 'docx-editor/scripts/visual-fidelity/**'
       - 'docx-editor/e2e/fixtures/repr-*.docx'
   workflow_dispatch:

--- a/docx-editor/e2e/editing-experience/collab-convergence.spec.ts
+++ b/docx-editor/e2e/editing-experience/collab-convergence.spec.ts
@@ -26,6 +26,14 @@
  *
  * When COLLAB_E2E is unset the suite records a skipped test so the gap is
  * visible in the report rather than silently absent.
+ *
+ * CI-FEASIBLE PATH FORWARD (planned — 2026-07-19 audit, tracker 27):
+ * Replace the flaky public y-webrtc signaling with a deterministic in-process
+ * server: add `@hocuspocus/server` as a devDep and, in a dedicated CI job,
+ * spawn it on an ephemeral port, then drive two `HocuspocusProvider` clients
+ * (the SAME provider production uses) against it and assert Y.Doc convergence.
+ * This exercises the real wire protocol without the collab server repo (which
+ * is a separate, currently-unvendored submodule) and without public signaling.
  */
 
 import { test, expect, chromium } from '@playwright/test';


### PR DESCRIPTION
Next-phase item (tracker 27). The visual-fidelity floor only fired on `packages/core/**`, so changes to `PagedEditor.tsx` (`packages/react`, ~5.4k lines — the file that drives the visible pages) escaped the gate. Adds `paged-editor/**` + react CSS to both the push and pull_request path filters.

Also updates the skipped `collab-convergence.spec.ts` header to record the CI-feasible path to a real 2-client HocuspocusProvider convergence test (in-process `@hocuspocus/server`) — a follow-up, since it needs a new devDep + a careful non-flaky harness.

CI-only change; no published-package code touched (no changeset).