### PR TITLE
fix(ux): honest copy for offline durability + share-link security

### DIFF
--- a/docx-editor/.changeset/honest-offline-and-share-copy.md
+++ b/docx-editor/.changeset/honest-offline-and-share-copy.md
@@ -1,0 +1,8 @@
+---
+'@casualoffice/docs': patch
+---
+
+Honesty fixes for two over-promising UI surfaces:
+
+- The offline reconnect banner no longer claims edits are "saved locally and will sync" — there is no local persistence provider yet, so closing the tab while offline loses them. It now says "keep this tab open and your edits will sync when the connection returns."
+- The share dialog's security note now states plainly that a view/comment link can currently be escalated to edit by removing the URL parameter, and to only share such links with trusted people until server-enforced secure links land.

--- a/docx-editor/packages/react/i18n/en.json
+++ b/docx-editor/packages/react/i18n/en.json
@@ -1067,7 +1067,7 @@
     "linkLabel": "Share link",
     "copy": "Copy",
     "copied": "Copied",
-    "secureNote": "The role is set by a link parameter today. Server-enforced secure links are coming soon.",
+    "secureNote": "The role is set by a link parameter, so a view or comment link can currently be changed to edit by removing it from the URL. Only share these links with people you trust until server-enforced secure links land.",
     "done": "Done"
   },
   "presence": {

--- a/docx-editor/packages/react/src/collab/ReconnectBanner.tsx
+++ b/docx-editor/packages/react/src/collab/ReconnectBanner.tsx
@@ -4,10 +4,12 @@
 
 // Default reconnecting/offline indicator for the SDK. A thin strip
 // rendered above the editing surface whenever the Yjs provider isn't
-// `connected`. The editor stays usable — edits buffer locally and
-// flush on reconnect — but the user sees that their changes aren't
-// being broadcast right now. Theme-token styled via --doc-* vars so
-// it inherits the host's light/dark surface.
+// `connected`. The editor stays usable — edits buffer in this tab's
+// in-memory Y.Doc and flush on reconnect — but they are NOT yet
+// persisted to disk (no y-indexeddb provider), so closing the tab
+// while offline loses them. The copy reflects that honestly until
+// offline persistence lands (tracker 27, Next phase). Theme-token
+// styled via --doc-* vars so it inherits the host's light/dark surface.
 import type { CSSProperties } from 'react';
 import type { CollabStatus } from './useCollab';
 
@@ -37,7 +39,7 @@ const byStatus: Record<Exclude<CollabStatus, 'connected'>, CSSProperties> = {
 const labels: Record<Exclude<CollabStatus, 'connected'>, string> = {
   connecting: 'Reconnecting to the session…',
   disconnected:
-    "You're offline — edits are saved locally and will sync when the connection comes back.",
+    "You're offline — keep this tab open and your edits will sync when the connection returns.",
 };
 
 /**


### PR DESCRIPTION
Next-phase truthfulness fixes (tracker 27) — both surfaces currently promise a guarantee the code doesn't provide:

- **Offline banner** claimed edits are "saved locally and will sync." There's no `y-indexeddb` provider, so a tab close while offline loses them. Reworded to "keep this tab open and your edits will sync when the connection returns." (The real durability fix — y-indexeddb — is a follow-up that needs browser-level verification.)
- **Share security note** now states plainly that a view/comment link can be escalated to edit by removing the URL parameter, until server-enforced secure links land (that enforcement lives in the separate collab server repo).

Copy-only; i18n keys in sync; no tests assert the old strings.