### PR TITLE
fix(mobile): auto fit-to-width on phone mount (verified)

### DIFF
--- a/docx-editor/.changeset/mobile-fit-to-width.md
+++ b/docx-editor/.changeset/mobile-fit-to-width.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Mobile: auto fit-to-width on phone mount. On a phone-width viewport (≤720px) the editor now scales the page to fit the screen on load, so a Letter/A4 page (~816px) no longer overflows at 100% zoom and forces the user to pinch just to read it. Only shrinks (never zooms in), only when the host didn't pass a custom `initialZoom`, and has no effect on desktop.

--- a/docx-editor/e2e/tests/mobile-fit-width.spec.ts
+++ b/docx-editor/e2e/tests/mobile-fit-width.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Mobile fit-to-width — on a phone-width viewport the editor auto-fits the page
+ * to the screen on mount, so a Letter/A4 page (~816px) doesn't overflow at zoom
+ * 1.0 and force the user to pinch just to read. On desktop the page stays 100%.
+ */
+
+import { test, expect } from '@playwright/test';
+
+function readZoomPct(page: import('@playwright/test').Page): Promise<number> {
+  return page
+    .locator('[data-testid="docx-editor"]')
+    .locator('text=/^\\d+%$/')
+    .first()
+    .textContent()
+    .then((s) => Number((s ?? '').replace('%', '')));
+}
+
+test.describe('Mobile fit-to-width', () => {
+  test.describe('phone viewport', () => {
+    test.use({ viewport: { width: 390, height: 844 }, hasTouch: true, isMobile: true });
+
+    test('the page auto-fits the phone width on mount (zoom < 100%)', async ({ page }) => {
+      await page.goto('/?e2e=1');
+      await page.waitForSelector('[data-testid="docx-editor"]');
+      // Allow the fit-to-width rAF + the resulting state update to settle.
+      await page.waitForTimeout(700);
+
+      const zoom = await readZoomPct(page);
+      // 390px screen / ~816px page ≈ 46%. Assert it shrank well below 100%.
+      expect(zoom).toBeGreaterThan(20);
+      expect(zoom).toBeLessThan(90);
+    });
+  });
+
+  test.describe('desktop viewport', () => {
+    test.use({ viewport: { width: 1280, height: 800 } });
+
+    test('does not shrink on desktop (stays 100%)', async ({ page }) => {
+      await page.goto('/?e2e=1');
+      await page.waitForSelector('[data-testid="docx-editor"]');
+      await page.waitForTimeout(700);
+
+      const zoom = await readZoomPct(page);
+      expect(zoom).toBe(100);
+    });
+  });
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -5822,6 +5822,37 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     setState((prev) => ({ ...prev, zoom }));
   }, []);
 
+  // Fit-to-width on phone mount. A Letter/A4 page (~816px) is far wider than a
+  // phone screen, so at zoom 1.0 the document overflows and the user has to
+  // pinch just to read it. On a phone-width viewport, auto-fit the first page to
+  // the screen once after the first render — only shrinking (never zooming in),
+  // and only when the host didn't pass a custom initialZoom. (tracker 27, mobile.)
+  const didFitToWidthRef = useRef(false);
+  useEffect(() => {
+    if (didFitToWidthRef.current) return;
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    if (initialZoom !== 1) return; // host chose an explicit zoom — respect it
+    if (!window.matchMedia('(max-width: 720px)').matches) return; // phones only
+    let raf = 0;
+    let tries = 0;
+    const attempt = () => {
+      // `.layout-page` offsetWidth is the page's natural (pre-scale) width; at
+      // mount zoom is 1.0 so it reads the true page width regardless of scaling.
+      const page = document.querySelector('.layout-page') as HTMLElement | null;
+      const pageWidth = page?.offsetWidth ?? 0;
+      if (!pageWidth) {
+        if (tries++ < 30) raf = requestAnimationFrame(attempt);
+        return;
+      }
+      const available = window.innerWidth - 16; // small gutter each side
+      const fit = Math.min(1, Math.max(0.25, available / pageWidth));
+      if (fit < 0.98) handleZoomChange(fit); // only shrink to fit
+      didFitToWidthRef.current = true;
+    };
+    raf = requestAnimationFrame(attempt);
+    return () => cancelAnimationFrame(raf);
+  }, [initialZoom, handleZoomChange]);
+
   // Stable PagedEditor onTotalPagesChange — avoids breaking memo() on every render.
   const handleTotalPagesChange = useCallback((totalPages: number) => {
     setScrollPageInfo((prev) => (prev.totalPages === totalPages ? prev : { ...prev, totalPages }));


### PR DESCRIPTION
Next-phase mobile item (tracker 27), Playwright-verified.

At zoom 1.0 a Letter/A4 page (~816px) overflows a phone screen, so users had to pinch just to read a doc. On a phone-width viewport (≤720px, the same gate the pinch-zoom hook uses) the editor now measures the page's natural width and scales it to fit once after first render — shrink-only, and only when the host didn't pass a custom `initialZoom`. No effect on desktop.

**Verified (Playwright, chromium):** fits to ~46% on a 390px phone; stays 100% on desktop; `mobile-pinch-zoom` still passes (phone + desktop). Typecheck clean.