### PR TITLE
fix(a11y): content language on the editor root (WCAG 3.1.1)

### DIFF
--- a/docx-editor/.changeset/content-language-a11y.md
+++ b/docx-editor/.changeset/content-language-a11y.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Accessibility (WCAG 3.1.1): the editor now carries a `lang` on its root so assistive tech pronounces document content in the right language, and the off-screen editable surface (what screen readers read) inherits it. Adds a `documentLang` prop (BCP-47); defaults to the host page's `<html lang>`, then `en`.

--- a/docx-editor/e2e/tests/content-language.spec.ts
+++ b/docx-editor/e2e/tests/content-language.spec.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Content language (WCAG 3.1.1) — the editor root carries a BCP-47 `lang` so
+ * assistive tech pronounces the document content correctly, and the off-screen
+ * editable surface (which is what screen readers actually read) inherits it.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Content language', () => {
+  test('the editor root has a lang and the editable surface inherits it', async ({ page }) => {
+    await page.goto('/?e2e=1');
+    await page.waitForSelector('[data-testid="docx-editor"]');
+
+    const rootLang = await page
+      .locator('[data-testid="docx-editor"]')
+      .first()
+      .getAttribute('lang');
+    expect(rootLang).toBeTruthy();
+
+    // The ProseMirror editable (the surface AT reads) inherits lang from the
+    // nearest ancestor that declares it — that's the editor root.
+    const inheritedLang = await page.evaluate(() => {
+      const pm = document.querySelector('.ProseMirror') as HTMLElement | null;
+      if (!pm) return null;
+      const owner = pm.closest('[lang]') as HTMLElement | null;
+      return owner?.getAttribute('lang') ?? null;
+    });
+    expect(inheritedLang).toBeTruthy();
+  });
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -837,6 +837,14 @@ export interface DocxEditorProps {
   /** Translation overrides. Import a locale JSON file and pass it directly. */
   i18n?: Translations;
   /**
+   * BCP-47 language tag for the document CONTENT (e.g. 'en', 'de', 'fr-CA').
+   * Set on the editor root so assistive tech pronounces the content in the
+   * right language (WCAG 3.1.1 Language of Page). Inherited by the editable
+   * surface. Defaults to the host page's `<html lang>`, then 'en'. Pass this
+   * when the document language differs from the host UI language.
+   */
+  documentLang?: string;
+  /**
    * Mount a controllable agent panel on the right side of the editor. The
    * panel is the chrome (header, close button, drag-resize); the consumer
    * supplies whatever content goes inside via `render` — typically a chat
@@ -1951,6 +1959,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     documentNameEditable = true,
     renderTitleBarRight,
     i18n,
+    documentLang,
     agentPanel,
     wordCompat = false,
     docopsTransport,
@@ -9806,6 +9815,14 @@ body { background: white; }
               className={`ep-root docx-editor ${className}`}
               style={containerStyle}
               data-testid="docx-editor"
+              // Document content language for assistive tech (WCAG 3.1.1);
+              // inherited by the editable surface. Host page's <html lang> is a
+              // good default; 'en' as a last resort. Overridable via documentLang.
+              lang={
+                documentLang ||
+                (typeof document !== 'undefined' ? document.documentElement.lang : '') ||
+                'en'
+              }
             >
               {/* Main content area */}
               <div style={mainContentStyle}>


### PR DESCRIPTION
Next-phase a11y (tracker 27), Playwright-verified.

The editable surface had no `lang`, so a screen reader pronounced document content using the OS default language regardless of the actual content. Now the editor root carries a BCP-47 `lang` (inherited by the off-screen editable that AT reads), via a new `documentLang` prop — defaulting to the host page's `<html lang>`, then `en`.

**Verified (Playwright):** the root has a `lang` and the ProseMirror editable inherits it. Typecheck clean.

Companion a11y item — the **roving-tabindex toolbar** (single Tab stop + Arrow/Home/End, reusing the MenuDropdown pattern) — is a larger follow-up tracked in 27.