### PR TITLE
fix(ux): platform-correct keyboard-shortcut hints in the formatting bar

### DIFF
--- a/docx-editor/.changeset/formatting-bar-shortcut-glyphs.md
+++ b/docx-editor/.changeset/formatting-bar-shortcut-glyphs.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Formatting bar: keyboard-shortcut hints in tooltips are now platform-correct. The bar hardcoded ⌘ glyphs, so Windows/Linux users saw Mac shortcuts (e.g. "⌘B" instead of "Ctrl+B"). Every hint now routes through the existing `formatShortcut()` helper, matching the main toolbar.

--- a/docx-editor/e2e/tests/shortcut-glyphs.spec.ts
+++ b/docx-editor/e2e/tests/shortcut-glyphs.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Formatting-bar shortcut hints are platform-correct. The bar used to hardcode
+ * ⌘ glyphs, so Windows/Linux users saw Mac shortcuts. The hints now route
+ * through formatShortcut(), so a non-Mac platform sees "Ctrl+…".
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Formatting bar shortcut glyphs', () => {
+  test('a non-Mac platform shows Ctrl+ shortcuts, not ⌘', async ({ page }) => {
+    // Force a Windows platform BEFORE any app code runs so isMac() → false,
+    // regardless of the host OS (the local machine may be a Mac). This
+    // deterministically exercises the exact case that regressed.
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'platform', { get: () => 'Win32' });
+    });
+
+    await page.goto('/?e2e=1');
+    await page.waitForSelector('[data-testid="docx-editor"]');
+
+    const bold = page.locator('[aria-label="Bold"]').first();
+    await expect(bold).toBeVisible();
+    await bold.hover();
+
+    // The tooltip shortcut hint should read Ctrl+B (not ⌘B) on this platform.
+    await expect(page.getByText('Ctrl+B', { exact: false }).first()).toBeVisible({ timeout: 3000 });
+
+    // And the Mac glyph must not be shown anywhere in the formatting bar hints.
+    const hasCmdGlyph = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('body *')).some(
+        (el) => el.childElementCount === 0 && /⌘/.test(el.textContent || '')
+      )
+    );
+    expect(hasCmdGlyph).toBe(false);
+  });
+});

--- a/docx-editor/packages/react/src/components/FormattingBar.tsx
+++ b/docx-editor/packages/react/src/components/FormattingBar.tsx
@@ -29,6 +29,7 @@ import { ImageWrapDropdown } from './ui/ImageWrapDropdown';
 import { ImageTransformDropdown } from './ui/ImageTransformDropdown';
 import type { TableAction } from './ui/TableToolbar';
 import { cn } from '../lib/utils';
+import { formatShortcut } from '../lib/platform';
 import { ToolbarButton, ToolbarGroup } from './Toolbar';
 import type { ToolbarProps, FormattingAction } from './Toolbar';
 import { EditorToolbarContext } from './EditorToolbarContext';
@@ -371,7 +372,7 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
           onClick={handleUndo}
           disabled={disabled || !canUndo}
           title={t('formattingBar.undo')}
-          shortcut="⌘Z"
+          shortcut={formatShortcut('Ctrl+Z')}
           ariaLabel={t('formattingBar.undo')}
         >
           <MaterialSymbol name="undo" size={ICON_SIZE} />
@@ -380,7 +381,7 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
           onClick={handleRedo}
           disabled={disabled || !canRedo}
           title={t('formattingBar.redo')}
-          shortcut="⌘Y"
+          shortcut={formatShortcut('Ctrl+Y')}
           ariaLabel={t('formattingBar.redo')}
         >
           <MaterialSymbol name="redo" size={ICON_SIZE} />
@@ -464,7 +465,7 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
           active={currentFormatting.bold}
           disabled={disabled}
           title={t('formattingBar.bold')}
-          shortcut="⌘B"
+          shortcut={formatShortcut('Ctrl+B')}
           ariaLabel={t('formattingBar.bold')}
           featureId="bold"
         >
@@ -475,7 +476,7 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
           active={currentFormatting.italic}
           disabled={disabled}
           title={t('formattingBar.italic')}
-          shortcut="⌘I"
+          shortcut={formatShortcut('Ctrl+I')}
           ariaLabel={t('formattingBar.italic')}
           featureId="italic"
         >
@@ -486,7 +487,7 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
           active={currentFormatting.underline}
           disabled={disabled}
           title={t('formattingBar.underline')}
-          shortcut="⌘U"
+          shortcut={formatShortcut('Ctrl+U')}
           ariaLabel={t('formattingBar.underline')}
           featureId="underline"
         >
@@ -497,7 +498,7 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
           active={currentFormatting.strike}
           disabled={disabled}
           title={t('formattingBar.strikethrough')}
-          shortcut="⌘⇧X"
+          shortcut={formatShortcut('Ctrl+Shift+X')}
           ariaLabel={t('formattingBar.strikethrough')}
           featureId="strikethrough"
         >
@@ -578,7 +579,7 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
           onClick={() => handleFormat('insertLink')}
           disabled={disabled}
           title={t('formattingBar.insertLink')}
-          shortcut="⌘K"
+          shortcut={formatShortcut('Ctrl+K')}
           ariaLabel={t('formattingBar.insertLink')}
         >
           <MaterialSymbol name="link" size={ICON_SIZE} />
@@ -612,7 +613,7 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
           active={currentFormatting.superscript}
           disabled={disabled}
           title={t('formattingBar.superscript')}
-          shortcut="⌘."
+          shortcut={formatShortcut('Ctrl+.')}
           ariaLabel={t('formattingBar.superscript')}
         >
           <MaterialSymbol name="superscript" size={ICON_SIZE} />
@@ -622,7 +623,7 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
           active={currentFormatting.subscript}
           disabled={disabled}
           title={t('formattingBar.subscript')}
-          shortcut="⌘,"
+          shortcut={formatShortcut('Ctrl+,')}
           ariaLabel={t('formattingBar.subscript')}
         >
           <MaterialSymbol name="subscript" size={ICON_SIZE} />
@@ -726,7 +727,7 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
         onClick={() => handleFormat('clearFormatting')}
         disabled={disabled}
         title={t('formattingBar.clearFormatting')}
-        shortcut={'⌘\\'}
+        shortcut={formatShortcut('Ctrl+\\')}
         ariaLabel={t('formattingBar.clearFormatting')}
       >
         <MaterialSymbol name="format_clear" size={ICON_SIZE} />


### PR DESCRIPTION
Feedback quick-win from the audit (tracker 27). The formatting bar hardcoded ⌘ glyphs on every shortcut hint, so **Windows/Linux users saw Mac shortcuts** (`⌘B` instead of `Ctrl+B`). All 10 hints now route through the existing `formatShortcut()` helper — the same one the main `Toolbar` already uses — so hints render correctly per platform (⌘ on Mac, Ctrl+ elsewhere).

**Verified (Playwright):** with a forced Win32 platform the Bold tooltip reads `Ctrl+B` and no `⌘` glyph appears; typecheck + prettier clean. (On Mac the output is unchanged.)