### PR TITLE
fix(ux): recovery action on the in-editor parse-error screen

### DIFF
--- a/docx-editor/.changeset/parse-error-recovery.md
+++ b/docx-editor/.changeset/parse-error-recovery.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+When a document fails to open in the editor, the error screen is no longer a dead-end: it now offers a "Try again" action (a full reload by default, overridable via a new `onRetry` prop on the error view) so the user can recover instead of being stuck.

--- a/docx-editor/e2e/tests/parse-error-recovery.spec.ts
+++ b/docx-editor/e2e/tests/parse-error-recovery.spec.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Parse-error recovery — a document that fails to open in the editor used to
+ * show a dead-end error screen with no way forward. It now offers a "Try again"
+ * recovery action.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Parse-error recovery', () => {
+  test('a failed document load shows a Try again action', async ({ page }) => {
+    await page.goto('/?e2e=1');
+    await page.waitForSelector('[data-testid="docx-editor"]');
+
+    // Feed garbage bytes as a .docx to force the parse-error path (invalid zip).
+    await page.locator('input[type="file"][accept*=".docx"]').setInputFiles({
+      name: 'corrupt.docx',
+      mimeType:
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      buffer: Buffer.from('this is definitely not a valid .docx zip archive'),
+    });
+
+    // The error screen now carries a recovery affordance instead of dead-ending.
+    await expect(page.getByTestId('parse-error-retry')).toBeVisible({ timeout: 8000 });
+  });
+});

--- a/docx-editor/packages/react/src/components/DocxEditorHelpers.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditorHelpers.tsx
@@ -129,7 +129,18 @@ export function DefaultPlaceholder(): React.ReactElement {
 /**
  * Parse error display
  */
-export function ParseError({ message }: { message: string }): React.ReactElement {
+export function ParseError({
+  message,
+  onRetry,
+}: {
+  message: string;
+  /**
+   * Recovery action for the "Try again" button. Defaults to a full page reload
+   * (re-fetches the source, recovering from transient failures). Hosts can pass
+   * a smarter retry (e.g. re-open from their own storage).
+   */
+  onRetry?: () => void;
+}): React.ReactElement {
   const { t } = useTranslation();
   return (
     <div
@@ -157,7 +168,31 @@ export function ParseError({ message }: { message: string }): React.ReactElement
         </svg>
       </div>
       <h3 style={{ color: 'var(--doc-error)', marginBottom: '8px' }}>{t('errors.failedToLoad')}</h3>
-      <p style={{ color: 'var(--doc-text-muted)', maxWidth: '400px' }}>{message}</p>
+      <p style={{ color: 'var(--doc-text-muted)', maxWidth: '400px', marginBottom: '20px' }}>
+        {message}
+      </p>
+      {/* Recovery affordance so a parse failure isn't a dead-end. */}
+      <button
+        type="button"
+        data-testid="parse-error-retry"
+        onClick={() => {
+          if (onRetry) onRetry();
+          else if (typeof window !== 'undefined') window.location.reload();
+        }}
+        style={{
+          padding: '8px 20px',
+          borderRadius: 8,
+          border: 'none',
+          background: 'var(--doc-primary, #2563eb)',
+          color: '#fff',
+          fontSize: 14,
+          fontWeight: 500,
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+        }}
+      >
+        {t('errors.tryAgain')}
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
Onboarding/error-state quick-win from the audit (tracker 27). When a `.docx` fails to open inside the editor, the error screen dead-ended with just a message. It now offers a **"Try again"** action — a full reload by default (recovers transient failures), overridable by hosts via a new `onRetry` prop on the error view.

**Verified (Playwright):** uploading corrupt `.docx` bytes forces the parse-error path and the recovery button appears. Typecheck + prettier clean.