### PR TITLE
docs: execution specs for the remaining hardening follow-ups

### DIFF
--- a/docs/internal/27-production-grade-tracker.md
+++ b/docs/internal/27-production-grade-tracker.md
@@ -31,8 +31,15 @@ Feedback follow-ups: **Fixed 2026-07-19 (PR #313)** — manual-save failure toas
 quick-win: unconfirmed comment-thread delete.
 
 **Now-phase status:** all 6 release gates that block a multi-user/WOPI production release are
-closed (PRs #310–#313). Remaining hardening is the Next/Later roadmap (share-token
-enforcement, offline persistence, incremental layout, `DocxEditor.tsx` decomposition).
+closed (PRs #310–#313). The safe, verifiable Next-phase slices then shipped as PRs #314–#322
+(fidelity-gate coverage, honest offline/share copy, real 2-client convergence net, touch
+editing + mobile fit-to-width, content-language a11y, comment-delete confirm, cross-platform
+shortcut hints, parse-error recovery) — readiness **57 → 70**.
+
+**Remaining work** is infra-gated or large & delicate. Each has a ready-to-execute spec in
+[40-hardening-followups-specs.md](./40-hardening-followups-specs.md): offline persistence,
+touch drag-select, roving-tabindex toolbar, screenshot suite, server-enforced share tokens,
+and the `DocxEditor.tsx` decomposition (the architecture lever).
 
 ### Status reconciliations (2026-07-19)
 

--- a/docs/internal/40-hardening-followups-specs.md
+++ b/docs/internal/40-hardening-followups-specs.md
@@ -1,0 +1,104 @@
+# 40 — Hardening Follow-ups: Execution Specs
+
+**Date:** 2026-07-20
+**Status:** Ready-to-execute specs for the remaining post-audit hardening items
+**Context:** Companion to the [2026-07-19 production-readiness audit](./27-production-grade-tracker.md#2026-07-19--production-readiness-audit--hardening-pass). The Now-phase release gates and the safe/verifiable Next-phase slices shipped as PRs #310–#322. What remains is either infra-gated, large & delicate, or the architecture lever — each deserving its own focused session. This doc gives each one a concrete plan so that session starts with a spec, not a blank page.
+
+## Local verification harness (learned this session — read first)
+
+Running Playwright locally needs three things the fresh checkout lacks:
+
+1. **`@schnsrw/design-system` submodule is empty.** One file imports it (`PresenceCluster.tsx`: `AvatarStack, Badge, Button, BadgeTone`). Create a local stub (NOT committed — it's a submodule path) at `docx-editor/vendor/design-system/`: a `package.json` (`name`, `main: ./index.js`), an `index.js` exporting those three as `React.createElement` shims, an `index.d.ts`, and a `dist/tokens.css` (can be near-empty — the editor uses `var(--token, fallback)` everywhere).
+2. **Build first.** The demo (`examples/vite`) imports `@eigenpal/docx-core` from **built dist** — run `bun run build` before Playwright, and after every source change.
+3. **Kill stale Vite** on :5173 between runs (`lsof -ti :5173 | xargs kill -9`) or the webServer times out.
+
+Platform-dependent tests: override `navigator.platform` via `page.addInitScript` (e.g. force `Win32`) rather than relying on the host OS — the local machine is a Mac, CI is Linux.
+
+---
+
+## 1. Offline persistence (y-indexeddb)  ·  risk: medium  ·  needs collab server to fully verify
+
+**Goal:** Offline edits survive a reload/crash and replay on reconnect; make the ReconnectBanner's durability claim true (the honest interim copy shipped in #315).
+
+**Files:** `packages/react/src/collab/useCollab.ts` (add `IndexeddbPersistence`), `packages/react/src/components/CasualEditor.tsx` (load-flow), `packages/react/src/collab/ReconnectBanner.tsx` (copy), `packages/react/package.json` (add `y-indexeddb` optional peer + devDep).
+
+**Approach:**
+- Construct `IndexeddbPersistence(roomKey, ydoc)` in `useCollab`, keyed by **room/docId** (must be available offline — do NOT key by etag; the etag comes from `open()` which fails offline, so etag-keying breaks the primary restore case). Destroy on teardown.
+- Expose a `localLoaded` boolean (from the persistence `synced` event) **distinct from** the server `synced` flag. **Never** fold `localLoaded` into the autosave sync-gate (`useFileSourceAutoSave` `isReady`) — that gate must stay on **server** `synced` only, or a blank pre-server-sync local doc could overwrite stored content (the exact gate #311 closed).
+- Fix `CasualEditor`'s load-flow: on an **offline** reload, `FileSource.open()` fails → today it renders the error screen and the editor never mounts, so IndexedDB never restores. In collab mode, tolerate `open()` failure and still mount (Yjs + IndexedDB provide content).
+
+**Correctness hazard (must handle):** the stateless collab server **re-seeds the Y.Doc from the host `.docx`** on cold start. If local and server states have no shared history, a Yjs merge unions content and an **offline deletion can resurrect**. This is fully correct only when the server persists Y.Doc updates (Redis — tracker P1.1, the recommended prod config). Document the caveat; do not claim full durability for the in-memory demo config.
+
+**Verification:** Playwright with a running collab server (or the in-process `@hocuspocus/server` harness from #316): edit → kill/reload the page offline → assert edits restore; reconnect → assert convergence. **Blocker:** needs the collab server; the `./collab` submodule is empty locally.
+
+---
+
+## 2. Touch drag-select + selection handles  ·  risk: medium  ·  verifiable here
+
+**Goal:** Select text by touch-dragging on mobile, with draggable start/end handles. (Tap-to-caret + `touch-action` + fit-to-width already shipped in #317/#318.)
+
+**Files:** `packages/react/src/paged-editor/PagedEditor.tsx` (`handlePagesMouseDown/Move/Up` at ~3385/3666/3793 + the window drag listeners at ~3971).
+
+**Approach:**
+- Slice 1 only: migrate the mouse handlers to **Pointer Events** (a strict superset — Playwright mouse actions dispatch pointer events, so the existing desktop selection specs re-validate for free). Leave the dead `PointerEventHandler.ts` alone (don't adopt it — it widens blast radius).
+- Gate touch drag-select behind a **long-press** so a one-finger drag still scrolls (the default); long-press-then-drag selects. Coexist with `usePinchZoom` by bailing the moment a 2nd pointer appears.
+- Reuse the existing `getPositionFromMouse(clientX, clientY)` (PagedEditor ~3077) for touch coords — it's the shared pixel→PM-position mapper.
+- Slice 2 (follow-up): draggable start/end handle pills.
+
+**Verification:** existing desktop selection specs (`cross-paragraph-selection`, `shift-click-select`, `paged-editor-clicks`) must stay green; add a touch-drag spec using CDP `Input.dispatchTouchEvent` (Playwright `touchscreen` only exposes `tap`). Run `mobile-pinch-zoom` to confirm no pinch regression. **Risk:** this is the crown-jewel selection code (5.4k-line file) — the fidelity gate now watches it (#314).
+
+---
+
+## 3. Roving-tabindex toolbar  ·  risk: medium-high  ·  verifiable here
+
+**Goal:** The formatting toolbar is a single Tab stop with Arrow/Home/End navigation (WAI-ARIA toolbar pattern). Today `role="toolbar"` is set (`FormattingBar.tsx:362`) but every one of ~53 controls is individually tabbable.
+
+**Files:** `FormattingBar.tsx`, `Toolbar.tsx` (`ToolbarButton`), plus a new `useToolbarRovingFocus(ref)` hook.
+
+**Approach:**
+- Navigate with **Left/Right** (horizontal toolbar) so it never conflicts with native `<select>` / picker controls that use Up/Down internally. Home/End jump to ends. **Skip interception when focus is in a text input** (font-size field) so Left/Right still move the caret.
+- Manage tabindex: exactly one control has `tabindex=0` at a time, the rest `-1`; the set is **dynamic** (table controls appear only in tables), so recompute the focusable set on each keydown rather than caching.
+- **Danger:** setting `tabindex=-1` removes controls from Tab order — if arrow nav has a bug, controls become unreachable. Comprehensive keyboard testing across every control type and every context (body / table / image / header-footer) is mandatory before merge.
+
+**Verification:** Playwright keyboard specs: Tab reaches the toolbar once then exits; Arrow keys cycle all controls; each control still activates; native selects still work with Up/Down. Test in table + image contexts.
+
+---
+
+## 4. Re-enable the screenshot regression suite  ·  risk: low product / medium flake  ·  needs Linux CI runner
+
+**Goal:** Turn the disabled `visual-regression.spec.ts` back on (the fidelity **path filter** was already extended to the react paged editor in #314; the convergence net landed in #316).
+
+**Files:** `playwright.config.ts` (remove `testIgnore` for the visual suite), `.github/workflows/visual-fidelity.yml` (or a dedicated screenshot job), `e2e/tests/visual-regression.spec.ts`.
+
+**Approach:** regenerate `*-chromium-linux` baselines **on the CI runner** (they cannot be generated on macOS — that darwin/linux font-metric mismatch is exactly why the suite was disabled). Use the metric-compatible fonts the fidelity job already installs (Carlito/Liberation) and keep `maxDiffPixels` tolerances. **Blocker:** requires a Linux runner to produce trustworthy baselines.
+
+---
+
+## 5. Server-enforced share tokens + access UI  ·  risk: low here / blocked  ·  lives in the collab server repo
+
+**Goal:** A view/comment share link cannot be escalated to edit by deleting the URL param (the client honesty copy shipped in #315).
+
+**Split:**
+- **In `CasualOffice/collab` (the separate, currently-unvendored submodule) — the actual guarantee:** mint role-bound tokens (`POST /files/:id/shares`), validate them on the Hocuspocus `onAuthenticate` join handshake, and persist collaborator/role/revoke state. Not buildable or runnable in this repo.
+- **In this repo — client scaffolding only:** thread a `?share=<token>` param into the existing `collab.token` pipe (`useCollab.ts:190`); a typed `ShareAccess` contract + `NoopShareAccess` stub; a collaborator-list / per-person-role / revoke UI in `ShareDialog.tsx` behind a real (non-Noop) contract so it degrades gracefully. Run `bun run i18n:fix` for any new strings.
+
+---
+
+## 6. Decompose `DocxEditor.tsx`  ·  risk: high if rushed  ·  the architecture lever (2/5)
+
+**Goal:** Shrink the 12k-line god-component so the codebase stays changeable. This is the single biggest remaining lever — and the one that most needs a **dedicated, careful** session, not a tail-end slice.
+
+**Sequence (each its own PR, each fully verified before the next):**
+1. **`useDialogs` registry** — collapse the ~37 `const [xxxOpen, setXxxOpen]` booleans + their `onXxx` props into one registry (`open(name)`/`close(name)`/`isOpen(name)`). Touches every dialog call site — mechanical but broad; verify each dialog opens/closes via Playwright.
+2. **`useDocumentIO`** — extract load/save/serialize (`handleSave`, `handleDownloadDocument`, `loadBuffer`, the autosave wiring).
+3. **`useComments`**, **`useTrackedChanges`** (some already extracted) — pull remaining sidebar state out.
+4. **Command/context bus** — collapse the ~80–98 `onXxx` props threaded into `EditorToolbar`/`PagedEditor` into a context, killing the 67 stale-closure `xxxRef.current=` mirrors and the hand-maintained imperative-API dep arrays.
+5. Move to a reducer/store once the seams are clean.
+
+**Verification:** the full Playwright suite must stay green at each step; no behavior change is the whole point. Do NOT combine steps.
+
+---
+
+## Not worth chasing (verified low-value or false)
+
+- The audit referenced a "`formatShortcut()` helper" and an "existing `confirmModal`" as if wiring were trivial — the helper existed (`lib/platform.ts`, used in #321) but **no confirm modal existed** (#320 added an inline two-step confirm instead). Verify such references against source before planning.


### PR DESCRIPTION
Closes out the post-audit hardening effort by turning the remaining work into ready-to-execute specs.

- New `docs/internal/40-hardening-followups-specs.md`: for each remaining item (offline persistence, touch drag-select, roving-tabindex toolbar, screenshot suite, server-enforced share tokens, `DocxEditor.tsx` decomposition) — the exact files, approach, verification method, correctness hazards, and infra needed. Includes the local Playwright harness (design-system stub + build + platform override) learned this pass.
- Tracker 27 reconciled: PRs #310–#322 shipped, readiness 57→70, with a pointer to doc 40.

Docs-only; no changeset.