### PR TITLE
refactor(editor): useDialogs registry — DocxEditor decomposition, batch 1

### DIFF
--- a/docx-editor/.changeset/usedialogs-registry.md
+++ b/docx-editor/.changeset/usedialogs-registry.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Internal: begin decomposing the large `DocxEditor` component by moving its modal dialog open/close state into a single `useDialogs` registry. First batch migrates 10 modals (Page Setup, File Properties, Word Count, About, Keyboard Shortcuts, Preferences, Watermark, Accessibility, Building Blocks, Dictionary) off individual `useState` booleans. No behavior change.

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -3037,17 +3037,20 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // (docs/internal/40 — DocxEditor decomposition, batch 1).
   const dialogs = useDialogs();
   const showPageSetup = dialogs.isOpen('pageSetup');
-  const setShowPageSetup = (v: boolean) => (v ? dialogs.open('pageSetup') : dialogs.close('pageSetup'));
+  const setShowPageSetup = (v: boolean) =>
+    v ? dialogs.open('pageSetup') : dialogs.close('pageSetup');
   const handleOpenPageSetup = useCallback(() => setShowPageSetup(true), []);
 
   // File → Properties dialog state.
   const showFileProperties = dialogs.isOpen('fileProperties');
-  const setShowFileProperties = (v: boolean) => (v ? dialogs.open('fileProperties') : dialogs.close('fileProperties'));
+  const setShowFileProperties = (v: boolean) =>
+    v ? dialogs.open('fileProperties') : dialogs.close('fileProperties');
   const handleOpenFileProperties = useCallback(() => setShowFileProperties(true), []);
 
   // Word count dialog state (Ctrl+Shift+C, also surfaced via Edit menu).
   const showWordCount = dialogs.isOpen('wordCount');
-  const setShowWordCount = (v: boolean) => (v ? dialogs.open('wordCount') : dialogs.close('wordCount'));
+  const setShowWordCount = (v: boolean) =>
+    v ? dialogs.open('wordCount') : dialogs.close('wordCount');
   const handleOpenWordCount = useCallback(() => setShowWordCount(true), []);
 
   // Voice typing — inserts recognized text at the active editor's
@@ -3083,11 +3086,14 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // menu action, sourced from the same callbacks the menus use.
   const [showCommandPalette, setShowCommandPalette] = useState(false);
   const showKeyboardShortcuts = dialogs.isOpen('keyboardShortcuts');
-  const setShowKeyboardShortcuts = (v: boolean) => (v ? dialogs.open('keyboardShortcuts') : dialogs.close('keyboardShortcuts'));
+  const setShowKeyboardShortcuts = (v: boolean) =>
+    v ? dialogs.open('keyboardShortcuts') : dialogs.close('keyboardShortcuts');
   const showPreferences = dialogs.isOpen('preferences');
-  const setShowPreferences = (v: boolean) => (v ? dialogs.open('preferences') : dialogs.close('preferences'));
+  const setShowPreferences = (v: boolean) =>
+    v ? dialogs.open('preferences') : dialogs.close('preferences');
   const showWatermarkDialog = dialogs.isOpen('watermark');
-  const setShowWatermarkDialog = (v: boolean) => (v ? dialogs.open('watermark') : dialogs.close('watermark'));
+  const setShowWatermarkDialog = (v: boolean) =>
+    v ? dialogs.open('watermark') : dialogs.close('watermark');
   const [showEquationDialog, setShowEquationDialog] = useState(false);
   // Equation dialog prefill — empty for a new insert, or the selected math
   // node's LaTeX/display when editing an existing equation.
@@ -3096,13 +3102,15 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     display: 'inline' | 'block';
   }>({ latex: '', display: 'inline' });
   const showAccessibility = dialogs.isOpen('accessibility');
-  const setShowAccessibility = (v: boolean) => (v ? dialogs.open('accessibility') : dialogs.close('accessibility'));
+  const setShowAccessibility = (v: boolean) =>
+    v ? dialogs.open('accessibility') : dialogs.close('accessibility');
   const [accessibilityIssues, setAccessibilityIssues] = useState<AccessibilityIssue[]>([]);
   // Building blocks (C6): persisted snippet list + a snapshot of whatever
   // the editor selection contained at the moment the dialog opened, so
   // saving works even after focus has shifted to the dialog input.
   const showBuildingBlocks = dialogs.isOpen('buildingBlocks');
-  const setShowBuildingBlocks = (v: boolean) => (v ? dialogs.open('buildingBlocks') : dialogs.close('buildingBlocks'));
+  const setShowBuildingBlocks = (v: boolean) =>
+    v ? dialogs.open('buildingBlocks') : dialogs.close('buildingBlocks');
   const [buildingBlocks, setBuildingBlocks] = useState<BuildingBlock[]>(() => loadBuildingBlocks());
   const [pendingBuildingBlock, setPendingBuildingBlock] = useState<{
     content: unknown;
@@ -3112,7 +3120,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // the dialog can show "looking up <word>" loading state without a
   // re-fetch on every render.
   const showDictionary = dialogs.isOpen('dictionary');
-  const setShowDictionary = (v: boolean) => (v ? dialogs.open('dictionary') : dialogs.close('dictionary'));
+  const setShowDictionary = (v: boolean) =>
+    v ? dialogs.open('dictionary') : dialogs.close('dictionary');
   const [dictionaryWord, setDictionaryWord] = useState<string | null>(null);
   // A5 — translate selection. Captures the selection text at open time.
   // `translateRange` is also captured when the dialog is opened from

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -286,6 +286,7 @@ import { Toaster, toast } from 'sonner';
 import { getBuiltinTableStyle, type TableStylePreset } from './ui/TableStyleGallery';
 import { DocumentAgent } from '@eigenpal/docx-core/agent';
 import { DefaultLoadingIndicator, DefaultPlaceholder, ParseError } from './DocxEditorHelpers';
+import { useDialogs } from '../hooks/useDialogs';
 import {
   parseDocx,
   getFootnoteText,
@@ -3032,15 +3033,21 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   const hyperlinkDialog = useHyperlinkDialog();
 
   // Page setup dialog state
-  const [showPageSetup, setShowPageSetup] = useState(false);
+  // Modal dialog open/close state, centralised in one registry
+  // (docs/internal/40 — DocxEditor decomposition, batch 1).
+  const dialogs = useDialogs();
+  const showPageSetup = dialogs.isOpen('pageSetup');
+  const setShowPageSetup = (v: boolean) => (v ? dialogs.open('pageSetup') : dialogs.close('pageSetup'));
   const handleOpenPageSetup = useCallback(() => setShowPageSetup(true), []);
 
   // File → Properties dialog state.
-  const [showFileProperties, setShowFileProperties] = useState(false);
+  const showFileProperties = dialogs.isOpen('fileProperties');
+  const setShowFileProperties = (v: boolean) => (v ? dialogs.open('fileProperties') : dialogs.close('fileProperties'));
   const handleOpenFileProperties = useCallback(() => setShowFileProperties(true), []);
 
   // Word count dialog state (Ctrl+Shift+C, also surfaced via Edit menu).
-  const [showWordCount, setShowWordCount] = useState(false);
+  const showWordCount = dialogs.isOpen('wordCount');
+  const setShowWordCount = (v: boolean) => (v ? dialogs.open('wordCount') : dialogs.close('wordCount'));
   const handleOpenWordCount = useCallback(() => setShowWordCount(true), []);
 
   // Voice typing — inserts recognized text at the active editor's
@@ -3065,7 +3072,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   }, [voiceTyping]);
 
   // Help → About dialog state.
-  const [showAbout, setShowAbout] = useState(false);
+  const showAbout = dialogs.isOpen('about');
+  const setShowAbout = (v: boolean) => (v ? dialogs.open('about') : dialogs.close('about'));
   const handleShowAbout = useCallback(() => setShowAbout(true), []);
   const handleReportBug = useCallback(() => {
     void import('./report-bug').then((m) => m.openBugReport());
@@ -3074,9 +3082,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // Command palette state (⌘⇧P / Ctrl+Shift+P). Searchable list of every
   // menu action, sourced from the same callbacks the menus use.
   const [showCommandPalette, setShowCommandPalette] = useState(false);
-  const [showKeyboardShortcuts, setShowKeyboardShortcuts] = useState(false);
-  const [showPreferences, setShowPreferences] = useState(false);
-  const [showWatermarkDialog, setShowWatermarkDialog] = useState(false);
+  const showKeyboardShortcuts = dialogs.isOpen('keyboardShortcuts');
+  const setShowKeyboardShortcuts = (v: boolean) => (v ? dialogs.open('keyboardShortcuts') : dialogs.close('keyboardShortcuts'));
+  const showPreferences = dialogs.isOpen('preferences');
+  const setShowPreferences = (v: boolean) => (v ? dialogs.open('preferences') : dialogs.close('preferences'));
+  const showWatermarkDialog = dialogs.isOpen('watermark');
+  const setShowWatermarkDialog = (v: boolean) => (v ? dialogs.open('watermark') : dialogs.close('watermark'));
   const [showEquationDialog, setShowEquationDialog] = useState(false);
   // Equation dialog prefill — empty for a new insert, or the selected math
   // node's LaTeX/display when editing an existing equation.
@@ -3084,12 +3095,14 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     latex: string;
     display: 'inline' | 'block';
   }>({ latex: '', display: 'inline' });
-  const [showAccessibility, setShowAccessibility] = useState(false);
+  const showAccessibility = dialogs.isOpen('accessibility');
+  const setShowAccessibility = (v: boolean) => (v ? dialogs.open('accessibility') : dialogs.close('accessibility'));
   const [accessibilityIssues, setAccessibilityIssues] = useState<AccessibilityIssue[]>([]);
   // Building blocks (C6): persisted snippet list + a snapshot of whatever
   // the editor selection contained at the moment the dialog opened, so
   // saving works even after focus has shifted to the dialog input.
-  const [showBuildingBlocks, setShowBuildingBlocks] = useState(false);
+  const showBuildingBlocks = dialogs.isOpen('buildingBlocks');
+  const setShowBuildingBlocks = (v: boolean) => (v ? dialogs.open('buildingBlocks') : dialogs.close('buildingBlocks'));
   const [buildingBlocks, setBuildingBlocks] = useState<BuildingBlock[]>(() => loadBuildingBlocks());
   const [pendingBuildingBlock, setPendingBuildingBlock] = useState<{
     content: unknown;
@@ -3098,7 +3111,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // A4 — dictionary lookup. Captures the selected word at open time so
   // the dialog can show "looking up <word>" loading state without a
   // re-fetch on every render.
-  const [showDictionary, setShowDictionary] = useState(false);
+  const showDictionary = dialogs.isOpen('dictionary');
+  const setShowDictionary = (v: boolean) => (v ? dialogs.open('dictionary') : dialogs.close('dictionary'));
   const [dictionaryWord, setDictionaryWord] = useState<string | null>(null);
   // A5 — translate selection. Captures the selection text at open time.
   // `translateRange` is also captured when the dialog is opened from

--- a/docx-editor/packages/react/src/hooks/useDialogs.test.ts
+++ b/docx-editor/packages/react/src/hooks/useDialogs.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+import { test, expect } from 'bun:test';
+import { dialogsReducer } from './useDialogs';
+
+const empty = new Set<string>();
+
+test('open adds a dialog; open of an already-open dialog is a no-op (same ref)', () => {
+  const a = dialogsReducer(empty, { type: 'open', name: 'about' });
+  expect(a.has('about')).toBe(true);
+  const b = dialogsReducer(a, { type: 'open', name: 'about' });
+  expect(b).toBe(a); // identity preserved so React can bail out
+});
+
+test('close removes a dialog; close of a closed dialog is a no-op (same ref)', () => {
+  const open = new Set(['about', 'wordCount']);
+  const a = dialogsReducer(open, { type: 'close', name: 'about' });
+  expect(a.has('about')).toBe(false);
+  expect(a.has('wordCount')).toBe(true);
+  const b = dialogsReducer(a, { type: 'close', name: 'about' });
+  expect(b).toBe(a);
+});
+
+test('toggle flips membership', () => {
+  const a = dialogsReducer(empty, { type: 'toggle', name: 'x' });
+  expect(a.has('x')).toBe(true);
+  const b = dialogsReducer(a, { type: 'toggle', name: 'x' });
+  expect(b.has('x')).toBe(false);
+});
+
+test('closeAll clears; closeAll on empty is a no-op (same ref)', () => {
+  const open = new Set(['a', 'b', 'c']);
+  const cleared = dialogsReducer(open, { type: 'closeAll' });
+  expect(cleared.size).toBe(0);
+  expect(dialogsReducer(empty, { type: 'closeAll' })).toBe(empty);
+});
+
+test('dialogs are independent', () => {
+  let s: ReadonlySet<string> = empty;
+  s = dialogsReducer(s, { type: 'open', name: 'a' });
+  s = dialogsReducer(s, { type: 'open', name: 'b' });
+  expect(s.has('a')).toBe(true);
+  expect(s.has('b')).toBe(true);
+  s = dialogsReducer(s, { type: 'close', name: 'a' });
+  expect(s.has('a')).toBe(false);
+  expect(s.has('b')).toBe(true);
+});

--- a/docx-editor/packages/react/src/hooks/useDialogs.ts
+++ b/docx-editor/packages/react/src/hooks/useDialogs.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * useDialogs — a tiny registry for modal open/close state.
+ *
+ * DocxEditor historically carried ~16 separate `const [showX, setShowX] =
+ * useState(false)` booleans for its modal dialogs. This hook holds them all in
+ * one place (a Set of open dialog names) so dialog state is managed centrally —
+ * enabling `closeAll()`, and cutting a pile of near-identical useState hooks out
+ * of the god-component. See docs/internal/40 (DocxEditor decomposition, batch 1).
+ *
+ * Pure set transitions live in `dialogsReducer` so they're unit-testable without
+ * a React renderer.
+ */
+
+import { useCallback, useMemo, useReducer } from 'react';
+
+export type DialogAction =
+  | { type: 'open'; name: string }
+  | { type: 'close'; name: string }
+  | { type: 'toggle'; name: string }
+  | { type: 'closeAll' };
+
+/** Pure, unit-testable state transition. Returns the SAME set when nothing
+ *  changes so React can bail out of a no-op update. */
+export function dialogsReducer(
+  open: ReadonlySet<string>,
+  action: DialogAction
+): ReadonlySet<string> {
+  switch (action.type) {
+    case 'open': {
+      if (open.has(action.name)) return open;
+      const next = new Set(open);
+      next.add(action.name);
+      return next;
+    }
+    case 'close': {
+      if (!open.has(action.name)) return open;
+      const next = new Set(open);
+      next.delete(action.name);
+      return next;
+    }
+    case 'toggle': {
+      const next = new Set(open);
+      if (next.has(action.name)) next.delete(action.name);
+      else next.add(action.name);
+      return next;
+    }
+    case 'closeAll':
+      return open.size === 0 ? open : new Set();
+  }
+}
+
+export interface DialogsApi {
+  /** True while the named dialog is open. */
+  isOpen: (name: string) => boolean;
+  open: (name: string) => void;
+  close: (name: string) => void;
+  toggle: (name: string) => void;
+  /** Close every open dialog (e.g. on Escape or route change). */
+  closeAll: () => void;
+}
+
+export function useDialogs(): DialogsApi {
+  const [open, dispatch] = useReducer(dialogsReducer, undefined, () => new Set<string>());
+
+  const isOpen = useCallback((name: string) => open.has(name), [open]);
+  const openFn = useCallback((name: string) => dispatch({ type: 'open', name }), []);
+  const closeFn = useCallback((name: string) => dispatch({ type: 'close', name }), []);
+  const toggle = useCallback((name: string) => dispatch({ type: 'toggle', name }), []);
+  const closeAll = useCallback(() => dispatch({ type: 'closeAll' }), []);
+
+  return useMemo(
+    () => ({ isOpen, open: openFn, close: closeFn, toggle, closeAll }),
+    [isOpen, openFn, closeFn, toggle, closeAll]
+  );
+}


### PR DESCRIPTION
First slice of the architecture lever (tracker 27 / `docs/internal/40` Spec #6): shrink the 12k-line `DocxEditor` by centralising modal dialog state.

- New `useDialogs` hook — a reducer-backed Set of open dialog names (`open`/`close`/`toggle`/`isOpen`/`closeAll`), with the pure `dialogsReducer` unit-tested.
- Migrates 10 pure-modal `useState(false)` booleans (Page Setup, File Properties, Word Count, About, Keyboard Shortcuts, Preferences, Watermark, Accessibility, Building Blocks, Dictionary) onto it via thin, behavior-identical adapters — call sites unchanged.

**Safety:** removing the `useState` declarations turns any missed reference into a compile error, so **typecheck gives complete call-site coverage** (0 errors). **Verified behaviorally:** the existing dialog e2e specs (watermark, dictionary, accessibility, help-menu/About, word-count, keyboard-shortcuts) all pass against the migrated code.

Follow-up batches (remaining modals, then the deeper prop-drilling / ref-mirror cleanup) per Spec #6. No behavior change; internal refactor.