### PR TITLE
refactor(editor): extract triggerBrowserDownload (IO-primitive, batch 3a)

### DIFF
--- a/docx-editor/.changeset/extract-download-helper.md
+++ b/docx-editor/.changeset/extract-download-helper.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Internal: extract the duplicated browser-download logic (object URL → hidden `<a download>` → click → deferred revoke) from DocxEditor's four save/export handlers into a single `triggerBrowserDownload()` utility. Pure refactor, no behavior change — first IO-primitive step of the DocxEditor decomposition.

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -80,6 +80,7 @@ import { AutosaveRestoreBanner } from './AutosaveRestoreBanner';
 import { writeAutosave, clearLegacyLocalStorageAutosave } from '../utils/autosave';
 import { restoreNativeBuildingBlocks } from '../utils/buildingBlocks';
 import { restoreNativeCitations } from '../utils/citations';
+import { triggerBrowserDownload } from '../utils/download';
 import { recordRecentFile } from '../utils/recent-files';
 import { openExternal } from '../utils/openExternal';
 import { CommentMarginMarkers } from './CommentMarginMarkers';
@@ -7847,14 +7848,8 @@ body { background: white; }
       const blob = new Blob([buffer], {
         type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       });
-      const url = URL.createObjectURL(blob);
-      const a = window.document.createElement('a');
-      a.href = url;
       const fileName = `${(documentName?.trim() || 'document').replace(/\.docx$/i, '')}.docx`;
-      a.download = fileName;
-      a.click();
-      // Defer revoke so Safari has time to start the download.
-      setTimeout(() => URL.revokeObjectURL(url), 0);
+      triggerBrowserDownload(blob, fileName);
       markDirty(false);
       toast.success(`Saved ${fileName}`);
     } catch (err) {
@@ -7937,12 +7932,7 @@ body { background: white; }
       // controls where the attachment lands; web falls back to a download.
       const savedViaHost = onExport ? await onExport(blob, fileName) : false;
       if (!savedViaHost) {
-        const url = URL.createObjectURL(blob);
-        const a = window.document.createElement('a');
-        a.href = url;
-        a.download = fileName;
-        a.click();
-        setTimeout(() => URL.revokeObjectURL(url), 0);
+        triggerBrowserDownload(blob, fileName);
       }
 
       const subject = encodeURIComponent(base);
@@ -7976,12 +7966,7 @@ body { background: white; }
         toast.success(`Saved ${fileName}`);
         return;
       }
-      const url = URL.createObjectURL(blob);
-      const a = window.document.createElement('a');
-      a.href = url;
-      a.download = fileName;
-      a.click();
-      setTimeout(() => URL.revokeObjectURL(url), 0);
+      triggerBrowserDownload(blob, fileName);
       toast.success(`Downloaded ${fileName}`);
     } finally {
       setIsSaving(false);
@@ -8022,12 +8007,7 @@ body { background: white; }
           toast.success(`Saved ${fileName}`, { id: toastId });
           return;
         }
-        const url = URL.createObjectURL(blob);
-        const a = window.document.createElement('a');
-        a.href = url;
-        a.download = fileName;
-        a.click();
-        setTimeout(() => URL.revokeObjectURL(url), 0);
+        triggerBrowserDownload(blob, fileName);
         toast.success(`Downloaded ${fileName}`, { id: toastId });
       } catch (error) {
         toast.error(`Failed to export as ${label}`, { id: toastId });

--- a/docx-editor/packages/react/src/utils/download.test.ts
+++ b/docx-editor/packages/react/src/utils/download.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+import { test, expect } from 'bun:test';
+import { triggerBrowserDownload } from './download';
+
+// Cast to a loose shape so the test can swap in DOM/URL/timer stubs without
+// fighting the full lib.dom overloads — this is test-only scaffolding.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const g = globalThis as any;
+
+test('triggerBrowserDownload wires a hidden anchor and defers the URL revoke', () => {
+  const created: string[] = [];
+  const anchor = {
+    href: '',
+    download: '',
+    clicked: false,
+    click() {
+      this.clicked = true;
+    },
+  };
+  // Held on an object so TS doesn't flow-narrow these to their initial null
+  // (the assignments happen inside the stub callbacks below).
+  const captured: { revoked: string | null; deferred: (() => void) | null } = {
+    revoked: null,
+    deferred: null,
+  };
+
+  const orig = { window: g.window, URL: g.URL, setTimeout: g.setTimeout };
+
+  g.window = { document: { createElement: (t: string) => (created.push(t), anchor) } };
+  g.URL = {
+    createObjectURL: () => 'blob:stub-url',
+    revokeObjectURL: (u: string) => {
+      captured.revoked = u;
+    },
+  };
+  g.setTimeout = (fn: () => void) => {
+    captured.deferred = fn;
+    return 0;
+  };
+
+  try {
+    triggerBrowserDownload(new Blob(['x']), 'Report.docx');
+    expect(created).toEqual(['a']);
+    expect(anchor.href).toBe('blob:stub-url');
+    expect(anchor.download).toBe('Report.docx');
+    expect(anchor.clicked).toBe(true);
+    // Revoke is deferred a tick (Safari cancels a sync revoke), not immediate.
+    expect(captured.revoked).toBeNull();
+    captured.deferred?.();
+    expect(captured.revoked).toBe('blob:stub-url');
+  } finally {
+    g.window = orig.window;
+    g.URL = orig.URL;
+    g.setTimeout = orig.setTimeout;
+  }
+});

--- a/docx-editor/packages/react/src/utils/download.ts
+++ b/docx-editor/packages/react/src/utils/download.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Trigger a browser file download for `blob` under `fileName`.
+ *
+ * The classic anchor-click dance (object URL → hidden `<a download>` → click →
+ * deferred revoke) was duplicated four times across DocxEditor's save/export
+ * handlers. Extracting it removes that duplication and pulls one small IO
+ * primitive out of the god-component (docs/internal/40 — DocxEditor
+ * decomposition). Pure with respect to React: no state, no closures.
+ *
+ * The revoke is deferred a tick because Safari cancels an in-flight download if
+ * the object URL is revoked synchronously after `click()`.
+ */
+export function triggerBrowserDownload(blob: Blob, fileName: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = window.document.createElement('a');
+  a.href = url;
+  a.download = fileName;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}


### PR DESCRIPTION
Smallest-increment start on the IO decomposition (Spec #6), deliberately chosen to be **zero-closure-risk** rather than moving the 220-line `handleSave` under fatigue.

The browser-download dance (object URL → hidden `<a download>` → click → deferred revoke) was duplicated across **4** save/export handlers. Extracted into one pure `triggerBrowserDownload(blob, fileName)` utility.

**Verified:** `download.test.ts` pins the exact behavior (anchor href/download/click + Safari-safe deferred revoke); typecheck proves all 4 call sites compatible (0 errors); prettier clean; `export-pdf` + `desktop-dirty-tracking` e2e pass. Pure refactor, no behavior change.

The larger, closure-heavy IO extractions (`handleSave`/`loadBuffer` into a `useDocumentIO` hook) remain for a dedicated pass with full save/autosave verification, per Spec #6.