### PR TITLE
refactor(editor): extract createDocxBlob + DOCX_MIME (IO-primitive, batch 3c)

### DIFF
--- a/docx-editor/.changeset/create-docx-blob.md
+++ b/docx-editor/.changeset/create-docx-blob.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Internal: extract the `.docx` Blob construction and its OOXML MIME type from three copy-pasted sites in DocxEditor into a `createDocxBlob()` helper and a `DOCX_MIME` constant. Pure refactor, no behavior change.

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -80,7 +80,7 @@ import { AutosaveRestoreBanner } from './AutosaveRestoreBanner';
 import { writeAutosave, clearLegacyLocalStorageAutosave } from '../utils/autosave';
 import { restoreNativeBuildingBlocks } from '../utils/buildingBlocks';
 import { restoreNativeCitations } from '../utils/citations';
-import { triggerBrowserDownload, documentBaseName } from '../utils/download';
+import { triggerBrowserDownload, documentBaseName, createDocxBlob } from '../utils/download';
 import { recordRecentFile } from '../utils/recent-files';
 import { openExternal } from '../utils/openExternal';
 import { CommentMarginMarkers } from './CommentMarginMarkers';
@@ -7845,9 +7845,7 @@ body { background: white; }
         markDirty(false);
         return;
       }
-      const blob = new Blob([buffer], {
-        type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      });
+      const blob = createDocxBlob(buffer);
       const fileName = `${documentBaseName(documentName, 'document')}.docx`;
       triggerBrowserDownload(blob, fileName);
       markDirty(false);
@@ -7923,9 +7921,7 @@ body { background: white; }
     try {
       const buffer = await handleSave();
       if (!buffer) return;
-      const blob = new Blob([buffer], {
-        type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      });
+      const blob = createDocxBlob(buffer);
       const base = documentBaseName(documentName, 'document');
       const fileName = `${base}.docx`;
       // Desktop shell: save via the native dialog (picker) so the user
@@ -7956,9 +7952,7 @@ body { background: white; }
     try {
       const buffer = await handleSave();
       if (!buffer) return;
-      const blob = new Blob([buffer], {
-        type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      });
+      const blob = createDocxBlob(buffer);
       const base = documentBaseName(documentName, 'document');
       const fileName = `Copy of ${base}.docx`;
       // Desktop shell: native Save dialog instead of a phantom download.

--- a/docx-editor/packages/react/src/utils/download.test.ts
+++ b/docx-editor/packages/react/src/utils/download.test.ts
@@ -3,7 +3,13 @@
  */
 
 import { test, expect } from 'bun:test';
-import { triggerBrowserDownload, documentBaseName } from './download';
+import { triggerBrowserDownload, documentBaseName, createDocxBlob, DOCX_MIME } from './download';
+
+test('createDocxBlob wraps bytes with the OOXML docx MIME type', () => {
+  const blob = createDocxBlob(new Uint8Array([0x50, 0x4b]));
+  expect(blob.type).toBe(DOCX_MIME);
+  expect(blob.size).toBe(2);
+});
 
 test('documentBaseName strips a trailing .docx, trims, and falls back', () => {
   expect(documentBaseName('Report.docx')).toBe('Report');

--- a/docx-editor/packages/react/src/utils/download.ts
+++ b/docx-editor/packages/react/src/utils/download.ts
@@ -2,6 +2,14 @@
  * Copyright (c) 2026 Casual Office. All rights reserved.
  */
 
+/** The OOXML MIME type for a Word `.docx` document. */
+export const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+/** Wrap serialized `.docx` bytes in a Blob with the correct OOXML MIME type. */
+export function createDocxBlob(bytes: BlobPart): Blob {
+  return new Blob([bytes], { type: DOCX_MIME });
+}
+
 /**
  * Trigger a browser file download for `blob` under `fileName`.
  *


### PR DESCRIPTION
Stacked on #327. The `.docx` Blob construction (with the long OOXML MIME literal) was duplicated 3× in DocxEditor's export handlers. Extracted into `createDocxBlob()` + a `DOCX_MIME` constant.

**Verified:** unit test (MIME + size); typecheck 0; prettier/eslint clean; `export-pdf` + `desktop-dirty-tracking` e2e pass. Pure refactor, no behavior change.

_Stack: #326 → #327 → #328. Retarget to main as each merges._