### PR TITLE
refactor(editor): land documentBaseName + createDocxBlob on main (stack recovery)

### DIFF
--- a/docx-editor/.changeset/create-docx-blob.md
+++ b/docx-editor/.changeset/create-docx-blob.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Internal: extract the `.docx` Blob construction and its OOXML MIME type from three copy-pasted sites in DocxEditor into a `createDocxBlob()` helper and a `DOCX_MIME` constant. Pure refactor, no behavior change.

--- a/docx-editor/.changeset/document-base-name.md
+++ b/docx-editor/.changeset/document-base-name.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Internal: extract the export/print base-filename computation (trim the title, strip a trailing `.docx`, fall back to a default) from six copy-pasted sites in DocxEditor into a `documentBaseName()` utility. Pure refactor, no behavior change (the title-case vs lower-case fallback difference is preserved via a parameter).

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -80,7 +80,7 @@ import { AutosaveRestoreBanner } from './AutosaveRestoreBanner';
 import { writeAutosave, clearLegacyLocalStorageAutosave } from '../utils/autosave';
 import { restoreNativeBuildingBlocks } from '../utils/buildingBlocks';
 import { restoreNativeCitations } from '../utils/citations';
-import { triggerBrowserDownload, documentBaseName } from '../utils/download';
+import { triggerBrowserDownload, documentBaseName, createDocxBlob } from '../utils/download';
 import { recordRecentFile } from '../utils/recent-files';
 import { openExternal } from '../utils/openExternal';
 import { CommentMarginMarkers } from './CommentMarginMarkers';
@@ -7845,9 +7845,7 @@ body { background: white; }
         markDirty(false);
         return;
       }
-      const blob = new Blob([buffer], {
-        type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      });
+      const blob = createDocxBlob(buffer);
       const fileName = `${documentBaseName(documentName, 'document')}.docx`;
       triggerBrowserDownload(blob, fileName);
       markDirty(false);
@@ -7923,9 +7921,7 @@ body { background: white; }
     try {
       const buffer = await handleSave();
       if (!buffer) return;
-      const blob = new Blob([buffer], {
-        type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      });
+      const blob = createDocxBlob(buffer);
       const base = documentBaseName(documentName, 'document');
       const fileName = `${base}.docx`;
       // Desktop shell: save via the native dialog (picker) so the user
@@ -7956,9 +7952,7 @@ body { background: white; }
     try {
       const buffer = await handleSave();
       if (!buffer) return;
-      const blob = new Blob([buffer], {
-        type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      });
+      const blob = createDocxBlob(buffer);
       const base = documentBaseName(documentName, 'document');
       const fileName = `Copy of ${base}.docx`;
       // Desktop shell: native Save dialog instead of a phantom download.

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -80,7 +80,7 @@ import { AutosaveRestoreBanner } from './AutosaveRestoreBanner';
 import { writeAutosave, clearLegacyLocalStorageAutosave } from '../utils/autosave';
 import { restoreNativeBuildingBlocks } from '../utils/buildingBlocks';
 import { restoreNativeCitations } from '../utils/citations';
-import { triggerBrowserDownload } from '../utils/download';
+import { triggerBrowserDownload, documentBaseName } from '../utils/download';
 import { recordRecentFile } from '../utils/recent-files';
 import { openExternal } from '../utils/openExternal';
 import { CommentMarginMarkers } from './CommentMarginMarkers';
@@ -7799,7 +7799,7 @@ body { background: white; }
     // host's print-to-PDF (same as Export as PDF) — the user prints the saved PDF
     // from their OS viewer. Web keeps the normal print dialog.
     if (onExportPdf) {
-      const base = (documentName?.trim() || 'Document').replace(/\.docx$/i, '');
+      const base = documentBaseName(documentName);
       if (await onExportPdf(`${base}.pdf`)) return;
     }
     triggerPrintFlow('Print');
@@ -7812,7 +7812,7 @@ body { background: white; }
   // than `Print.pdf`. There is no JS API to preselect the PDF
   // destination — the user picks it once in the print dialog.
   const handleExportPdf = useCallback(async () => {
-    const base = (documentName?.trim() || 'Document').replace(/\.docx$/i, '');
+    const base = documentBaseName(documentName);
     // Desktop: route through the host's native print-to-PDF (selectable text,
     // reliable on WebKitGTK) instead of the browser print dialog. If the host
     // didn't handle it (web, or user cancelled the save dialog), fall back.
@@ -7848,7 +7848,7 @@ body { background: white; }
       const blob = new Blob([buffer], {
         type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       });
-      const fileName = `${(documentName?.trim() || 'document').replace(/\.docx$/i, '')}.docx`;
+      const fileName = `${documentBaseName(documentName, 'document')}.docx`;
       triggerBrowserDownload(blob, fileName);
       markDirty(false);
       toast.success(`Saved ${fileName}`);
@@ -7926,7 +7926,7 @@ body { background: white; }
       const blob = new Blob([buffer], {
         type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       });
-      const base = (documentName?.trim() || 'document').replace(/\.docx$/i, '');
+      const base = documentBaseName(documentName, 'document');
       const fileName = `${base}.docx`;
       // Desktop shell: save via the native dialog (picker) so the user
       // controls where the attachment lands; web falls back to a download.
@@ -7959,7 +7959,7 @@ body { background: white; }
       const blob = new Blob([buffer], {
         type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       });
-      const base = (documentName?.trim() || 'document').replace(/\.docx$/i, '');
+      const base = documentBaseName(documentName, 'document');
       const fileName = `Copy of ${base}.docx`;
       // Desktop shell: native Save dialog instead of a phantom download.
       if (onExport && (await onExport(blob, fileName))) {
@@ -7988,7 +7988,7 @@ body { background: white; }
         }
         const { exportDocxAs } = await import('../lib/format-converter');
         const out = await exportDocxAs(new Uint8Array(buffer), target);
-        const base = (documentName?.trim() || 'document').replace(/\.docx$/i, '');
+        const base = documentBaseName(documentName, 'document');
         const mime =
           target === 'odt'
             ? 'application/vnd.oasis.opendocument.text'

--- a/docx-editor/packages/react/src/utils/download.test.ts
+++ b/docx-editor/packages/react/src/utils/download.test.ts
@@ -3,7 +3,13 @@
  */
 
 import { test, expect } from 'bun:test';
-import { triggerBrowserDownload, documentBaseName } from './download';
+import { triggerBrowserDownload, documentBaseName, createDocxBlob, DOCX_MIME } from './download';
+
+test('createDocxBlob wraps bytes with the OOXML docx MIME type', () => {
+  const blob = createDocxBlob(new Uint8Array([0x50, 0x4b]));
+  expect(blob.type).toBe(DOCX_MIME);
+  expect(blob.size).toBe(2);
+});
 
 test('documentBaseName strips a trailing .docx, trims, and falls back', () => {
   expect(documentBaseName('Report.docx')).toBe('Report');

--- a/docx-editor/packages/react/src/utils/download.test.ts
+++ b/docx-editor/packages/react/src/utils/download.test.ts
@@ -3,7 +3,18 @@
  */
 
 import { test, expect } from 'bun:test';
-import { triggerBrowserDownload } from './download';
+import { triggerBrowserDownload, documentBaseName } from './download';
+
+test('documentBaseName strips a trailing .docx, trims, and falls back', () => {
+  expect(documentBaseName('Report.docx')).toBe('Report');
+  expect(documentBaseName('  Report.DOCX  ')).toBe('Report');
+  expect(documentBaseName('Notes')).toBe('Notes');
+  expect(documentBaseName('')).toBe('Document'); // default fallback
+  expect(documentBaseName(undefined)).toBe('Document');
+  expect(documentBaseName('   ', 'document')).toBe('document'); // custom fallback
+  // Only a trailing .docx is stripped, not a mid-name occurrence.
+  expect(documentBaseName('my.docx.report.docx')).toBe('my.docx.report');
+});
 
 // Cast to a loose shape so the test can swap in DOM/URL/timer stubs without
 // fighting the full lib.dom overloads — this is test-only scaffolding.

--- a/docx-editor/packages/react/src/utils/download.ts
+++ b/docx-editor/packages/react/src/utils/download.ts
@@ -22,3 +22,15 @@ export function triggerBrowserDownload(blob: Blob, fileName: string): void {
   a.click();
   setTimeout(() => URL.revokeObjectURL(url), 0);
 }
+
+/**
+ * The document's base name for building an export filename: the trimmed title
+ * with any trailing `.docx` stripped, or `fallback` when there's no title.
+ * De-duplicates the same expression that appeared six times across DocxEditor's
+ * save/export/print handlers. `fallback` is a parameter because the callers use
+ * a title-case `Document` for print/PDF titles and lower-case `document` for the
+ * downloaded `.docx` filename — preserved rather than silently unified.
+ */
+export function documentBaseName(documentName: string | undefined, fallback = 'Document'): string {
+  return (documentName?.trim() || fallback).replace(/\.docx$/i, '');
+}

--- a/docx-editor/packages/react/src/utils/download.ts
+++ b/docx-editor/packages/react/src/utils/download.ts
@@ -2,6 +2,14 @@
  * Copyright (c) 2026 Casual Office. All rights reserved.
  */
 
+/** The OOXML MIME type for a Word `.docx` document. */
+export const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+/** Wrap serialized `.docx` bytes in a Blob with the correct OOXML MIME type. */
+export function createDocxBlob(bytes: BlobPart): Blob {
+  return new Blob([bytes], { type: DOCX_MIME });
+}
+
 /**
  * Trigger a browser file download for `blob` under `fileName`.
  *


### PR DESCRIPTION
The stacked PRs #327 (documentBaseName) and #328 (createDocxBlob) were merged into their intermediate branches rather than main, so their changes never reached main. This re-lands the two orphaned commits directly on top of main (the third, #326/triggerBrowserDownload, is already merged).

Content is unchanged from #327/#328 — both were already verified (unit tests + export e2e). Re-confirmed: typecheck 0, download unit tests pass, prettier clean.