### PR TITLE
fix(collab): restore the save-conflict force-save recovery path

### DIFF
--- a/docx-editor/.changeset/conflict-recovery-fix.md
+++ b/docx-editor/.changeset/conflict-recovery-fix.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix the save-conflict recovery path. After a WOPI 409 / personal 412 the autosave loop correctly paused (no data loss), but a user-initiated "Save anyway" (`flush()`) could never succeed — it re-sent the stale version and conflicted forever. Now the host's current version (`actual`) is surfaced on the conflict error (WOPI already did; personal now reads it from the response `ETag`) and adopted so the force-save overwrites successfully. Also stops a spurious conflict when the initial etag resolves after a save already advanced it.

--- a/docx-editor/packages/react/src/file-source/personal.test.ts
+++ b/docx-editor/packages/react/src/file-source/personal.test.ts
@@ -189,6 +189,42 @@ describe('PersonalFileSource', () => {
     expect(result.etag).toBe('v5');
   });
 
+  it('save() surfaces a 412 If-Match conflict with the host version (actual)', async () => {
+    const h = makeHarness();
+    h.setRespond(() => jsonRes(412, { error: 'version_conflict' }, { ETag: 'v9' }));
+    let err: unknown;
+    try {
+      await h.source.save('doc_a', new Uint8Array([1]).buffer, { etag: 'v4' });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(PersonalFileSourceError);
+    expect((err as PersonalFileSourceError).status).toBe(412);
+    // The host's CURRENT version is surfaced so the caller can force-save.
+    expect((err as PersonalFileSourceError).actual).toBe('v9');
+  });
+
+  it('after a 412, re-threading the host version (actual) overwrites successfully', async () => {
+    const h = makeHarness();
+    let n = 0;
+    h.setRespond(() => {
+      n += 1;
+      // First save conflicts (stale etag); second carries the host version.
+      return n === 1
+        ? jsonRes(412, { error: 'version_conflict' }, { ETag: 'v9' })
+        : jsonRes(200, { file: file({ id: 'doc_a', etag: 'v10' }) });
+    });
+
+    await expect(
+      h.source.save('doc_a', new Uint8Array([1]).buffer, { etag: 'v4' })
+    ).rejects.toBeInstanceOf(PersonalFileSourceError);
+
+    const result = await h.source.save('doc_a', new Uint8Array([1]).buffer, { etag: 'v9' });
+    expect(result.etag).toBe('v10');
+    // The recovery save carried the adopted version, not the stale one.
+    expect((h.calls[1].init?.headers as Record<string, string>)['If-Match']).toBe('v9');
+  });
+
   it('rename() PATCHes { name } (204) and updates the recent observer', async () => {
     const h = makeHarness();
     h.setRespond(() => jsonRes(200, { files: [file({ id: 'doc_a', name: 'old.docx' })] }));

--- a/docx-editor/packages/react/src/file-source/personal.ts
+++ b/docx-editor/packages/react/src/file-source/personal.ts
@@ -59,11 +59,19 @@ export interface PersonalFileSourceOptions {
 export class PersonalFileSourceError extends Error {
   readonly status: number;
   readonly code: string;
-  constructor(status: number, code: string, message: string) {
+  /**
+   * On a 412 If-Match conflict, the host's CURRENT version (from the response
+   * ETag). Lets a caller re-thread it and force-save (overwrite) instead of
+   * re-sending the stale version and 412-ing forever. Mirrors
+   * `WopiSaveConflictError.actual`.
+   */
+  readonly actual?: string;
+  constructor(status: number, code: string, message: string, actual?: string) {
     super(message);
     this.name = 'PersonalFileSourceError';
     this.status = status;
     this.code = code;
+    this.actual = actual;
   }
 }
 
@@ -224,7 +232,10 @@ export class PersonalFileSource implements FileSource {
       } catch {
         // Non-JSON error body — keep the synthesized envelope.
       }
-      throw new PersonalFileSourceError(res.status, code, message);
+      // A 412 If-Match conflict carries the host's current version in the
+      // response ETag; surface it so the caller can force-save against it.
+      const actual = res.status === 412 ? (res.headers.get('ETag') ?? undefined) : undefined;
+      throw new PersonalFileSourceError(res.status, code, message, actual);
     }
     return res;
   }

--- a/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.ts
+++ b/docx-editor/packages/react/src/file-source/useFileSourceAutoSave.ts
@@ -292,8 +292,18 @@ export function useFileSourceAutoSave(
   // initialEtag, refreshed from each successful save, and reseeded whenever the
   // doc changes so a stale etag can't leak across documents.
   const lastEtagRef = useRef<string | undefined>(initialEtag);
+  // Seed the concurrency etag from the freshly-opened doc, but NEVER clobber an
+  // etag we've already advanced via a save — initialEtag can resolve late
+  // (undefined → loadState.etag) after a save already ran, which would send a
+  // stale version and cause a spurious conflict. Reset only when the doc changes.
+  const seededDocRef = useRef<string | undefined>(undefined);
   useEffect(() => {
-    lastEtagRef.current = initialEtag;
+    if (seededDocRef.current !== docId) {
+      seededDocRef.current = docId;
+      lastEtagRef.current = initialEtag; // new document — take its etag
+    } else if (lastEtagRef.current === undefined && initialEtag !== undefined) {
+      lastEtagRef.current = initialEtag; // same doc, etag resolved after mount
+    }
   }, [docId, initialEtag]);
 
   // Callbacks captured via ref so the tick effect doesn't restart
@@ -361,6 +371,12 @@ export function useFileSourceAutoSave(
           break;
         case 'err':
           if (isConflictError(result.err)) {
+            // Adopt the host's CURRENT version from the conflict error so a
+            // user-initiated flush() ('Save anyway') sends it and overwrites,
+            // instead of re-threading the stale etag and conflicting forever
+            // (WopiSaveConflictError.actual / PersonalFileSourceError.actual).
+            const actual = (result.err as { actual?: string }).actual;
+            if (actual) lastEtagRef.current = actual;
             // Durable conflict: pause the auto-loop and surface it until the
             // user resolves it. Deliberately NOT auto-cleared — a hidden
             // conflict means every further edit is silently lost.


### PR DESCRIPTION
A multi-agent verification pass over the 20 shipped hardening fixes found **19 sound and one broken** — this fixes the one.

**The defect (in my own WOPI-409 work, #311):** after a WOPI 409 / personal 412 the autosave loop correctly *pauses* (so there's no silent data loss), but the advertised **"Save anyway" recovery is dead** — `flush()` re-threads the stale `lastEtagRef`, and `wopi.save`'s `ifMatch = opts?.etag ?? this.version` lets that stale caller etag override the `body.actual` the source adopted, so it 409s forever. Personal never surfaced the host version at all.

**Fix:**
- `PersonalFileSourceError` now carries `actual` (from the 412 response `ETag`), mirroring `WopiSaveConflictError`.
- The autosave hook adopts `result.err.actual` into `lastEtagRef` on conflict, so a user-initiated `flush()` sends the host's current version and overwrites successfully.
- The etag reseed effect no longer clobbers an already-advanced etag (a latent spurious-412 edge).

**Verified:** new `personal.test.ts` tests (412 surfaces `actual`; re-thread overwrites); existing wopi 409 + autosave suites green (38 pass); typecheck/prettier/eslint clean. Not data loss, but restores a dead durability escape-hatch. Self-contained — touches no decomposition surface.