### PR TITLE
refactor(editor): useDialogs registry — final dialogs (batch 3)

### DIFF
--- a/docx-editor/.changeset/usedialogs-batch3.md
+++ b/docx-editor/.changeset/usedialogs-batch3.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Internal: migrate the remaining modal dialogs (Bookmarks, Character Spacing, Paragraph, Borders & Shading, Image Properties, Insert Symbol) onto the `useDialogs` registry, so all modal dialog state now lives in one place. No behavior change. (Version history stays a rail panel, deliberately excluded.)

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -2011,10 +2011,17 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
 
   // Table properties dialog state
   const [tablePropsOpen, setTablePropsOpen] = useState(false);
+  // Modal dialog open/close state, centralised in one registry
+  // (docs/internal/40 — DocxEditor decomposition, batches 1-3).
+  const dialogs = useDialogs();
   // Bookmarks dialog state (Phase 1.5 U14)
-  const [bookmarksDialogOpen, setBookmarksDialogOpen] = useState(false);
+  const bookmarksDialogOpen = dialogs.isOpen('bookmarks');
+  const setBookmarksDialogOpen = (v: boolean) =>
+    v ? dialogs.open('bookmarks') : dialogs.close('bookmarks');
   // Character spacing dialog state (Phase 1.5 U1)
-  const [characterSpacingDialogOpen, setCharacterSpacingDialogOpen] = useState(false);
+  const characterSpacingDialogOpen = dialogs.isOpen('characterSpacing');
+  const setCharacterSpacingDialogOpen = (v: boolean) =>
+    v ? dialogs.open('characterSpacing') : dialogs.close('characterSpacing');
   const [characterSpacingInitial, setCharacterSpacingInitial] = useState<{
     scale: number | null;
     spacing: number | null;
@@ -2022,9 +2029,13 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     kerning: number | null;
   }>({ scale: null, spacing: null, position: null, kerning: null });
   // Paragraph dialog state (Phase 1.5 U5)
-  const [paragraphDialogOpen, setParagraphDialogOpen] = useState(false);
+  const paragraphDialogOpen = dialogs.isOpen('paragraph');
+  const setParagraphDialogOpen = (v: boolean) =>
+    v ? dialogs.open('paragraph') : dialogs.close('paragraph');
   // Borders + Shading dialog state (Phase 1.5 U6)
-  const [bordersShadingOpen, setBordersShadingOpen] = useState(false);
+  const bordersShadingOpen = dialogs.isOpen('bordersShading');
+  const setBordersShadingOpen = (v: boolean) =>
+    v ? dialogs.open('bordersShading') : dialogs.close('bordersShading');
   const [bordersShadingInitial, setBordersShadingInitial] = useState<BordersAndShadingValue>({
     borders: {},
     shading: { fillHex: '', pattern: 'clear', patternColorHex: '' },
@@ -2043,7 +2054,9 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // Image position dialog state
   const [imagePositionOpen, setImagePositionOpen] = useState(false);
   // Image properties dialog state
-  const [imagePropsOpen, setImagePropsOpen] = useState(false);
+  const imagePropsOpen = dialogs.isOpen('imageProperties');
+  const setImagePropsOpen = (v: boolean) =>
+    v ? dialogs.open('imageProperties') : dialogs.close('imageProperties');
   // Footnote properties dialog state
   const [footnotePropsOpen, setFootnotePropsOpen] = useState(false);
   // Header/footer editing state
@@ -2059,7 +2072,9 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   const [showCommentsSidebar, setShowCommentsSidebar] = useState(false);
   // Wire-up batch (Docs parity #1.5): dialogs that already existed but
   // had no menu entry. Each is open/close + a trigger handler.
-  const [insertSymbolOpen, setInsertSymbolOpen] = useState(false);
+  const insertSymbolOpen = dialogs.isOpen('insertSymbol');
+  const setInsertSymbolOpen = (v: boolean) =>
+    v ? dialogs.open('insertSymbol') : dialogs.close('insertSymbol');
   // Ruler visibility override — once the user toggles it, this takes
   // precedence over the showRuler prop. Initialised from the prop.
   const [showRulerLocal, setShowRulerLocal] = useState<boolean | null>(null);
@@ -3034,9 +3049,6 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   const hyperlinkDialog = useHyperlinkDialog();
 
   // Page setup dialog state
-  // Modal dialog open/close state, centralised in one registry
-  // (docs/internal/40 — DocxEditor decomposition, batch 1).
-  const dialogs = useDialogs();
   const showPageSetup = dialogs.isOpen('pageSetup');
   const setShowPageSetup = (v: boolean) =>
     v ? dialogs.open('pageSetup') : dialogs.close('pageSetup');


### PR DESCRIPTION
Completes the dialog-state consolidation (Spec #6), the prerequisite for the DialogContext step (`docs/internal/40`). Migrates the last 6 modal dialogs — Bookmarks, Character Spacing, Paragraph, Borders & Shading, Image Properties, Insert Symbol — onto the shipped `useDialogs` registry via the same behavior-identical adapter pattern used in batches 1–2. The extra-work open handlers (e.g. `handleOpenCharacterSpacing`, which captures selection state first) are untouched — they call the same setter, now registry-backed. Version history is intentionally left as a rail panel.

**Safety/verification:** typecheck 0 — complete call-site coverage, and it would have caught any `setX(prev => …)` functional-updater (there are none); prettier/eslint clean; `toolbar-state` e2e green. Now ALL modal dialog state lives in one registry.

Next: the DialogContext refactor (option 3) — ~100 edits routing both Toolbar/TitleBar consumers to the registry via context, as its own focused PR.