### PR TITLE
refactor(editor): DialogActionsContext — group ~18 dialog opens off the toolbar call site

### DIFF
--- a/docs/internal/40-hardening-followups-specs.md
+++ b/docs/internal/40-hardening-followups-specs.md
@@ -149,3 +149,40 @@ surface, read from `DocxEditor.tsx` `<EditorToolbar>` (81 props) and its consume
 2. DialogContext (~12 props + the 7-dialog registry migration — medium, ~100 edits).
 3. useDocumentIO (handleSave/loadBuffer — high, 39-fixture gate) THEN DocumentIOContext.
 4. Formatting / Insert contexts last (largest, most entangled with selection state).
+
+### DialogContext — the exact prop→handler map + edge cases (2026-07-20)
+
+Prerequisite DONE: all modal dialog state is now on the `useDialogs` registry
+(batches 1–3, PRs #324/#325/#332). versionHistory intentionally stays a rail panel.
+
+The 18 dialog handlers on `<EditorToolbar>` (DocxEditor.tsx ~9856-9960) split THREE ways —
+a uniform "route all to `dialogs.open()`" pass WILL introduce bugs:
+
+**A. Simple — safe to route to `dialogs.open('<key>')` and delete the prop:**
+onOpenCommandPalette, onOpenKeyboardShortcuts, onOpenPreferences, onOpenWatermark (all
+`() => setShowX(true)`); onOpenBookmarks (`() => setBookmarksDialogOpen(true)`);
+onOpenParagraphDialog, onOpenInsertSymbol, onOpenImageProperties (trivial `handleOpenX =
+setXOpen(true)`); onPageSetup, onFileProperties, onOpenWordCount, onOpenAccessibility,
+onOpenBuildingBlocks, onOpenDictionary, onOpenCitations (VERIFY each `handleOpenX` body is
+trivial before treating as pure-open — a couple may do light setup).
+
+**B. Extra-work handlers — MUST keep calling the handler, NOT `dialogs.open()`:**
+`onOpenCharacterSpacing → handleOpenCharacterSpacing` and `onOpenBordersShading →
+handleOpenBordersShading` read the active editor view and capture selection/initial state
+BEFORE opening. Provide these via the context as the FULL handler (a `dialogActions` object,
+not the raw registry), or leave them as props. Routing them to raw `dialogs.open()` silently
+drops the setup — a real defect.
+
+**C. Conditional / special:**
+`onShowAbout = appShellHidden ? undefined : handleShowAbout` — the About item HIDES in
+embedded mode; preserve that (context action must be undefined when appShellHidden, or the
+menu keeps gating on appShellHidden). `onOpenVersionHistory` — rail panel, exclude.
+
+**Recommended shape:** a `DialogContext` providing a stable `dialogActions` object
+(`{ openWordCount, openCharacterSpacing, … }`) where simple entries are
+`() => dialogs.open('key')` and extra-work entries are the existing handlers — so consumers
+are uniform and bucket B is preserved. Convert `Toolbar.tsx` + `TitleBar.tsx` to
+`useDialogActions()`, delete the ~18 props from both interfaces + the call site. Typecheck is
+the completeness net. Verify: open EVERY dialog from BOTH the menu bar and the command
+palette, plus confirm character-spacing/borders capture selection and About hides when
+embedded. Full-attention PR.


### PR DESCRIPTION
Executes option 3 of the DocxEditor decomposition, **non-breaking**.

**What:** the ~18 dialog-open handlers (word count, preferences, citations, bookmarks, page setup, watermark, …) previously passed as individual props on the `<EditorToolbar>` call site are now delivered via a dedicated `DialogActionsContext`. The DocxEditor god-component's worst call site drops from 81 → 63 props.

**Key constraint discovered mid-implementation:** `Toolbar` / `ToolbarProps` / `FormattingBar` are exported from the published `@casualoffice/docs` API (`index.ts`), and `EditorToolbarContext` already eliminates true prop-drilling. So the original "slim the interfaces" framing would have been a **breaking change**. This PR instead groups the handlers additively and leaves every public prop contract intact — an explicitly-passed `onOpen*` prop still wins in `FormattingBar`. The two live consumers (MenuBar, FormattingBar) re-source the handlers from the context under their historical names, so the ~900 lines of menu-building bodies are unchanged.

**Verified:** typecheck + 61 e2e green — Tools/Insert menus, command palette, FormattingBar, toolbar-state, line-spacing, image-layout.

Also includes the design/edge-case notes in `docs/internal/40`.

_Stacked on #332 (batch-3 registry adapters). Merge #332 first; retarget this to main after._