### PR TITLE
fix(painter): watermark missing on pages of long documents

### DIFF
--- a/docx-editor/.changeset/watermark-multipage.md
+++ b/docx-editor/.changeset/watermark-multipage.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix watermark going missing on some pages of long (8+ page) documents. Applying, removing, or changing a watermark now correctly repaints every page — previously the incremental-render cache key ignored the watermark, so already-rendered pages kept their stale state.

--- a/docx-editor/packages/core/src/layout-painter/__tests__/options-hash-watermark.test.ts
+++ b/docx-editor/packages/core/src/layout-painter/__tests__/options-hash-watermark.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Regression for the watermark-missing-on-some-pages bug (multi-page docs).
+ *
+ * `renderPages` skips a full rebuild (the incremental path) when
+ * `computeOptionsHash` is unchanged. The watermark overlay is drawn on every
+ * page shell, but the hash used to omit it — so on virtualized (8+ page) docs,
+ * applying / removing / changing a watermark left the cache key identical, the
+ * incremental path ran, and already-rendered pages never gained (or kept a
+ * stale) overlay. The hash must therefore change whenever the watermark does.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { computeOptionsHash } from '../renderPage';
+import type { RenderPageOptions } from '../renderPage';
+
+const base = {} as RenderPageOptions;
+const withWatermark = (wm: RenderPageOptions['watermark']): RenderPageOptions =>
+  ({ watermark: wm }) as RenderPageOptions;
+
+describe('computeOptionsHash — watermark', () => {
+  test('applying a watermark changes the hash (no-watermark → watermark)', () => {
+    const none = computeOptionsHash(base);
+    const applied = computeOptionsHash(withWatermark({ text: 'DRAFT' }));
+    expect(applied).not.toBe(none);
+  });
+
+  test('removing a watermark changes the hash (watermark → none)', () => {
+    const applied = computeOptionsHash(withWatermark({ text: 'DRAFT' }));
+    const removed = computeOptionsHash(base);
+    expect(removed).not.toBe(applied);
+  });
+
+  test('changing the watermark text changes the hash', () => {
+    expect(computeOptionsHash(withWatermark({ text: 'DRAFT' }))).not.toBe(
+      computeOptionsHash(withWatermark({ text: 'CONFIDENTIAL' }))
+    );
+  });
+
+  test('changing a watermark style knob (color/opacity/size/rotation) changes the hash', () => {
+    const a = computeOptionsHash(withWatermark({ text: 'DRAFT', color: '808080' }));
+    const b = computeOptionsHash(withWatermark({ text: 'DRAFT', color: 'ff0000' }));
+    const c = computeOptionsHash(withWatermark({ text: 'DRAFT', color: 'ff0000', opacity: 0.2 }));
+    const d = computeOptionsHash(withWatermark({ text: 'DRAFT', color: 'ff0000', rotation: 30 }));
+    expect(new Set([a, b, c, d]).size).toBe(4);
+  });
+
+  test('an empty-text watermark is treated as absent (matches the paint guard)', () => {
+    // renderPage only paints when `watermark?.text` is truthy; the hash mirrors
+    // that so an empty object doesn't spuriously force rebuilds.
+    expect(computeOptionsHash(withWatermark({ text: '' }))).toBe(computeOptionsHash(base));
+  });
+});

--- a/docx-editor/packages/core/src/layout-painter/renderPage.ts
+++ b/docx-editor/packages/core/src/layout-painter/renderPage.ts
@@ -1921,7 +1921,10 @@ function computePageFingerprint(page: Page): string {
  * Compute a hash for render options that affect all pages globally.
  * When this changes, all pages need a full re-render.
  */
-function computeOptionsHash(options: RenderPageOptions): string {
+// Exported for unit testing: the incremental-render cache key. Any option that
+// affects every page's shell (headers, borders, watermark, …) must be reflected
+// here, or applying it on a virtualized (8+ page) doc won't invalidate the cache.
+export function computeOptionsHash(options: RenderPageOptions): string {
   const parts: string[] = [];
 
   // Header/footer content changes affect all pages
@@ -1969,6 +1972,17 @@ function computeOptionsHash(options: RenderPageOptions): string {
   // Header/footer distances
   if (options.headerDistance !== undefined) parts.push(`hd:${options.headerDistance}`);
   if (options.footerDistance !== undefined) parts.push(`fd:${options.footerDistance}`);
+
+  // Watermark — drawn on every page shell, so applying/removing/changing it must
+  // invalidate the incremental-render cache. Omitting this let the watermark go
+  // missing on already-rendered pages of virtualized (8+ page) docs, since
+  // `canIncremental` stayed true and pages kept their stale overlay state.
+  if (options.watermark?.text) {
+    const w = options.watermark;
+    parts.push(
+      `wm:${w.text},${w.color ?? ''},${w.opacity ?? ''},${w.fontSize ?? ''},${w.rotation ?? ''}`
+    );
+  }
 
   return parts.join('|');
 }


### PR DESCRIPTION
**Bug:** on multi-page docs the watermark showed on only some pages.

**Cause:** the watermark overlay is painted on every page shell, but `computeOptionsHash()` (the incremental-render cache key in `renderPages`) didn't include it. On virtualized 8+ page docs, applying/removing/changing a watermark left the hash unchanged → `renderPages` took the incremental path → already-rendered pages never gained (or kept a stale) overlay. Only pages lazily built after the change showed it.

**Fix:** hash the watermark's identifying fields so any change invalidates the cache and forces a full repaint. Unit test on the now-exported `computeOptionsHash` (5 cases: apply / remove / text change / style-knob change / empty-text-is-absent).