### PR TITLE
fix(open): .md/.odt from home/recent files rendered as garbage

### DIFF
--- a/docx-editor/.changeset/md-open-routing.md
+++ b/docx-editor/.changeset/md-open-routing.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix opening a Markdown (.md) file from the home / recent-files list rendering as garbage. Foreign formats (.md/.odt/.txt) opened via any path are now converted to DOCX before the editor loads them, matching the in-editor File → Open behavior.

--- a/docx-editor/packages/react/src/components/CasualEditor.tsx
+++ b/docx-editor/packages/react/src/components/CasualEditor.tsx
@@ -300,9 +300,16 @@ export const CasualEditor = forwardRef<CasualEditorRef, CasualEditorProps>(
         try {
           const result = await fileSource.open(docId);
           if (cancelled) return;
+          // Normalize foreign formats (e.g. .md / .odt / .txt) to DOCX before
+          // handing bytes to the editor. Without this a stored/recent .md was
+          // fed to the DOCX zip parser and rendered as garbage. DOCX passes
+          // through untouched (no worker spun up).
+          const { toDocxBytes } = await import('../lib/format-converter');
+          const buffer = await toDocxBytes(result.bytes, result.name);
+          if (cancelled) return;
           setLoadState({
             kind: 'ready',
-            buffer: result.bytes,
+            buffer,
             fileName: result.name,
             etag: result.etag,
           });

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -8068,21 +8068,11 @@ body { background: white; }
       if (!file) return;
       try {
         const buffer = await file.arrayBuffer();
-        const { formatFromFilename, isForeignFormat, convertToDocx } =
-          await import('../lib/format-converter');
-        const fmt = formatFromFilename(file.name);
-        let docxBuffer: ArrayBuffer = buffer;
-        if (fmt && isForeignFormat(fmt)) {
-          // .odt / .md / .txt → DOCX via the WASM worker, then feed the
-          // existing parser. PDF is intentionally not handled.
-          const out = await convertToDocx(new Uint8Array(buffer), fmt);
-          // Take ownership of just the populated slice so the buffer
-          // passed to loadBuffer is exactly the converter's output.
-          docxBuffer = out.buffer.slice(
-            out.byteOffset,
-            out.byteOffset + out.byteLength
-          ) as ArrayBuffer;
-        }
+        // .odt / .md / .txt → DOCX via the WASM worker, then feed the existing
+        // parser (PDF is intentionally not handled). Shared with the
+        // FileSource/home open path so both convert identically.
+        const { toDocxBytes } = await import('../lib/format-converter');
+        const docxBuffer = await toDocxBytes(buffer, file.name);
         await loadBuffer(docxBuffer);
         const cleanName = file.name.replace(/\.(docx|odt|md|markdown|txt)$/i, '');
         onDocumentNameChange?.(cleanName);

--- a/docx-editor/packages/react/src/lib/format-converter.test.ts
+++ b/docx-editor/packages/react/src/lib/format-converter.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Routing coverage for the file-open format decision. The bug this guards:
+ * opening a Markdown file via the FileSource / home-screen path fed its bytes
+ * straight to the DOCX zip parser (garbled render). `toDocxBytes` is the shared
+ * decision now used by every open path; a `.docx`/unknown/no-name input must
+ * pass through untouched (no worker), and a foreign extension must be routed
+ * for conversion.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { formatFromFilename, isForeignFormat, toDocxBytes } from './format-converter';
+
+describe('formatFromFilename + isForeignFormat — open routing decision', () => {
+  test('markdown extensions resolve to the convertible "md" format', () => {
+    expect(formatFromFilename('notes.md')).toBe('md');
+    expect(formatFromFilename('README.markdown')).toBe('md');
+    expect(isForeignFormat('md')).toBe(true);
+  });
+
+  test('odt and txt are convertible foreign formats', () => {
+    expect(isForeignFormat(formatFromFilename('a.odt') as string)).toBe(true);
+    expect(isForeignFormat(formatFromFilename('a.txt') as string)).toBe(true);
+  });
+
+  test('docx and pdf are NOT foreign (stay on the native path)', () => {
+    expect(formatFromFilename('report.docx')).toBe('docx');
+    expect(isForeignFormat('docx')).toBe(false);
+    expect(isForeignFormat('pdf')).toBe(false);
+  });
+});
+
+describe('toDocxBytes — passthrough (no worker) for native/unknown inputs', () => {
+  const bytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04]).buffer; // "PK.." zip magic
+
+  test('a .docx filename returns the identical buffer', async () => {
+    expect(await toDocxBytes(bytes, 'report.docx')).toBe(bytes);
+  });
+
+  test('a non-convertible extension (.pdf) returns the identical buffer', async () => {
+    expect(await toDocxBytes(bytes, 'scan.pdf')).toBe(bytes);
+  });
+
+  test('no filename returns the identical buffer', async () => {
+    expect(await toDocxBytes(bytes)).toBe(bytes);
+  });
+});

--- a/docx-editor/packages/react/src/lib/format-converter.ts
+++ b/docx-editor/packages/react/src/lib/format-converter.ts
@@ -85,6 +85,32 @@ export async function convertToDocx(bytes: Uint8Array, from: ForeignFormat): Pro
 }
 
 /**
+ * Normalize opened-file bytes to DOCX bytes for the editor's DOCX parser.
+ *
+ * If `fileName` names a foreign format we can convert (.odt / .md / .markdown /
+ * .txt / config sources), route the bytes through the WASM converter; otherwise
+ * return them unchanged (DOCX and unknown types feed the parser as before).
+ *
+ * This is the shared entry point for EVERY file-open path. The in-editor
+ * File → Open picker already did this inline; the FileSource / home-screen open
+ * path did not, so a stored/recent `.md` was handed straight to the DOCX zip
+ * parser and rendered as garbage. Both paths now funnel through here.
+ *
+ * Note: on the conversion branch the input buffer is transferred to the worker
+ * (neutered); callers must use the returned buffer and not the original. The
+ * pass-through branch leaves the input untouched.
+ */
+export async function toDocxBytes(bytes: ArrayBuffer, fileName?: string): Promise<ArrayBuffer> {
+  const fmt = fileName ? formatFromFilename(fileName) : null;
+  if (fmt && isForeignFormat(fmt)) {
+    const out = await convertToDocx(new Uint8Array(bytes), fmt);
+    // Own exactly the converter's output slice.
+    return out.buffer.slice(out.byteOffset, out.byteOffset + out.byteLength) as ArrayBuffer;
+  }
+  return bytes;
+}
+
+/**
  * Convert DOCX bytes to a foreign format. Used by File → Export As — the
  * existing serializer produces the DOCX bytes, we hand them off here.
  *


### PR DESCRIPTION
**Bug:** opening a Markdown file via the home / recent-files list loaded it into the editor as garbage.

**Cause:** the in-editor File ▸ Open picker converts foreign formats (.md/.odt/.txt) to DOCX, but the FileSource / home open path (`fileSource.open` → `documentBuffer` → `loadBuffer` → `parseDocx`) had no conversion, so markdown bytes hit the DOCX zip parser.

**Fix:** a shared `toDocxBytes(bytes, fileName?)` helper, called at the `CasualEditor` open boundary where the filename is available — `formatFromFilename` is a cheap sync check, so the WASM converter only spins up for actual foreign files (`.docx` passes straight through). The in-editor picker was refactored onto the same helper so both open paths convert identically.

**Verified:** 6 unit tests (routing + passthrough) + `odt-open` e2e + typecheck. (Restore-version and the dev demo remain DOCX-only paths — they don't open user markdown.)