### PR TITLE
fix(layout): text runs off the page with a negative indent

### DIFF
--- a/docx-editor/.changeset/negative-indent-overflow.md
+++ b/docx-editor/.changeset/negative-indent-overflow.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix text running off the page for paragraphs with a negative left/right indent. Text wrapping now clamps negative block indents to zero to match the renderer, so lines stay inside the page content box instead of overflowing into the margin.

--- a/docx-editor/packages/core/src/layout-bridge/measuring/__tests__/negative-indent-wrap.test.ts
+++ b/docx-editor/packages/core/src/layout-bridge/measuring/__tests__/negative-indent-wrap.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Regression for the "text runs off the page" bug.
+ *
+ * The renderer only applies POSITIVE left/right indents (renderParagraph clamps
+ * negatives to 0). Measurement, however, used the signed indent, so a negative
+ * left/right indent WIDENED the wrap width (maxWidth - (-n) = maxWidth + n).
+ * Lines were then packed wider than the content box and painted (white-space:
+ * pre) past the page margin. Measurement must clamp block indent to >= 0 to
+ * match the renderer, so a negative indent wraps exactly like a zero indent.
+ */
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { measureParagraph } from '../measureParagraph';
+import { resetCanvasContext } from '../measureContainer';
+import type { ParagraphBlock, ParagraphMeasure } from '../../../layout-engine/types';
+
+let zero: ParagraphMeasure;
+let negative: ParagraphMeasure;
+let positive: ParagraphMeasure;
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  // happy-dom has no canvas 2D context. Inject a deterministic one: text width
+  // is proportional to character count, so wrapping is stable and independent
+  // of any real font metrics — exactly what a wrap-width regression needs.
+  const fakeCtx = {
+    font: '',
+    measureText: (s: string) => ({
+      width: s.length * 8,
+      actualBoundingBoxAscent: 12,
+      actualBoundingBoxDescent: 4,
+    }),
+  };
+  // @ts-expect-error — override canvas for measurement determinism in tests.
+  HTMLCanvasElement.prototype.getContext = () => fakeCtx;
+  resetCanvasContext();
+
+  // Measured AFTER the stub is installed (a describe-body const would run at
+  // collection time, before beforeAll).
+  zero = measureWithLeftIndent(0);
+  negative = measureWithLeftIndent(-100);
+  positive = measureWithLeftIndent(100);
+});
+afterAll(() => GlobalRegistrator.unregister());
+
+// Long enough to wrap several times inside a narrow content box.
+const TEXT = Array.from({ length: 40 }, (_, i) => `word${i}`).join(' ');
+const MAX_WIDTH = 300;
+
+function measureWithLeftIndent(left: number) {
+  const block = {
+    kind: 'paragraph',
+    id: 'p',
+    pmStart: 0,
+    pmEnd: 0,
+    runs: [{ kind: 'text', text: TEXT }],
+    attrs: { defaultFontSize: 12, defaultFontFamily: 'Arial', indent: { left } },
+  } as unknown as ParagraphBlock;
+  return measureParagraph(block, MAX_WIDTH);
+}
+
+describe('measureParagraph — negative indent does not widen the wrap', () => {
+  test('measurement actually responds to width (guard: positive indent wraps into more lines)', () => {
+    // Proves the canvas is measuring text and wrapping — otherwise the equality
+    // assertion below would pass vacuously.
+    expect(positive.lines.length).toBeGreaterThan(zero.lines.length);
+  });
+
+  test('a negative left indent wraps identically to a zero indent (clamped, no overflow)', () => {
+    expect(negative.lines.length).toBe(zero.lines.length);
+    const widestNegative = Math.max(...negative.lines.map((l) => l.width));
+    const widestZero = Math.max(...zero.lines.map((l) => l.width));
+    expect(widestNegative).toBeCloseTo(widestZero, 5);
+  });
+
+  test('no measured line exceeds the content-box width', () => {
+    for (const line of negative.lines) {
+      expect(line.width).toBeLessThanOrEqual(MAX_WIDTH + 1);
+    }
+  });
+});

--- a/docx-editor/packages/core/src/layout-bridge/measuring/measureParagraph.ts
+++ b/docx-editor/packages/core/src/layout-bridge/measuring/measureParagraph.ts
@@ -416,10 +416,17 @@ export function measureParagraph(
   const floatingZones = options?.floatingZones;
   const paragraphYOffset = options?.paragraphYOffset ?? 0;
 
-  // Handle indentation
+  // Handle indentation. Clamp block left/right indent to >= 0 to match the
+  // renderer, which only applies positive indents (renderParagraph.ts). A
+  // negative left/right indent used to WIDEN the measured wrap width here
+  // (maxWidth - negative = maxWidth + |indent|), so lines were packed wider
+  // than the renderer's content box and then painted (white-space: pre) past
+  // the page margin — the "text runs off the page" bug. firstLine/hanging are
+  // deliberately left signed: those are handled separately and legitimately go
+  // negative (hanging indents).
   const indent = attrs?.indent;
-  const indentLeft = indent?.left ?? 0;
-  const indentRight = indent?.right ?? 0;
+  const indentLeft = Math.max(0, indent?.left ?? 0);
+  const indentRight = Math.max(0, indent?.right ?? 0);
   const firstLineOffset = (indent?.firstLine ?? 0) - (indent?.hanging ?? 0);
 
   // Calculate base available widths (before floating image adjustment)


### PR DESCRIPTION
**Bug:** in some documents text spilled past the page margin (ran off the page).

**Cause:** `measureParagraph` computed the wrap width from the **signed** block indent (`maxWidth - indentLeft - indentRight`), so a negative left/right indent *widened* it to `maxWidth + |indent|`. The renderer only applies **positive** indents (negatives clamp to 0), so lines measured to the wider width were painted (`white-space: pre`) beyond the content box, into the margin.

**Fix:** clamp the block left/right indent to `>= 0` in measurement, matching the renderer. `firstLine`/`hanging` stay signed (hanging indents legitimately go negative and are handled separately); positive indents are unaffected.

**Verified:** a regression test asserts a negative indent now wraps identically to a zero indent — it fails on the pre-fix code and passes after. 179 layout unit tests + typecheck green. Measurement-only, so serialization/round-trip is untouched.

_Follow-up (separate): full Word fidelity would have the renderer *honor* negative indents (shift text into the margin); this PR makes measure/paint consistent and stops the overflow._