### PR TITLE
refactor(editor): DialogActionsContext (recovery of stranded #333)

### DIFF
--- a/docs/internal/27-production-grade-tracker.md
+++ b/docs/internal/27-production-grade-tracker.md
@@ -56,6 +56,34 @@ Whole-corpus staleness triage (37 docs). Deleted `docs/DEPLOYMENT.md` (supersede
 backend-truth drift and shipped-status drift across 22 docs. This tracker is now the single
 live production tracker.
 
+### DocxEditor decomposition (Spec #6) — progress (2026-07-21)
+
+- **Dialog registry** — all 22 modal dialogs on the `useDialogs` reducer registry
+  (batches 1–3, #324/#325/#332); download/IO primitives extracted to `utils/download.ts`
+  (#326–#329).
+- **DialogActionsContext (option 3, #333)** — ~18 dialog-open handlers grouped into one
+  context; DocxEditor's `<EditorToolbar>` call site 81 → 63 props. **Non-breaking** —
+  `Toolbar`/`ToolbarProps`/`FormattingBar` are published API, so their prop contracts were
+  left intact. Verified typecheck + 61 e2e.
+- **Still open (dedicated sessions):** `useDocumentIO` (handleSave/loadBuffer behind the
+  39-fixture round-trip gate), ViewState/Formatting/Insert contexts. Specs in
+  [40-hardening-followups-specs.md](./40-hardening-followups-specs.md).
+
+### Hands-on product bugs (2026-07-21) — all fixed
+
+Found through real use; each root-caused (multi-agent), fixed, and regression-tested:
+- **B1 — `.md` open rendered as garbage** → **Fixed (#335)**. The FileSource / home-open path
+  fed markdown bytes straight to the DOCX zip parser (the in-editor picker already converted).
+  Shared `toDocxBytes()` helper applied at the open boundary; `.docx` still passes through
+  with no worker. 6 unit tests + `odt-open` e2e.
+- **B2 — watermark missing on some pages of 8+ page docs** → **Fixed (#334)**. The
+  incremental-render cache key (`computeOptionsHash`) ignored the watermark, so virtualized
+  docs kept stale per-page overlay state. Hash the watermark. 5 unit tests.
+- **B3 — text ran off the page** → **Fixed (#336)**. Wrapping used the signed block indent
+  (a negative indent *widened* the wrap width) while the renderer clamps negatives to 0.
+  Clamp measurement to match. Regression test fails on pre-fix code; 179 layout tests green.
+  _Follow-up: renderer honoring negative indents (pull text into the margin) for full Word
+  fidelity — the reported defect was the overflow, now fixed._
 
 **Target:** A reliable, polished, production-grade self-hosted office suite where Casual Docs can stand credibly against LibreOffice Writer and OnlyOffice Document Editor, and share one collaboration protocol/server with Casual Sheets and Casual Slides.
 

--- a/docs/internal/40-hardening-followups-specs.md
+++ b/docs/internal/40-hardening-followups-specs.md
@@ -149,3 +149,40 @@ surface, read from `DocxEditor.tsx` `<EditorToolbar>` (81 props) and its consume
 2. DialogContext (~12 props + the 7-dialog registry migration — medium, ~100 edits).
 3. useDocumentIO (handleSave/loadBuffer — high, 39-fixture gate) THEN DocumentIOContext.
 4. Formatting / Insert contexts last (largest, most entangled with selection state).
+
+### DialogContext — the exact prop→handler map + edge cases (2026-07-20)
+
+Prerequisite DONE: all modal dialog state is now on the `useDialogs` registry
+(batches 1–3, PRs #324/#325/#332). versionHistory intentionally stays a rail panel.
+
+The 18 dialog handlers on `<EditorToolbar>` (DocxEditor.tsx ~9856-9960) split THREE ways —
+a uniform "route all to `dialogs.open()`" pass WILL introduce bugs:
+
+**A. Simple — safe to route to `dialogs.open('<key>')` and delete the prop:**
+onOpenCommandPalette, onOpenKeyboardShortcuts, onOpenPreferences, onOpenWatermark (all
+`() => setShowX(true)`); onOpenBookmarks (`() => setBookmarksDialogOpen(true)`);
+onOpenParagraphDialog, onOpenInsertSymbol, onOpenImageProperties (trivial `handleOpenX =
+setXOpen(true)`); onPageSetup, onFileProperties, onOpenWordCount, onOpenAccessibility,
+onOpenBuildingBlocks, onOpenDictionary, onOpenCitations (VERIFY each `handleOpenX` body is
+trivial before treating as pure-open — a couple may do light setup).
+
+**B. Extra-work handlers — MUST keep calling the handler, NOT `dialogs.open()`:**
+`onOpenCharacterSpacing → handleOpenCharacterSpacing` and `onOpenBordersShading →
+handleOpenBordersShading` read the active editor view and capture selection/initial state
+BEFORE opening. Provide these via the context as the FULL handler (a `dialogActions` object,
+not the raw registry), or leave them as props. Routing them to raw `dialogs.open()` silently
+drops the setup — a real defect.
+
+**C. Conditional / special:**
+`onShowAbout = appShellHidden ? undefined : handleShowAbout` — the About item HIDES in
+embedded mode; preserve that (context action must be undefined when appShellHidden, or the
+menu keeps gating on appShellHidden). `onOpenVersionHistory` — rail panel, exclude.
+
+**Recommended shape:** a `DialogContext` providing a stable `dialogActions` object
+(`{ openWordCount, openCharacterSpacing, … }`) where simple entries are
+`() => dialogs.open('key')` and extra-work entries are the existing handlers — so consumers
+are uniform and bucket B is preserved. Convert `Toolbar.tsx` + `TitleBar.tsx` to
+`useDialogActions()`, delete the ~18 props from both interfaces + the call site. Typecheck is
+the completeness net. Verify: open EVERY dialog from BOTH the menu bar and the command
+palette, plus confirm character-spacing/borders capture selection and About hides when
+embedded. Full-attention PR.

--- a/docx-editor/.changeset/dialog-actions-context.md
+++ b/docx-editor/.changeset/dialog-actions-context.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Internal: route the ~18 dialog-open handlers through a dedicated DialogActionsContext instead of individual props on the toolbar, slimming the DocxEditor call site. No public API change.

--- a/docx-editor/packages/react/src/components/DialogActionsContext.tsx
+++ b/docx-editor/packages/react/src/components/DialogActionsContext.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+import { createContext, useContext } from 'react';
+
+/**
+ * DialogActions — the dialog/overlay OPEN handlers the editor chrome
+ * (MenuBar, FormattingBar) invokes.
+ *
+ * Why a dedicated context: these ~18 handlers were previously passed as
+ * individual props on the `<EditorToolbar>` call site in DocxEditor (the
+ * god-component), inflating an already ~80-prop call. They don't vary per
+ * sub-component and are only ever produced by DocxEditor, so a single
+ * cohesive context both slims that call site and groups "opening a dialog"
+ * into one typed surface.
+ *
+ * Deliberately NOT folded into `ToolbarProps` / `EditorToolbarContext`:
+ * `ToolbarProps` (and the `Toolbar` / `FormattingBar` components) are part
+ * of the published `@casualoffice/docs` API — removing the flat `onOpen*`
+ * props from them would be a breaking change. This context is purely
+ * internal wiring; the public prop contracts are untouched, and consumers
+ * still honour an explicitly-passed `onOpen*` prop first (see FormattingBar).
+ *
+ * Each field is optional: a `null` provider (or a missing key) simply means
+ * "that menu entry is absent", which the consumers already presence-gate on.
+ */
+export interface DialogActions {
+  openBookmarks?: () => void;
+  openCharacterSpacing?: () => void;
+  openParagraphDialog?: () => void;
+  openBordersShading?: () => void;
+  openInsertSymbol?: () => void;
+  openImageProperties?: () => void;
+  openPageSetup?: () => void;
+  openFileProperties?: () => void;
+  openWordCount?: () => void;
+  showAbout?: () => void;
+  openCommandPalette?: () => void;
+  openKeyboardShortcuts?: () => void;
+  openPreferences?: () => void;
+  openWatermark?: () => void;
+  openAccessibility?: () => void;
+  openBuildingBlocks?: () => void;
+  openDictionary?: () => void;
+  openCitations?: () => void;
+}
+
+const EMPTY: DialogActions = {};
+
+export const DialogActionsContext = createContext<DialogActions | null>(null);
+
+/**
+ * Read the dialog-open handlers. Returns a stable empty object when no
+ * provider is present, so callers can `dlg.openX?.()` without null checks.
+ */
+export function useDialogActions(): DialogActions {
+  return useContext(DialogActionsContext) ?? EMPTY;
+}

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -44,6 +44,7 @@ import {
 } from './Toolbar';
 import type { FontOption } from './ui/FontPicker';
 import { EditorToolbar } from './EditorToolbar';
+import { DialogActionsContext, type DialogActions } from './DialogActionsContext';
 import { StatusBar } from './StatusBar';
 import { FocusModeBar } from './FocusModeBar';
 import { useStatPrefs } from './statbar-prefs';
@@ -7458,6 +7459,34 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     setShowDictionary(true);
   }, [getActiveEditorView]);
 
+  // Dialog-open handlers, grouped into one object delivered to the toolbar
+  // chrome (MenuBar / FormattingBar) via DialogActionsContext instead of ~18
+  // individual props on the <EditorToolbar> call site below. A plain object
+  // (not memoized) is intentional: the call site already passed fresh inline
+  // arrows every render, so the toolbar subtree's re-render cadence is
+  // unchanged. `showAbout`/... stay presence-gated (undefined ⇒ menu entry
+  // hidden), preserving the embedded-mode behavior.
+  const dialogActions: DialogActions = {
+    openBookmarks: () => setBookmarksDialogOpen(true),
+    openCharacterSpacing: handleOpenCharacterSpacing,
+    openParagraphDialog: handleOpenParagraphDialog,
+    openBordersShading: handleOpenBordersShading,
+    openInsertSymbol: handleOpenInsertSymbol,
+    openImageProperties: handleOpenImageProperties,
+    openPageSetup: handleOpenPageSetup,
+    openFileProperties: handleOpenFileProperties,
+    openWordCount: handleOpenWordCount,
+    showAbout: appShellHidden ? undefined : handleShowAbout,
+    openCommandPalette: () => setShowCommandPalette(true),
+    openKeyboardShortcuts: () => setShowKeyboardShortcuts(true),
+    openPreferences: () => setShowPreferences(true),
+    openWatermark: () => setShowWatermarkDialog(true),
+    openAccessibility: handleOpenAccessibility,
+    openBuildingBlocks: handleOpenBuildingBlocks,
+    openDictionary: handleOpenDictionary,
+    openCitations: handleOpenCitations,
+  };
+
   // Watermark apply/clear handler (C5) — writes into the doc-level
   // body.watermark slot so the painter draws the overlay on the next
   // render. `undefined` clears it. Round-trip to header XML lands in a
@@ -9855,150 +9884,134 @@ body { background: white; }
                       ref={toolbarRefCallback}
                       className="z-50 flex flex-col gap-0 flex-shrink-0"
                     >
-                      <EditorToolbar
-                        // When the agent panel is open, round the toolbar's
-                        // bottom-right corner so it mirrors the panel's top-left.
-                        // The radius transition (inline style on the inner div)
-                        // makes opening / closing ease instead of snap.
-                        className={agentPanelOpen ? 'rounded-br-2xl' : undefined}
-                        style={{
-                          transition: 'border-radius var(--doc-anim-slow)',
-                        }}
-                        currentFormatting={state.selectionFormatting}
-                        onFormat={handleFormat}
-                        onUndo={undoActiveEditor}
-                        onRedo={redoActiveEditor}
-                        canUndo={canUndoActiveEditor}
-                        canRedo={canRedoActiveEditor}
-                        disabled={readOnly}
-                        documentStyles={history.state?.package.styles?.styles}
-                        theme={history.state?.package.theme || theme}
-                        showPrintButton={showPrintButtonEffective}
-                        fontFamilies={fontFamilies}
-                        onPrint={handleDirectPrint}
-                        /* When the app shell is hidden (embedded), the host
+                      <DialogActionsContext.Provider value={dialogActions}>
+                        <EditorToolbar
+                          // When the agent panel is open, round the toolbar's
+                          // bottom-right corner so it mirrors the panel's top-left.
+                          // The radius transition (inline style on the inner div)
+                          // makes opening / closing ease instead of snap.
+                          className={agentPanelOpen ? 'rounded-br-2xl' : undefined}
+                          style={{
+                            transition: 'border-radius var(--doc-anim-slow)',
+                          }}
+                          currentFormatting={state.selectionFormatting}
+                          onFormat={handleFormat}
+                          onUndo={undoActiveEditor}
+                          onRedo={redoActiveEditor}
+                          canUndo={canUndoActiveEditor}
+                          canRedo={canRedoActiveEditor}
+                          disabled={readOnly}
+                          documentStyles={history.state?.package.styles?.styles}
+                          theme={history.state?.package.theme || theme}
+                          showPrintButton={showPrintButtonEffective}
+                          fontFamilies={fontFamilies}
+                          onPrint={handleDirectPrint}
+                          /* When the app shell is hidden (embedded), the host
                           owns file identity/lifecycle and versions — prune the
                           File-menu entries it provides so the editing menus
                           stay without a redundant "second product" File menu.
                           A MenuBar item disappears when its callback is
                           undefined (presence-gated). */
-                        onOpen={appShellHidden ? undefined : handleOpenDocument}
-                        onSave={handleDownloadDocument}
-                        onMakeCopy={appShellHidden ? undefined : handleMakeCopy}
-                        onEmailAsAttachment={appShellHidden ? undefined : handleEmailAsAttachment}
-                        onOpenVersionHistory={
-                          appShellHidden
-                            ? undefined
-                            : () => {
-                                if (!showVersionHistory) handleToggleVersionHistory();
-                              }
-                        }
-                        onNew={appShellHidden ? undefined : onNew}
-                        showZoomControl={showZoomControlEffective}
-                        zoom={state.zoom}
-                        onZoomChange={handleZoomChange}
-                        onRefocusEditor={focusActiveEditor}
-                        onInsertTable={handleInsertTable}
-                        showTableInsert={true}
-                        onInsertImage={handleInsertImageClick}
-                        onInsertPageBreak={handleInsertPageBreak}
-                        onInsertSectionBreak={handleInsertSectionBreak}
-                        onInsertField={handleInsertField}
-                        onInsertTOC={handleInsertTOC}
-                        onOpenBookmarks={() => setBookmarksDialogOpen(true)}
-                        onOpenCharacterSpacing={handleOpenCharacterSpacing}
-                        onOpenParagraphDialog={handleOpenParagraphDialog}
-                        onOpenBordersShading={handleOpenBordersShading}
-                        onAddComment={handleStartAddComment}
-                        onPaintFormat={handleTogglePaintFormat}
-                        paintFormatArmed={paintFormatMarks != null}
-                        onInsertHorizontalRule={handleInsertHorizontalRule}
-                        onInsertFootnote={handleInsertFootnote}
-                        onOpenInsertSymbol={handleOpenInsertSymbol}
-                        onToggleShowRuler={handleToggleShowRuler}
-                        rulerVisible={showRulerEffective}
-                        onToggleShowFormattingMarks={handleToggleShowFormattingMarks}
-                        showFormattingMarks={showFormattingMarks}
-                        onToggleOutline={handleToggleOutline}
-                        outlineVisible={showOutlineEffective}
-                        imageContext={state.pmImageContext}
-                        onImageWrapType={handleImageWrapType}
-                        onImageTransform={handleImageTransform}
-                        onOpenImageProperties={handleOpenImageProperties}
-                        onPageSetup={handleOpenPageSetup}
-                        onFileProperties={handleOpenFileProperties}
-                        onOpenWordCount={handleOpenWordCount}
-                        // Voice typing hidden — Web Speech API is
-                        // inconsistent across browsers. Re-enable when
-                        // we standardize on a backend.
-                        onExportPdf={handleExportPdf}
-                        onExportOdt={handleExportOdt}
-                        onExportMd={handleExportMd}
-                        /* Branding/support entries the host owns in embedded. */
-                        onReportBug={appShellHidden ? undefined : handleReportBug}
-                        onShowAbout={appShellHidden ? undefined : handleShowAbout}
-                        onOpenCommandPalette={() => setShowCommandPalette(true)}
-                        onOpenKeyboardShortcuts={() => setShowKeyboardShortcuts(true)}
-                        onOpenPreferences={() => setShowPreferences(true)}
-                        onOpenWatermark={() => setShowWatermarkDialog(true)}
-                        onOpenAccessibility={handleOpenAccessibility}
-                        onOpenBuildingBlocks={handleOpenBuildingBlocks}
-                        onConvertSelectionToTable={handleConvertSelectionToTable}
-                        onConvertTableToText={
-                          state.pmTableContext?.isInTable ? handleConvertTableToText : undefined
-                        }
-                        onOpenDictionary={handleOpenDictionary}
-                        // LLM-stack entry points hidden: onOpenTranslate,
-                        // onTranslateDocument, onOpenWritingAssistant,
-                        // onOpenExplore. WebLLM inference blocks the main
-                        // thread on long docs; until that lands a yielding
-                        // path, these surfaces stay off. Re-wire with the
-                        // existing handlers when ready.
-                        onToggleSpellcheck={handleToggleSpellcheck}
-                        spellcheckEnabled={spellOn}
-                        onToggleGrammar={handleToggleGrammar}
-                        grammarEnabled={grammarOn}
-                        onOpenCitations={handleOpenCitations}
-                        onInsertShape={handleInsertShape}
-                        onInsertTextBox={handleInsertTextBox}
-                        onSetColorTheme={handleSetColorTheme}
-                        colorTheme={colorTheme}
-                        isDirty={isDirty}
-                        isSaving={isSaving}
-                        tableContext={state.pmTableContext}
-                        onTableAction={handleTableAction}
-                      >
-                        {/* The title row (logo + document name) is the app
+                          onOpen={appShellHidden ? undefined : handleOpenDocument}
+                          onSave={handleDownloadDocument}
+                          onMakeCopy={appShellHidden ? undefined : handleMakeCopy}
+                          onEmailAsAttachment={appShellHidden ? undefined : handleEmailAsAttachment}
+                          onOpenVersionHistory={
+                            appShellHidden
+                              ? undefined
+                              : () => {
+                                  if (!showVersionHistory) handleToggleVersionHistory();
+                                }
+                          }
+                          onNew={appShellHidden ? undefined : onNew}
+                          showZoomControl={showZoomControlEffective}
+                          zoom={state.zoom}
+                          onZoomChange={handleZoomChange}
+                          onRefocusEditor={focusActiveEditor}
+                          onInsertTable={handleInsertTable}
+                          showTableInsert={true}
+                          onInsertImage={handleInsertImageClick}
+                          onInsertPageBreak={handleInsertPageBreak}
+                          onInsertSectionBreak={handleInsertSectionBreak}
+                          onInsertField={handleInsertField}
+                          onInsertTOC={handleInsertTOC}
+                          onAddComment={handleStartAddComment}
+                          onPaintFormat={handleTogglePaintFormat}
+                          paintFormatArmed={paintFormatMarks != null}
+                          onInsertHorizontalRule={handleInsertHorizontalRule}
+                          onInsertFootnote={handleInsertFootnote}
+                          onToggleShowRuler={handleToggleShowRuler}
+                          rulerVisible={showRulerEffective}
+                          onToggleShowFormattingMarks={handleToggleShowFormattingMarks}
+                          showFormattingMarks={showFormattingMarks}
+                          onToggleOutline={handleToggleOutline}
+                          outlineVisible={showOutlineEffective}
+                          imageContext={state.pmImageContext}
+                          onImageWrapType={handleImageWrapType}
+                          onImageTransform={handleImageTransform}
+                          // Voice typing hidden — Web Speech API is
+                          // inconsistent across browsers. Re-enable when
+                          // we standardize on a backend.
+                          onExportPdf={handleExportPdf}
+                          onExportOdt={handleExportOdt}
+                          onExportMd={handleExportMd}
+                          /* Branding/support entries the host owns in embedded. */
+                          onReportBug={appShellHidden ? undefined : handleReportBug}
+                          onConvertSelectionToTable={handleConvertSelectionToTable}
+                          onConvertTableToText={
+                            state.pmTableContext?.isInTable ? handleConvertTableToText : undefined
+                          }
+                          // LLM-stack entry points hidden: onOpenTranslate,
+                          // onTranslateDocument, onOpenWritingAssistant,
+                          // onOpenExplore. WebLLM inference blocks the main
+                          // thread on long docs; until that lands a yielding
+                          // path, these surfaces stay off. Re-wire with the
+                          // existing handlers when ready.
+                          onToggleSpellcheck={handleToggleSpellcheck}
+                          spellcheckEnabled={spellOn}
+                          onToggleGrammar={handleToggleGrammar}
+                          grammarEnabled={grammarOn}
+                          onInsertShape={handleInsertShape}
+                          onInsertTextBox={handleInsertTextBox}
+                          onSetColorTheme={handleSetColorTheme}
+                          colorTheme={colorTheme}
+                          isDirty={isDirty}
+                          isSaving={isSaving}
+                          tableContext={state.pmTableContext}
+                          onTableAction={handleTableAction}
+                        >
+                          {/* The title row (logo + document name) is the app
                           shell — hidden in `chrome:"embedded"`. The menu bar is
                           the editing surface, gated independently, so embedded
                           keeps the Insert/Format/Tools/… menus while dropping
                           only the logo/name row (doc 39). */}
-                        {(showTitleBarEffective || showMenuBarEffective) && (
-                          <EditorToolbar.TitleBar>
-                            {showTitleBarEffective && renderLogo && (
-                              <EditorToolbar.Logo>{renderLogo()}</EditorToolbar.Logo>
-                            )}
-                            {showTitleBarEffective && documentName !== undefined && (
-                              <EditorToolbar.DocumentName
-                                value={documentName}
-                                onChange={onDocumentNameChange}
-                                editable={documentNameEditable}
-                              />
-                            )}
-                            {showTitleBarEffective && renderTitleBarRight && (
-                              <EditorToolbar.TitleBarRight>
-                                {renderTitleBarRight()}
-                              </EditorToolbar.TitleBarRight>
-                            )}
-                            {showMenuBarEffective && <EditorToolbar.MenuBar />}
-                          </EditorToolbar.TitleBar>
-                        )}
-                        {showToolbarEffective && (
-                          <EditorToolbar.FormattingBar>
-                            {toolbarChildren}
-                          </EditorToolbar.FormattingBar>
-                        )}
-                      </EditorToolbar>
+                          {(showTitleBarEffective || showMenuBarEffective) && (
+                            <EditorToolbar.TitleBar>
+                              {showTitleBarEffective && renderLogo && (
+                                <EditorToolbar.Logo>{renderLogo()}</EditorToolbar.Logo>
+                              )}
+                              {showTitleBarEffective && documentName !== undefined && (
+                                <EditorToolbar.DocumentName
+                                  value={documentName}
+                                  onChange={onDocumentNameChange}
+                                  editable={documentNameEditable}
+                                />
+                              )}
+                              {showTitleBarEffective && renderTitleBarRight && (
+                                <EditorToolbar.TitleBarRight>
+                                  {renderTitleBarRight()}
+                                </EditorToolbar.TitleBarRight>
+                              )}
+                              {showMenuBarEffective && <EditorToolbar.MenuBar />}
+                            </EditorToolbar.TitleBar>
+                          )}
+                          {showToolbarEffective && (
+                            <EditorToolbar.FormattingBar>
+                              {toolbarChildren}
+                            </EditorToolbar.FormattingBar>
+                          )}
+                        </EditorToolbar>
+                      </DialogActionsContext.Provider>
                     </div>
                   )}
 

--- a/docx-editor/packages/react/src/components/FormattingBar.tsx
+++ b/docx-editor/packages/react/src/components/FormattingBar.tsx
@@ -33,6 +33,7 @@ import { formatShortcut } from '../lib/platform';
 import { ToolbarButton, ToolbarGroup } from './Toolbar';
 import type { ToolbarProps, FormattingAction } from './Toolbar';
 import { EditorToolbarContext } from './EditorToolbarContext';
+import { useDialogActions } from './DialogActionsContext';
 
 const ICON_SIZE = 18;
 
@@ -114,6 +115,13 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
     paintFormatArmed,
     inline = false,
   } = props as FormattingBarProps;
+
+  // These two dialog opens now flow through DialogActionsContext when the bar
+  // is used inside <EditorToolbar>. An explicitly-passed prop still wins, so
+  // standalone <FormattingBar onOpenImageProperties=… /> use is unchanged.
+  const dialogActions = useDialogActions();
+  const openImageProperties = onOpenImageProperties ?? dialogActions.openImageProperties;
+  const openParagraphDialog = onOpenParagraphDialog ?? dialogActions.openParagraphDialog;
 
   const barRef = useRef<HTMLDivElement>(null);
 
@@ -666,7 +674,7 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
               spaceAfter={currentFormatting.spaceAfter}
               onSpaceBeforeChange={(twips) => onFormat?.({ type: 'spaceBefore', value: twips })}
               onSpaceAfterChange={(twips) => onFormat?.({ type: 'spaceAfter', value: twips })}
-              onOpenCustomSpacing={onOpenParagraphDialog}
+              onOpenCustomSpacing={openParagraphDialog}
               keepNext={currentFormatting.keepNext}
               keepLines={currentFormatting.keepLines}
               pageBreakBefore={currentFormatting.pageBreakBefore}
@@ -694,9 +702,9 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
           {onImageTransform && (
             <ImageTransformDropdown onTransform={onImageTransform} disabled={disabled} />
           )}
-          {onOpenImageProperties && (
+          {openImageProperties && (
             <ToolbarButton
-              onClick={onOpenImageProperties}
+              onClick={openImageProperties}
               disabled={disabled}
               title={t('formattingBar.imagePropertiesShortcut')}
               ariaLabel={t('formattingBar.imageProperties')}

--- a/docx-editor/packages/react/src/components/TitleBar.tsx
+++ b/docx-editor/packages/react/src/components/TitleBar.tsx
@@ -22,6 +22,7 @@ import { Tooltip } from './ui/Tooltip';
 import { TableGridInline } from './ui/TableGridInline';
 import { WriterStatusPill } from './WriterStatusPill';
 import { useEditorToolbar } from './EditorToolbarContext';
+import { useDialogActions } from './DialogActionsContext';
 import type { FormattingAction } from './Toolbar';
 import { useTranslation } from '../i18n';
 import { openReportIssue } from './reportIssue';
@@ -258,23 +259,13 @@ export function MenuBar() {
     onMakeCopy,
     onEmailAsAttachment,
     onOpenVersionHistory,
-    onPageSetup,
-    onFileProperties,
     onExportPdf,
     onExportOdt,
     onExportMd,
     onExportTxt,
     onReportBug,
-    onShowAbout,
-    onOpenCommandPalette,
-    onOpenKeyboardShortcuts,
-    onOpenPreferences,
-    onOpenWatermark,
-    onOpenAccessibility,
-    onOpenBuildingBlocks,
     onConvertSelectionToTable,
     onConvertTableToText,
-    onOpenDictionary,
     onOpenTranslate,
     onTranslateDocument,
     onToggleSpellcheck,
@@ -283,7 +274,6 @@ export function MenuBar() {
     grammarEnabled,
     onOpenWritingAssistant,
     onOpenExplore,
-    onOpenCitations,
     onInsertShape,
     onInsertTextBox,
     onSetColorTheme,
@@ -296,7 +286,6 @@ export function MenuBar() {
     canRedo,
     onOpenFind,
     onOpenFindReplace,
-    onOpenWordCount,
     onToggleVoiceTyping,
     voiceTypingActive,
     onToggleSpellCheck,
@@ -309,11 +298,7 @@ export function MenuBar() {
     onInsertSectionBreak,
     onInsertField,
     onInsertTOC,
-    onOpenBookmarks,
-    onOpenParagraphDialog,
-    onOpenBordersShading,
     onInsertHorizontalRule,
-    onOpenInsertSymbol,
     onInsertFootnote,
     onToggleShowRuler,
     rulerVisible,
@@ -323,6 +308,29 @@ export function MenuBar() {
     outlineVisible,
     onRefocusEditor,
   } = ctx;
+
+  // Dialog-open handlers now arrive via DialogActionsContext instead of ~16
+  // individual props on the <EditorToolbar> call site (see
+  // DialogActionsContext.tsx). Re-bound to their historical `onOpen*` names
+  // so the menu-building bodies below are unchanged.
+  const {
+    openPageSetup: onPageSetup,
+    openFileProperties: onFileProperties,
+    showAbout: onShowAbout,
+    openCommandPalette: onOpenCommandPalette,
+    openKeyboardShortcuts: onOpenKeyboardShortcuts,
+    openPreferences: onOpenPreferences,
+    openWatermark: onOpenWatermark,
+    openAccessibility: onOpenAccessibility,
+    openBuildingBlocks: onOpenBuildingBlocks,
+    openDictionary: onOpenDictionary,
+    openCitations: onOpenCitations,
+    openWordCount: onOpenWordCount,
+    openBookmarks: onOpenBookmarks,
+    openParagraphDialog: onOpenParagraphDialog,
+    openBordersShading: onOpenBordersShading,
+    openInsertSymbol: onOpenInsertSymbol,
+  } = useDialogActions();
 
   const handleFormat = useCallback(
     (action: FormattingAction) => {


### PR DESCRIPTION
#333 was merged into the intermediate `harden/usedialogs-batch3` branch, but #332 squash-merged to main without it, so the DialogActionsContext work never reached main. This re-lands it cleanly off current main (the batch-3 adapters it builds on are already merged via #332).

Groups the ~18 dialog-open handlers into one `DialogActionsContext`; DocxEditor's `<EditorToolbar>` call site drops 81 → 63 props. **Non-breaking** — `Toolbar`/`ToolbarProps`/`FormattingBar` are published API, so their prop contracts are untouched; the two live consumers (MenuBar, FormattingBar) read handlers from the context.

Re-verified on top of main (with B1/B2/B3): typecheck + dialog e2e (preferences / word-count / citations) green. Includes the tracker + doc-40 notes.