### PR TITLE
fix(editor): confirm before File > Open discards unsaved edits

### DIFF
--- a/docx-editor/.changeset/open-unsaved-guard.md
+++ b/docx-editor/.changeset/open-unsaved-guard.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix File → Open silently discarding unsaved edits. Opening another document while the current one has unsaved changes now asks for confirmation first (the beforeunload guard only covered tab close/reload, not in-app document replacement).

--- a/docx-editor/e2e/tests/open-unsaved-guard.spec.ts
+++ b/docx-editor/e2e/tests/open-unsaved-guard.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+import { test, expect } from '@playwright/test';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { EditorPage } from '../helpers/editor-page';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * File ▸ Open must not silently discard unsaved edits.
+ *
+ * Opening a file replaces the in-window document (loadBuffer →
+ * resetForNewDocument + markDirty(false)). The beforeunload guard only covers
+ * tab close/reload, so before this fix an in-app Open threw away unsaved work
+ * with no warning. Now a native confirm gates the replacement.
+ */
+
+const SENTINEL = 'UnsavedGuardSentinel12345';
+const FIXTURE = 'fixtures/generic-render-regression.docx';
+
+test.describe('File > Open — unsaved-changes guard', () => {
+  test('cancelling the confirm keeps the current (dirty) document', async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+    await editor.typeText(SENTINEL);
+
+    // Dirty now. Cancel the confirm → the open must be aborted.
+    let confirmShown = false;
+    page.once('dialog', (d) => {
+      confirmShown = true;
+      void d.dismiss();
+    });
+
+    const input = page.locator('input[type="file"][accept*=".docx"]');
+    await input.setInputFiles(path.join(__dirname, '..', FIXTURE));
+    await page.waitForTimeout(600);
+
+    expect(confirmShown).toBe(true);
+    // The document was NOT replaced — our unsaved text is still there.
+    await expect(page.locator('.paged-editor__pages')).toContainText(SENTINEL);
+  });
+
+  test('accepting the confirm opens the new document', async ({ page }) => {
+    const editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+    await editor.typeText(SENTINEL);
+
+    // Accept the confirm → the open proceeds and the unsaved doc is discarded.
+    page.once('dialog', (d) => void d.accept());
+    await editor.loadDocxFile(FIXTURE);
+
+    await expect(page.locator('.paged-editor__pages')).not.toContainText(SENTINEL);
+  });
+});

--- a/docx-editor/packages/react/i18n/de.json
+++ b/docx-editor/packages/react/i18n/de.json
@@ -956,7 +956,8 @@
     "unsavedTitle": "Dokument hat nicht gespeicherte Änderungen",
     "savedTitle": "Alle Änderungen gespeichert",
     "unsavedAriaLabel": "Nicht gespeicherte Änderungen",
-    "savedAriaLabel": "Alle Änderungen gespeichert"
+    "savedAriaLabel": "Alle Änderungen gespeichert",
+    "openDiscardConfirm": null
   },
   "loading": {
     "label": "Wird geladen"

--- a/docx-editor/packages/react/i18n/en.json
+++ b/docx-editor/packages/react/i18n/en.json
@@ -990,7 +990,8 @@
     "unsavedTitle": "Document has unsaved changes",
     "savedTitle": "All changes saved",
     "unsavedAriaLabel": "Unsaved changes",
-    "savedAriaLabel": "All changes saved"
+    "savedAriaLabel": "All changes saved",
+    "openDiscardConfirm": "You have unsaved changes that will be lost if you open another document. Open anyway?"
   },
   "loading": {
     "label": "Loading"

--- a/docx-editor/packages/react/i18n/he.json
+++ b/docx-editor/packages/react/i18n/he.json
@@ -956,7 +956,8 @@
     "unsavedTitle": "המסמך כולל שינויים שלא נשמרו",
     "savedTitle": "כל השינויים נשמרו",
     "unsavedAriaLabel": "שינויים שלא נשמרו",
-    "savedAriaLabel": "כל השינויים נשמרו"
+    "savedAriaLabel": "כל השינויים נשמרו",
+    "openDiscardConfirm": null
   },
   "loading": {
     "label": "טוען"

--- a/docx-editor/packages/react/i18n/pl.json
+++ b/docx-editor/packages/react/i18n/pl.json
@@ -956,7 +956,8 @@
     "unsavedTitle": "Dokument ma niezapisane zmiany",
     "savedTitle": "Wszystkie zmiany zapisane",
     "unsavedAriaLabel": "Niezapisane zmiany",
-    "savedAriaLabel": "Wszystkie zmiany zapisane"
+    "savedAriaLabel": "Wszystkie zmiany zapisane",
+    "openDiscardConfirm": null
   },
   "loading": {
     "label": "Ładowanie"

--- a/docx-editor/packages/react/i18n/pt-BR.json
+++ b/docx-editor/packages/react/i18n/pt-BR.json
@@ -956,7 +956,8 @@
     "unsavedTitle": "Documento tem alterações não salvas",
     "savedTitle": "Todas as alterações salvas",
     "unsavedAriaLabel": "Alterações não salvas",
-    "savedAriaLabel": "Todas as alterações salvas"
+    "savedAriaLabel": "Todas as alterações salvas",
+    "openDiscardConfirm": null
   },
   "loading": {
     "label": "Carregando"

--- a/docx-editor/packages/react/i18n/tr.json
+++ b/docx-editor/packages/react/i18n/tr.json
@@ -959,7 +959,8 @@
     "unsavedTitle": "Belgede kaydedilmemiş değişiklikler var",
     "savedTitle": "Tüm değişiklikler kaydedildi",
     "unsavedAriaLabel": "Kaydedilmemiş değişiklikler",
-    "savedAriaLabel": "Tüm değişiklikler kaydedildi"
+    "savedAriaLabel": "Tüm değişiklikler kaydedildi",
+    "openDiscardConfirm": null
   },
   "loading": {
     "label": "Yükleniyor"

--- a/docx-editor/packages/react/i18n/zh-CN.json
+++ b/docx-editor/packages/react/i18n/zh-CN.json
@@ -956,7 +956,8 @@
     "unsavedTitle": "文档有未保存的更改",
     "savedTitle": "所有更改已保存",
     "unsavedAriaLabel": "有未保存的更改",
-    "savedAriaLabel": "所有更改已保存"
+    "savedAriaLabel": "所有更改已保存",
+    "openDiscardConfirm": null
   },
   "loading": {
     "label": "正在加载"

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -8095,6 +8095,14 @@ body { background: white; }
       // Reset so picking the same file twice still fires `change`.
       event.target.value = '';
       if (!file) return;
+      // Opening a file replaces the in-window document via loadBuffer
+      // (resetForNewDocument + markDirty(false)), discarding unsaved edits.
+      // The beforeunload guard only covers tab close/reload — not in-app
+      // document replacement — so confirm before discarding unsaved work.
+      if (isDirtyRef.current && typeof window !== 'undefined') {
+        const proceed = window.confirm(t('unsaved.openDiscardConfirm'));
+        if (!proceed) return;
+      }
       try {
         const buffer = await file.arrayBuffer();
         // .odt / .md / .txt → DOCX via the WASM worker, then feed the existing
@@ -8129,7 +8137,7 @@ body { background: white; }
         emitError(error instanceof Error ? error : new Error('Failed to open document'));
       }
     },
-    [loadBuffer, onDocumentNameChange, emitError, onFileOpened]
+    [loadBuffer, onDocumentNameChange, emitError, onFileOpened, t]
   );
 
   // ============================================================================


### PR DESCRIPTION
**Bug (found via a data-integrity audit):** `File ▸ Open` calls `loadBuffer` unconditionally, which runs `resetForNewDocument()` + `markDirty(false)` — discarding the current document's unsaved edits with no warning. The `beforeunload` guard only covers tab close/reload, not in-app document replacement.

**Fix:** when the document is dirty, gate the open behind a native `confirm` (new i18n key `unsaved.openDiscardConfirm`). Autosaved docs are clean, so this only prompts when there is genuinely unsaved work.

**Verified:** e2e — cancelling the confirm keeps the dirty document (unsaved text still present); accepting opens the new document. Typecheck + i18n in sync.