### PR TITLE
fix(serializer): XML-escape block-SDT alias/tag (save corruption)

### DIFF
--- a/docx-editor/.changeset/block-sdt-xml-escape.md
+++ b/docx-editor/.changeset/block-sdt-xml-escape.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix documents with a block-level content control (SDT) whose title/tag contains `&`, `<`, or `"` saving as a corrupt .docx that Word refuses to open. The alias/tag are now XML-escaped, matching the inline content-control path.

--- a/docx-editor/packages/core/src/docx/serializer/block-sdt-escape.test.ts
+++ b/docx-editor/packages/core/src/docx/serializer/block-sdt-escape.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Block-level SDT (content control) `alias` / `tag` must be XML-escaped on
+ * serialize. Interpolating them raw produced malformed document.xml (e.g. a
+ * control titled `Terms & Conditions` → `w:val="Terms & Conditions"`), which
+ * Microsoft Word rejects as corrupt. The inline-SDT path already escaped;
+ * this guards the block path.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { serializeDocumentBody } from './documentSerializer';
+import type { DocumentBody } from '../../types/content';
+
+function bodyWithBlockSdt(alias: string, tag: string): DocumentBody {
+  return {
+    content: [
+      {
+        type: 'blockSdt',
+        properties: { alias, tag },
+        content: [],
+      },
+    ],
+  } as unknown as DocumentBody;
+}
+
+describe('block SDT alias/tag XML escaping', () => {
+  test('special characters in alias/tag are escaped, not emitted raw', () => {
+    const xml = serializeDocumentBody(bodyWithBlockSdt('Terms & Conditions <x>', 'a"b'));
+
+    expect(xml).toContain('<w:alias w:val="Terms &amp; Conditions &lt;x&gt;"/>');
+    expect(xml).toContain('<w:tag w:val="a&quot;b"/>');
+    // The raw, unescaped ampersand/angle bracket must never reach the XML.
+    expect(xml).not.toContain('Terms & Conditions <x>');
+  });
+
+  test('plain alias/tag round-trip unchanged', () => {
+    const xml = serializeDocumentBody(bodyWithBlockSdt('Summary', 'sum1'));
+    expect(xml).toContain('<w:alias w:val="Summary"/>');
+    expect(xml).toContain('<w:tag w:val="sum1"/>');
+  });
+});

--- a/docx-editor/packages/core/src/docx/serializer/documentSerializer.ts
+++ b/docx-editor/packages/core/src/docx/serializer/documentSerializer.ts
@@ -30,7 +30,7 @@ import type {
 import { serializeParagraph } from './paragraphSerializer';
 import { resetAutoIdCounter } from './runSerializer';
 import { serializeTable } from './tableSerializer';
-import { intAttr } from './xmlUtils';
+import { escapeXml, intAttr } from './xmlUtils';
 
 // ============================================================================
 // XML NAMESPACES
@@ -623,8 +623,8 @@ function serializeBlockContent(block: BlockContent): string {
     const contentXml = block.content.map((b) => serializeBlockContent(b)).join('');
     const props = block.properties;
     const prParts: string[] = [];
-    if (props.alias) prParts.push(`<w:alias w:val="${props.alias}"/>`);
-    if (props.tag) prParts.push(`<w:tag w:val="${props.tag}"/>`);
+    if (props.alias) prParts.push(`<w:alias w:val="${escapeXml(props.alias)}"/>`);
+    if (props.tag) prParts.push(`<w:tag w:val="${escapeXml(props.tag)}"/>`);
     return `<w:sdt><w:sdtPr>${prParts.join('')}</w:sdtPr><w:sdtContent>${contentXml}</w:sdtContent></w:sdt>`;
   }
   return '';


### PR DESCRIPTION
**Bug (data-integrity audit):** `serializeBlockContent` interpolated a block-level content control's `alias`/`tag` raw. A control titled `Terms & Conditions` (or a tag with `<`/`"`) serialized to `<w:alias w:val="Terms & Conditions"/>` — malformed `document.xml` that Word refuses to open. Save-time corruption.

**Fix:** wrap both in `escapeXml(...)`, matching the inline-SDT path (`paragraphSerializer.ts`) which already escaped.

**Verified:** unit test (special chars escaped, plain values unchanged) + typecheck.