### PR TITLE
fix(save): drop-free saves — preserve edits made during serialization

### DIFF
--- a/docx-editor/.changeset/save-during-serialize-loss.md
+++ b/docx-editor/.changeset/save-during-serialize-loss.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix edits made while a save is in progress being silently dropped. During the async document serialization, a local keystroke — or a remote collaborator's edit — that lands on another paragraph is now preserved and saved on the next tick, instead of being cleared from the change tracker and lost.

--- a/docx-editor/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.test.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.test.ts
@@ -410,4 +410,61 @@ describe('ParagraphChangeTrackerExtension', () => {
       expect(changed.has('P2')).toBe(false);
     });
   });
+
+  describe('selective clear (edits during async serialize are preserved)', () => {
+    // Locate a paragraph's content-start position by paraId.
+    function paraContentStart(state: EditorState, paraId: string): number {
+      let pos = 0;
+      state.doc.descendants((node, p) => {
+        if (node.type.name === 'paragraph' && node.attrs.paraId === paraId) pos = p + 1;
+      });
+      return pos;
+    }
+
+    test('clears only the served paraIds; edits to other paragraphs are kept', () => {
+      let state = createState([
+        { text: 'Hello', paraId: 'P1' },
+        { text: 'World', paraId: 'P2' },
+      ]);
+
+      // t0: edit P1 — this is what the (selective) save serializes.
+      state = typeText(state, 'X', paraContentStart(state, 'P1'));
+      const served = new Set(getChangedParagraphIds(state)); // snapshot {P1}
+      expect(served.has('P1')).toBe(true);
+
+      // During the async serialize, an edit lands on P2.
+      state = typeText(state, 'Y', paraContentStart(state, 'P2'));
+      expect(getChangedParagraphIds(state).has('P2')).toBe(true);
+
+      // Selective clear removes only the served set.
+      state = state.apply(clearTrackedChanges(state, served));
+
+      const changed = getChangedParagraphIds(state);
+      expect(changed.has('P1')).toBe(false); // saved → cleared
+      expect(changed.has('P2')).toBe(true); // during-serialize edit → preserved (the fix)
+    });
+
+    test('a full (no-arg) clear still wipes everything (unchanged behavior)', () => {
+      let state = createState([
+        { text: 'Hello', paraId: 'P1' },
+        { text: 'World', paraId: 'P2' },
+      ]);
+      state = typeText(state, 'X', paraContentStart(state, 'P1'));
+      state = typeText(state, 'Y', paraContentStart(state, 'P2'));
+
+      state = state.apply(clearTrackedChanges(state)); // no served set → full clear
+      expect(getChangedParagraphIds(state).size).toBe(0);
+    });
+
+    test('clearing a served set that is already gone is a no-op on other entries', () => {
+      let state = createState([
+        { text: 'A', paraId: 'P1' },
+        { text: 'B', paraId: 'P2' },
+      ]);
+      state = typeText(state, 'Z', paraContentStart(state, 'P2'));
+      // Serve a paraId that was never changed — P2 must survive.
+      state = state.apply(clearTrackedChanges(state, new Set(['P1'])));
+      expect(getChangedParagraphIds(state).has('P2')).toBe(true);
+    });
+  });
 });

--- a/docx-editor/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
@@ -206,14 +206,33 @@ function createParagraphChangeTrackerPlugin(): Plugin<ParagraphChangeTrackerStat
         };
       },
       apply(tr: Transaction, prevState: ParagraphChangeTrackerState): ParagraphChangeTrackerState {
-        // Check for explicit clear meta
-        if (tr.getMeta(paragraphChangeTrackerKey) === 'clear') {
+        const meta = tr.getMeta(paragraphChangeTrackerKey);
+        // Full clear — reset everything (post-save, non-selective).
+        if (meta === 'clear') {
           return {
             changedParaIds: new Set(),
             structuralChange: false,
             hasUntrackedChanges: false,
             paragraphCount: prevState.paragraphCount,
             changedBlockTypes: new Set(),
+          };
+        }
+        // Selective clear — remove ONLY the paragraph ids that were actually
+        // serialized into the just-saved buffer (captured before the async
+        // serialize). Edits (local keystrokes or remote collab transactions)
+        // that landed on OTHER paragraphs during the serialize keep their
+        // tracker entries, so the next save re-serializes them instead of the
+        // stale cached XML. Without this, a blanket wipe dropped those edits
+        // permanently (they were not in the saved bytes yet no longer tracked).
+        if (meta && typeof meta === 'object' && Array.isArray(meta.clearServed)) {
+          const served = new Set<string>(meta.clearServed as string[]);
+          const remaining = new Set<string>();
+          for (const id of prevState.changedParaIds) {
+            if (!served.has(id)) remaining.add(id);
+          }
+          return {
+            ...prevState,
+            changedParaIds: remaining,
           };
         }
 
@@ -411,9 +430,21 @@ export function hasNonParagraphBlockChanges(state: EditorState): boolean {
 }
 
 /**
- * Create a transaction that clears the change tracker
+ * Create a transaction that clears the change tracker.
+ *
+ * @param servedParaIds When provided, performs a SELECTIVE clear: only these
+ *   paragraph ids (the ones actually serialized into the just-saved buffer,
+ *   captured BEFORE the async serialize) are removed from the tracker. Edits
+ *   that landed on other paragraphs during the serialize keep their entries so
+ *   the next save re-serializes them. Pass this only when the save took the
+ *   selective path (no structural / untracked changes at capture time), so the
+ *   preserved flags reflect any changes that arrived during the serialize.
+ *   Omit it for a full save to reset the tracker entirely (previous behavior).
  */
-export function clearTrackedChanges(state: EditorState): Transaction {
+export function clearTrackedChanges(state: EditorState, servedParaIds?: Set<string>): Transaction {
+  if (servedParaIds) {
+    return state.tr.setMeta(paragraphChangeTrackerKey, { clearServed: [...servedParaIds] });
+  }
   return state.tr.setMeta(paragraphChangeTrackerKey, 'clear');
 }
 

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -7695,11 +7695,25 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
           };
         }
 
+        // A selective save serialized ONLY these paragraph ids (captured at t0,
+        // before the async serialize below). We clear exactly them afterwards so
+        // that edits — local keystrokes OR remote collab transactions — that land
+        // on other paragraphs DURING the serialize keep their tracker entries and
+        // get re-serialized next save. A blanket clear dropped them permanently
+        // (not in the saved bytes, yet no longer tracked). Only safe when the save
+        // took the selective path: a full repack forces the plain 'clear' so its
+        // structural/untracked flags reset as before.
+        const selective = selectiveOptions?.selective;
+        const servedParaIds =
+          selective && !selective.structuralChange && !selective.hasUntrackedChanges
+            ? selective.changedParaIds
+            : undefined;
+
         const buffer = await agentRef.current.toBuffer(selectiveOptions);
 
         // Clear change tracker after successful save
         if (view) {
-          view.dispatch(clearTrackedChanges(view.state));
+          view.dispatch(clearTrackedChanges(view.state, servedParaIds));
         }
 
         onSave?.(buffer);


### PR DESCRIPTION
**Bug (data-integrity audit, dedicated-verified):** `handleSave` snapshots the content + `changedParaIds` at t0, then `await`s `toBuffer` — which is genuinely async (jszip yields). A local keystroke, or a **remote collaborator's edit** applied via y-prosemirror, that lands on another paragraph during that window is added to the live change tracker but is NOT in the serialized snapshot. The post-await `clearTrackedChanges` then blanket-wiped the tracker, so the next selective save saw an empty changed set, skipped `document.xml`, and re-emitted the stale cached XML. **The edit was lost permanently** — worst for collaboration, where peer edits stream in continuously.

**Fix:** a selective clear that removes only the paraIds actually serialized (captured at t0). Edits to *other* paragraphs during the serialize keep their tracker entries and get re-serialized on the next save. Only applied on the selective path; a full repack still clears everything as before, so its structural/untracked flag reset is unchanged.

**Verified:** 3 new tracker unit tests (served cleared / during-serialize edit preserved / full clear unchanged) + `selectiveSave` (22) + prosemirror & docx suites (598 pass, 0 fail) + typecheck. Serialization output is unchanged, so the round-trip fidelity gate is unaffected.

Note: the verification pass also examined a related claim (tracker cleared before the network write is durable) and **refuted** it — `toBuffer` refreshes the in-memory base on success regardless of the later network result, so the next tick re-emits the paragraph. Not touched here.