### PR TITLE
fix(convert): preserve non-text content inside hyperlinks (R2)

### DIFF
--- a/docx-editor/.changeset/hyperlink-non-text-content.md
+++ b/docx-editor/.changeset/hyperlink-non-text-content.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix non-text content inside a hyperlink (a clickable image, a table-of-contents leader tab, a line break, a symbol) being silently dropped on open. It is now preserved instead of only the link's text surviving.

--- a/docx-editor/packages/core/src/prosemirror/conversion/__tests__/hyperlink-non-text-content.test.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/__tests__/hyperlink-non-text-content.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Non-text content inside a <w:hyperlink> — a clickable image, a TOC leader
+ * tab, a line break — must survive the ProseMirror round-trip. Previously the
+ * load path emitted only `text` children (dropping the image/tab) and the save
+ * path only re-emitted text runs, so a clickable image vanished on open and a
+ * TOC entry lost its leader tab.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { Node as PMNode } from 'prosemirror-model';
+import { toProseDoc } from '../toProseDoc';
+import { fromProseDoc } from '../fromProseDoc';
+import type { Document, Image, Paragraph, Hyperlink, Run } from '../../../types/document';
+
+function makeImage(): Image {
+  return {
+    type: 'image',
+    rId: 'rIdImg',
+    src: 'data:image/png;base64,synthetic',
+    size: { width: 914400, height: 914400 },
+    wrap: { type: 'inline' },
+  };
+}
+
+function docWithHyperlink(): Document {
+  const hyperlink: Hyperlink = {
+    type: 'hyperlink',
+    rId: 'rIdLink',
+    children: [
+      { type: 'run', content: [{ type: 'drawing', image: makeImage() }] },
+      { type: 'run', content: [{ type: 'text', text: 'Chapter 1' }] },
+      { type: 'run', content: [{ type: 'tab' }] },
+      { type: 'run', content: [{ type: 'text', text: '5' }] },
+    ],
+  };
+  const paragraph: Paragraph = { type: 'paragraph', content: [hyperlink] };
+  return { package: { document: { content: [paragraph] } } } as unknown as Document;
+}
+
+function countNodeType(doc: PMNode, typeName: string): number {
+  let n = 0;
+  doc.descendants((node) => {
+    if (node.type.name === typeName) n++;
+    return true;
+  });
+  return n;
+}
+
+describe('hyperlink non-text content round-trips', () => {
+  test('toProseDoc preserves an image + tab inside a hyperlink (not just text)', () => {
+    const pm = toProseDoc(docWithHyperlink());
+    expect(countNodeType(pm, 'image')).toBe(1);
+    expect(countNodeType(pm, 'tab')).toBe(1);
+    // The text children carry the hyperlink mark.
+    let sawLinkedText = false;
+    pm.descendants((node) => {
+      if (node.isText && node.marks.some((m) => m.type.name === 'hyperlink')) sawLinkedText = true;
+      return true;
+    });
+    expect(sawLinkedText).toBe(true);
+  });
+
+  test('fromProseDoc preserves the image + tab on save round-trip (no content loss)', () => {
+    const rebuilt = fromProseDoc(toProseDoc(docWithHyperlink()));
+    const para = rebuilt.package.document.content[0] as Paragraph;
+
+    // Collect every run content type across the paragraph — the hyperlink label
+    // text stays inside the <w:hyperlink>; the atom image/tab survive as
+    // adjacent runs (they can't hold the link mark). The point is that nothing
+    // is dropped, which the old text-only path did.
+    const allTypes: string[] = [];
+    for (const item of para.content) {
+      const runs =
+        item.type === 'hyperlink' ? (item.children as Run[]) : item.type === 'run' ? [item] : [];
+      for (const r of runs) for (const c of r.content ?? []) allTypes.push(c.type);
+    }
+
+    expect(allTypes).toContain('drawing'); // image preserved (was dropped before)
+    expect(allTypes).toContain('tab'); // TOC leader tab preserved
+    expect(allTypes).toContain('text'); // label text
+
+    // And the hyperlink label text still round-trips inside the hyperlink.
+    const link = para.content.find((c) => c.type === 'hyperlink') as Hyperlink | undefined;
+    expect(link).toBeDefined();
+  });
+});

--- a/docx-editor/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -635,6 +635,9 @@ function addNodeToHyperlink(hyperlink: Hyperlink, node: PMNode): void {
     const run = createRunFromText(node.text, nonLinkMarks);
     hyperlink.children.push(run);
   }
+  // Atom nodes (image/tab/break) can't carry the hyperlink mark in this schema,
+  // so they never reach here — the main extract loop emits them as standalone
+  // runs adjacent to the hyperlink (content preserved; see toProseDoc note).
 }
 
 /**

--- a/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1674,10 +1674,15 @@ function convertHyperlink(
       // Add link mark to run marks
       const allMarks = [...runMarks, linkMark];
 
+      // Route every child through the same converter regular runs use, so
+      // non-text content inside a hyperlink (a clickable image, a tab in a
+      // TOC leader, a line break, a symbol glyph) is preserved instead of
+      // silently dropped. Previously only `text` was emitted. Text/symbol
+      // carry the link mark; atom nodes (image/tab/break) can't hold marks in
+      // this schema, so they survive as inline content but not clickable — a
+      // fidelity follow-up would map an in-hyperlink image to its hlinkRId.
       for (const content of child.content) {
-        if (content.type === 'text' && content.text) {
-          nodes.push(schema.text(content.text, allMarks));
-        }
+        nodes.push(...convertRunContent(content, allMarks));
       }
     }
   }


### PR DESCRIPTION
**Bug (audit R2):** the hyperlink→ProseMirror loop emitted only `text` children, so an image, tab, line break, or symbol inside a `<w:hyperlink>` was silently dropped — a clickable image vanished on open, and a TOC entry lost its leader tab (collapsing the leader spacing).

**Fix:** route hyperlink children through the same `convertRunContent` used for regular runs, so every content type is preserved. Text/symbol keep the link mark; atom nodes (image/tab/break) can't hold marks in this schema, so they survive as inline content and serialize via the existing standalone-run paths — no content loss.

**Follow-up (noted):** keeping an in-hyperlink image *clickable* through round-trip needs mapping it to the image's `hlinkRId` attr (images link via attr, not mark). Out of scope here; this PR stops the content loss.

**Verified:** load + save round-trip unit test + 418 conversion/docx tests, 0 fail + typecheck.