### PR TITLE
fix(image): preserve linked / unresolved images (R6)

### DIFF
--- a/docx-editor/.changeset/linked-image-preserve.md
+++ b/docx-editor/.changeset/linked-image-preserve.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix linked (externally-referenced) images, and images whose data is missing, being silently dropped on open. They are now kept — shown as a labelled placeholder — and their relationship reference survives a round-trip save instead of being lost.

--- a/docx-editor/packages/core/src/docx/__tests__/linked-image-parse.test.ts
+++ b/docx-editor/packages/core/src/docx/__tests__/linked-image-parse.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * A linked (`<a:blip r:link>`) image — or one whose binary can't be resolved —
+ * parses to an Image with an `rId` but no `src`. runParser keeps such drawings
+ * (guard: `image.src || image.rId`) instead of dropping them, so the reference
+ * survives round-trip and the painter can show a placeholder. This pins the
+ * data that guard relies on.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { parseDrawing } from '../imageParser';
+import { parseXml } from '../xmlParser';
+import type { XmlElement } from '../xmlParser';
+import type { Image } from '../../types/document';
+
+const NS = [
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"',
+  'xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"',
+  'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"',
+  'xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"',
+  'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"',
+].join(' ');
+
+function parseDrawingFromXml(innerXml: string): Image | null {
+  const doc = parseXml(`<w:drawing ${NS}>${innerXml}</w:drawing>`);
+  const drawing = (doc.elements as XmlElement[])[0];
+  return parseDrawing(drawing, undefined, undefined);
+}
+
+function linkedImageXml(blip: string): string {
+  return `
+    <wp:inline distT="0" distB="0" distL="0" distR="0">
+      <wp:extent cx="914400" cy="914400"/>
+      <wp:docPr id="1" name="Linked Picture"/>
+      <a:graphic>
+        <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+          <pic:pic>
+            <pic:nvPicPr><pic:cNvPr id="1" name="img"/><pic:cNvPicPr/></pic:nvPicPr>
+            <pic:blipFill>${blip}<a:stretch><a:fillRect/></a:stretch></pic:blipFill>
+            <pic:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm></pic:spPr>
+          </pic:pic>
+        </a:graphicData>
+      </a:graphic>
+    </wp:inline>`;
+}
+
+describe('linked / unresolved image parsing', () => {
+  test('an r:link blip yields rId but no src (kept by the runParser guard)', () => {
+    const img = parseDrawingFromXml(linkedImageXml('<a:blip r:link="rId7"/>'));
+    expect(img).not.toBeNull();
+    expect(img!.rId).toBe('rId7');
+    expect(img!.src).toBeUndefined();
+  });
+
+  test('an r:embed blip with no resolvable media also yields rId, no src', () => {
+    const img = parseDrawingFromXml(linkedImageXml('<a:blip r:embed="rId9"/>'));
+    expect(img).not.toBeNull();
+    expect(img!.rId).toBe('rId9');
+    expect(img!.src).toBeUndefined();
+  });
+});

--- a/docx-editor/packages/core/src/docx/runParser.ts
+++ b/docx-editor/packages/core/src/docx/runParser.ts
@@ -695,7 +695,15 @@ function parseRunContents(
         // the shape pipeline already draws. Skip those here — same rule the
         // AlternateContent branch below already applies ("skip shapes").
         const drawing = parseDrawingContent(child, rels, media);
-        if (drawing?.image?.src) {
+        // Keep a drawing that carries a real image reference: either resolved
+        // bytes (`src`) OR a blip relationship id (`rId`) whose data we couldn't
+        // resolve — a LINKED (r:link) image or a missing/mis-pathed binary.
+        // Previously the `src`-only guard dropped those entirely, losing the
+        // image and its rId on round-trip. A shape-only drawing (<wps:wsp>, no
+        // <a:blip>) has neither src nor rId, so it stays skipped as before (the
+        // shape pipeline draws it); the painter renders a placeholder for the
+        // src-less case.
+        if (drawing?.image?.src || drawing?.image?.rId) {
           contents.push(drawing);
         }
         break;

--- a/docx-editor/packages/core/src/layout-painter/__tests__/linked-image-placeholder.test.ts
+++ b/docx-editor/packages/core/src/layout-painter/__tests__/linked-image-placeholder.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * A linked (r:link) image, or one whose binary is missing, reaches the painter
+ * with an empty src. It must render a soft placeholder instead of a broken
+ * <img>. Pairs with runParser keeping rId-bearing-but-unresolved drawings
+ * instead of dropping them.
+ */
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { renderImageFragment } from '../renderImage';
+import type { ImageFragment, ImageBlock, ImageMeasure } from '../../layout-engine/types';
+import type { RenderContext } from '../renderPage';
+
+beforeAll(() => GlobalRegistrator.register());
+afterAll(() => GlobalRegistrator.unregister());
+
+const fragment = {
+  blockId: 'img1',
+  width: 100,
+  height: 80,
+  isAnchored: false,
+  pmStart: 0,
+  pmEnd: 1,
+  zIndex: 0,
+} as unknown as ImageFragment;
+
+function render(block: Partial<ImageBlock>): HTMLElement {
+  return renderImageFragment(
+    fragment,
+    block as ImageBlock,
+    {} as ImageMeasure,
+    {} as RenderContext,
+    { document }
+  );
+}
+
+describe('renderImage — src-less (linked/unresolved) image', () => {
+  test('renders a placeholder, not a broken <img>, when src is empty', () => {
+    const el = render({ src: '' });
+    expect(el.querySelector('img')).toBeNull();
+    const placeholder = el.querySelector('div');
+    expect(placeholder?.textContent).toBe('[Linked image]');
+  });
+
+  test('still renders an <img> for a normal embedded image', () => {
+    const el = render({ src: 'data:image/png;base64,iVBORw0KGgo=' });
+    const img = el.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toContain('data:image/png');
+  });
+});

--- a/docx-editor/packages/core/src/layout-painter/renderImage.ts
+++ b/docx-editor/packages/core/src/layout-painter/renderImage.ts
@@ -15,6 +15,25 @@ import type { ImageFragment, ImageBlock, ImageMeasure } from '../layout-engine/t
 import type { RenderContext } from './renderPage';
 import { safeUrl } from '../utils/safeUrl';
 
+// Soft placeholder box for images we can't paint (unsupported EMF/WMF/EPS
+// format, or a linked/unresolved image with no inline bytes).
+const PLACEHOLDER_CSS = [
+  'display:flex',
+  'align-items:center',
+  'justify-content:center',
+  'width:100%',
+  'height:100%',
+  'border:1px dashed #cbd5e1',
+  'background:#f8fafc',
+  'color:#64748b',
+  'font:11px/1.3 system-ui, sans-serif',
+  'box-sizing:border-box',
+  'border-radius:4px',
+  'padding:6px',
+  'text-align:center',
+  'user-select:none',
+].join(';');
+
 /**
  * CSS class names for image elements
  */
@@ -137,6 +156,20 @@ export function renderImageFragment(
     containerEl.dataset.pmEnd = String(fragment.pmEnd);
   }
 
+  // A linked (r:link) image, or one whose binary is missing/mis-pathed, reaches
+  // the painter with no inline bytes (empty src). Putting that into <img> shows
+  // a broken-image icon; render a soft placeholder instead. The blip rId is
+  // preserved on the model, so a round-trip save keeps the reference.
+  if (!block.src) {
+    const placeholder = doc.createElement('div');
+    placeholder.style.cssText = PLACEHOLDER_CSS;
+    placeholder.textContent = '[Linked image]';
+    placeholder.title =
+      "This image is linked or its data isn't embedded in this file. The reference is preserved on save.";
+    containerEl.appendChild(placeholder);
+    return containerEl;
+  }
+
   // Detect formats that browsers can't render natively. The bytes are
   // still preserved in the source data URL (so a round-trip save keeps
   // the original EMF / WMF / EPS), but trying to put them in <img>
@@ -147,22 +180,7 @@ export function renderImageFragment(
   if (m) {
     const label = (m[2] ?? 'image').toUpperCase();
     const placeholder = doc.createElement('div');
-    placeholder.style.cssText = [
-      'display:flex',
-      'align-items:center',
-      'justify-content:center',
-      'width:100%',
-      'height:100%',
-      'border:1px dashed #cbd5e1',
-      'background:#f8fafc',
-      'color:#64748b',
-      'font:11px/1.3 system-ui, sans-serif',
-      'box-sizing:border-box',
-      'border-radius:4px',
-      'padding:6px',
-      'text-align:center',
-      'user-select:none',
-    ].join(';');
+    placeholder.style.cssText = PLACEHOLDER_CSS;
     placeholder.textContent = `[${label}]`;
     placeholder.title = `Image is in ${label} format — web previews can't render it. The original file content is preserved on save.`;
     containerEl.appendChild(placeholder);


### PR DESCRIPTION
**Bug (audit R6):** `runParser` kept a drawing only when its image had resolved bytes (`src`). A **linked** image (`<a:blip r:link>`), or one whose binary is missing/mis-pathed, parses to an image with an `rId` but no `src` — so it was dropped on load and its reference lost on round-trip.

**Fix (two parts):**
- Parser: keep the drawing when it has `src` **or** an `rId`. A shape-only drawing (`<wps:wsp>`, no `<a:blip>`) has neither, so it stays skipped — the deliberate guard against spurious broken-image boxes is preserved.
- Painter: a src-less image was rendered as a broken `<img>`; render a soft `[Linked image]` placeholder instead (reusing the existing EMF/WMF placeholder styling, now a shared constant).

**Verified:** parser test (r:link and r:embed both yield `rId`, no `src`) + painter test (placeholder vs `<img>`) + 426 docx/painter tests, 0 fail + typecheck.