### PR TITLE
fix(layout): floating image collapsing text to ~1 char/line (R5)

### DIFF
--- a/docx-editor/.changeset/floating-full-width-wrap.md
+++ b/docx-editor/.changeset/floating-full-width-wrap.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix an oversized or full-width floating image collapsing wrapped text to about one character per line (with the paragraph's height ballooning and pushing following content off the page). The text column beside a float is now kept to a minimum width.

--- a/docx-editor/packages/core/src/layout-bridge/measuring/__tests__/floating-full-width-wrap.test.ts
+++ b/docx-editor/packages/core/src/layout-bridge/measuring/__tests__/floating-full-width-wrap.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Regression for "oversized / full-width floating image collapses text to ~1
+ * char per line + height blowup".
+ *
+ * A floating image whose wrap exclusion spans (almost) the whole column used to
+ * drive adjustedWidth to Math.max(1, …) = 1px, so text broke to one character
+ * per line and the paragraph's height exploded, pushing following content off
+ * the page. The text column is now floored to a minimum width.
+ */
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { measureParagraph } from '../measureParagraph';
+import { resetCanvasContext } from '../measureContainer';
+import type { FloatingImageZone } from '../measureParagraph';
+import type { ParagraphBlock, ParagraphMeasure } from '../../../layout-engine/types';
+
+const MAX_WIDTH = 400;
+const TEXT = Array.from({ length: 40 }, (_, i) => `word${i}`).join(' ');
+
+let noFloat: ParagraphMeasure;
+let fullWidthFloat: ParagraphMeasure;
+
+function para(): ParagraphBlock {
+  return {
+    kind: 'paragraph',
+    id: 'p',
+    pmStart: 0,
+    pmEnd: 0,
+    runs: [{ kind: 'text', text: TEXT }],
+    attrs: { defaultFontSize: 12, defaultFontFamily: 'Arial' },
+  } as unknown as ParagraphBlock;
+}
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  const fakeCtx = {
+    font: '',
+    measureText: (s: string) => ({
+      width: s.length * 8,
+      actualBoundingBoxAscent: 12,
+      actualBoundingBoxDescent: 4,
+    }),
+  };
+  // @ts-expect-error — deterministic canvas for measurement tests.
+  HTMLCanvasElement.prototype.getContext = () => fakeCtx;
+  resetCanvasContext();
+
+  noFloat = measureParagraph(para(), MAX_WIDTH);
+  // A zone that excludes the entire column for the whole paragraph height.
+  const zone: FloatingImageZone = {
+    leftMargin: MAX_WIDTH,
+    rightMargin: 0,
+    topY: 0,
+    bottomY: 100000,
+  };
+  fullWidthFloat = measureParagraph(para(), MAX_WIDTH, { floatingZones: [zone] });
+});
+afterAll(() => GlobalRegistrator.unregister());
+
+describe('full-width floating exclusion does not collapse the text column', () => {
+  test('does not degenerate to ~1 character per line', () => {
+    // Pre-fix: ~one char per line → line count near the character count.
+    // Post-fix: floored to a real column → far fewer lines.
+    const charCount = TEXT.length;
+    expect(fullWidthFloat.lines.length).toBeLessThan(charCount / 4);
+  });
+
+  test('every line fits within a minimum column (no 1px collapse)', () => {
+    // With an 8px/char stub and a ~96px floor, a filled line is ~10+ chars wide.
+    const widest = Math.max(...fullWidthFloat.lines.map((l) => l.width));
+    expect(widest).toBeGreaterThan(40);
+  });
+
+  test('the un-excluded paragraph still wraps normally (no behavior change)', () => {
+    // Sanity: without a float, wrapping is unaffected by the floor.
+    expect(noFloat.lines.length).toBeGreaterThan(0);
+    expect(noFloat.lines.length).toBeLessThan(fullWidthFloat.lines.length);
+  });
+});

--- a/docx-editor/packages/core/src/layout-bridge/measuring/measureParagraph.ts
+++ b/docx-editor/packages/core/src/layout-bridge/measuring/measureParagraph.ts
@@ -44,6 +44,14 @@ const DEFAULT_LINE_HEIGHT_MULTIPLIER = 1.0; // OOXML spec default: single spacin
 // Prevents premature line breaks due to measurement rounding
 const WIDTH_TOLERANCE = 0.5;
 
+// Minimum text-column width (px, ~1 inch) left when a floating image's wrap
+// exclusion would otherwise consume (almost) the whole line. Without a floor,
+// adjustedWidth collapses to 1px for an oversized / near-full-width float, text
+// breaks to ~1 char per line, and the paragraph height explodes — shoving
+// following content off the page. The floor is capped to the body width so a
+// genuinely narrow column/page still wraps at its real width.
+const MIN_FLOAT_WRAP_WIDTH = 96;
+
 /**
  * Compute the width a tab character should advance to reach the next tab stop.
  *
@@ -619,9 +627,16 @@ export function measureParagraph(
       paragraphYOffset
     );
 
-    // Body content width minus floating image margins
+    // Body content width minus floating image margins, floored so an oversized
+    // float can't collapse the text column to ~1px (which would break text to
+    // one char per line and blow up the paragraph height). The floor never
+    // exceeds the body width, so a legitimately narrow column still wraps at
+    // its true width (and can't overflow the page — see the negative-indent
+    // fix). A proper full-width float should skip the line past the image;
+    // tracked as a follow-up.
+    const minColumnWidth = Math.min(MIN_FLOAT_WRAP_WIDTH, bodyContentWidth);
     const adjustedWidth = Math.max(
-      1,
+      minColumnWidth,
       bodyContentWidth - floatingMargins.leftMargin - floatingMargins.rightMargin
     );
 


### PR DESCRIPTION
**Bug (audit R5):** a floating image whose wrap exclusion spanned (almost) the whole column — an oversized or near-full-width float — drove `adjustedWidth` to `Math.max(1, …)` = 1px. Text broke to ~1 character per line and the paragraph's height exploded, pushing following content off the page.

**Fix:** floor the wrap column at a minimum width (~1in), capped to the body width so a legitimately narrow column/page still wraps at its true width (and can't overflow — consistent with the negative-indent fix). Single chokepoint in `measureParagraph`, covering page- and cell-level floats.

**Scope:** this is a mitigation that stops the catastrophic collapse/off-page blowup. Full fidelity — a full-width float *skipping* the line past the image (advancing Y past its bottom) rather than flowing a narrow column beside it — is a follow-up in the delicate floating-wrap layout code.

**Verified:** regression test (fails without the floor, passes with it) + 264 layout-bridge/painter/engine tests, 0 fail + typecheck.