### PR TITLE
fix(table): document crash on a fully vertical-merged row (R3)

### DIFF
--- a/docx-editor/.changeset/empty-table-row-crash.md
+++ b/docx-editor/.changeset/empty-table-row-crash.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix a document failing to open (throwing "Invalid content for node tableRow") when it contains a table row fully covered by a vertical cell merge — e.g. a single-column table with a cell merged down several rows. Such rows now render with a placeholder cell instead of crashing the whole document.

--- a/docx-editor/packages/core/src/prosemirror/conversion/__tests__/empty-table-row-vmerge.test.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/__tests__/empty-table-row-vmerge.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * A table row whose cells are ALL vMerge="continue" (fully covered by a
+ * vertical merge from the row above) used to skip every cell, producing an
+ * empty <tableRow>. That is invalid for the schema ((tableCell | tableHeader)+)
+ * and threw "Invalid content for node tableRow" during conversion — crashing
+ * the ENTIRE document on open. A spanning placeholder cell now keeps the row
+ * valid.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { toProseDoc } from '../toProseDoc';
+import type { Document } from '../../../types/document';
+
+function cell(vMerge?: 'restart' | 'continue') {
+  return {
+    type: 'tableCell',
+    content: [
+      { type: 'paragraph', content: [{ type: 'run', content: [{ type: 'text', text: 'x' }] }] },
+    ],
+    formatting: vMerge ? { vMerge } : {},
+  };
+}
+
+// 1-column table with a 3-row vertical merge → rows 2 and 3 are fully covered.
+function docWithFullyMergedRows(): Document {
+  return {
+    package: {
+      document: {
+        content: [
+          {
+            type: 'table',
+            rows: [
+              { type: 'tableRow', cells: [cell('restart')] },
+              { type: 'tableRow', cells: [cell('continue')] },
+              { type: 'tableRow', cells: [cell('continue')] },
+            ],
+          },
+        ],
+      },
+    },
+  } as unknown as Document;
+}
+
+describe('table row fully covered by a vertical merge', () => {
+  test('does not throw (no document-crash on open)', () => {
+    expect(() => toProseDoc(docWithFullyMergedRows())).not.toThrow();
+  });
+
+  test('every row is schema-valid (>= 1 cell) and the doc passes check()', () => {
+    const pm = toProseDoc(docWithFullyMergedRows());
+    const rowCellCounts: number[] = [];
+    pm.descendants((n) => {
+      if (n.type.name === 'tableRow') rowCellCounts.push(n.childCount);
+      return true;
+    });
+    expect(rowCellCounts.length).toBe(3);
+    expect(rowCellCounts.every((c) => c >= 1)).toBe(true);
+    expect(() => pm.check()).not.toThrow();
+  });
+});

--- a/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -979,6 +979,19 @@ function convertTableRow(
     );
   }
 
+  // A row whose cells are ALL vMerge="continue" (fully covered by a vertical
+  // merge from the row above) skips every cell, leaving `cells` empty — which
+  // is invalid for tableRow ((tableCell | tableHeader)+) and throws "Invalid
+  // content for node tableRow" during conversion, crashing the WHOLE document
+  // on open. Emit a spanning placeholder cell so the row stays schema-valid;
+  // prosemirror-tables' fixTables reconciles the merge geometry on the next
+  // transaction. (The empty-cell and empty-doc cases are already guarded.)
+  if (cells.length === 0) {
+    const colCount = Math.max(1, columnWidths?.length ?? 1);
+    const nodeType = isHeaderRow ? 'tableHeader' : 'tableCell';
+    cells.push(schema.node(nodeType, { colspan: colCount }, [schema.node('paragraph', {}, [])]));
+  }
+
   return schema.node('tableRow', attrs, cells);
 }
 


### PR DESCRIPTION
**Bug (audit R3, confirmed with a repro):** a table row whose cells are all `vMerge="continue"` — fully covered by a vertical merge from the row above (e.g. a single-column table with a cell merged down several rows) — skipped every cell, producing an empty `<tableRow>`. That is invalid for the schema (`(tableCell | tableHeader)+`), so `toProseDoc` threw **"Invalid content for node tableRow"** and the **entire document failed to open**.

**Fix:** emit a spanning placeholder cell when a row would otherwise be empty, keeping it schema-valid; prosemirror-tables' `fixTables` reconciles the merge geometry on the next transaction. Mirrors the existing empty-cell and empty-doc guards.

**Verified:** repro test — `toProseDoc` threw before, and now `doc.check()` passes with every row having ≥1 cell — plus 660 conversion/painter/docx tests, 0 fail + typecheck.