### PR TITLE
fix(parser): preserve cross-paragraph complex fields / TOC content (R1)

### DIFF
--- a/docx-editor/.changeset/cross-paragraph-complex-field.md
+++ b/docx-editor/.changeset/cross-paragraph-complex-field.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix content being dropped from documents with a table of contents or other complex field that spans multiple paragraphs. The field's instruction and visible text in its opening paragraph are now preserved instead of silently discarded.

--- a/docx-editor/packages/core/src/docx/__tests__/cross-paragraph-complex-field.test.ts
+++ b/docx-editor/packages/core/src/docx/__tests__/cross-paragraph-complex-field.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * A complex field (TOC / INCLUDETEXT / index) whose begin…end straddles
+ * paragraph boundaries never closed inside its begin-paragraph, so every run
+ * gathered after the `begin` — the instruction and the visible result in that
+ * paragraph — was silently dropped and the field structure destroyed. The
+ * field is now closed at the paragraph boundary so its content survives.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { XmlElement } from '../xmlParser';
+import { parseXmlDocument } from '../xmlParser';
+import { parseParagraph } from '../paragraphParser';
+import type { ComplexField } from '../../types/document';
+
+const W = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+function parseP(xml: string) {
+  const root = parseXmlDocument(xml) as XmlElement;
+  return parseParagraph(root, null, null, null, null, null);
+}
+
+describe('cross-paragraph complex field', () => {
+  test('the begin-paragraph of a TOC field keeps its instruction and result', () => {
+    // begin + instrText + separate + result, but NO end (it lands later).
+    const para = parseP(`
+      <w:p ${W}>
+        <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+        <w:r><w:instrText xml:space="preserve"> TOC \\o "1-3" </w:instrText></w:r>
+        <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+        <w:r><w:t>Chapter 1</w:t></w:r>
+      </w:p>`);
+
+    const field = para.content.find((c) => c.type === 'complexField') as ComplexField | undefined;
+    expect(field).toBeDefined();
+    expect(field!.instruction).toContain('TOC');
+    // The visible result text must survive (was dropped entirely before).
+    expect(JSON.stringify(field!.fieldResult)).toContain('Chapter 1');
+  });
+
+  test('a normally-closed field in one paragraph still works (control)', () => {
+    const para = parseP(`
+      <w:p ${W}>
+        <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+        <w:r><w:instrText xml:space="preserve"> PAGE </w:instrText></w:r>
+        <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+        <w:r><w:t>1</w:t></w:r>
+        <w:r><w:fldChar w:fldCharType="end"/></w:r>
+      </w:p>`);
+
+    const fields = para.content.filter((c) => c.type === 'complexField');
+    expect(fields.length).toBe(1);
+    expect((fields[0] as ComplexField).instruction).toContain('PAGE');
+  });
+
+  test('a paragraph with no field is unaffected', () => {
+    const para = parseP(`<w:p ${W}><w:r><w:t>plain</w:t></w:r></w:p>`);
+    expect(para.content.some((c) => c.type === 'complexField')).toBe(false);
+  });
+});

--- a/docx-editor/packages/core/src/docx/paragraphParser.ts
+++ b/docx-editor/packages/core/src/docx/paragraphParser.ts
@@ -1406,6 +1406,27 @@ function parseParagraphContents(
     }
   }
 
+  // The paragraph ended with a complex field still open — its `end` fldChar
+  // lands in a LATER paragraph (a TOC / INCLUDETEXT / index field spans
+  // paragraph boundaries). Without this, every run gathered after the `begin`
+  // (the instruction and the visible result in this paragraph) was silently
+  // dropped and the field structure destroyed. Close the field at the paragraph
+  // boundary so its instruction and result are preserved. This flattens a
+  // cross-paragraph field to its begin-paragraph — full multi-paragraph field
+  // reconstruction (persisting state across the paragraph loop) is a follow-up.
+  if (inComplexField) {
+    const complexField: ComplexField = {
+      type: 'complexField',
+      instruction: complexFieldInstr.trim(),
+      fieldType: parseFieldType(complexFieldInstr),
+      fieldCode: complexFieldCodeRuns,
+      fieldResult: complexFieldResultRuns,
+    };
+    if (complexFieldLock) complexField.fldLock = true;
+    if (complexFieldDirty) complexField.dirty = true;
+    contents.push(complexField);
+  }
+
   return contents;
 }
 


### PR DESCRIPTION
**Bug (audit R1, confirmed with a repro):** `parseParagraphContents` tracks complex-field state *per paragraph* and only emits a `ComplexField` when the closing `fldChar` is in the same paragraph. A TOC / INCLUDETEXT / index field whose `begin`…`end` straddles paragraphs never closed in its begin-paragraph, so every run after the `begin` — the instruction **and the visible result text** — was silently dropped and the field structure destroyed. (Repro: the begin-paragraph parsed to empty `content: []`.)

**Fix:** close an open complex field at the paragraph boundary, preserving its instruction and result.

**Scope:** this flattens a cross-paragraph field to its begin-paragraph — full multi-paragraph field reconstruction (persisting field state across the paragraph loop) is a follow-up. `parse → serialize → parse` is stable and content-preserving.

**Verified:** repro (begin-paragraph → `[]` before, keeps the field + "Chapter 1" after) + round-trip stability check + 377 docx (parser/serializer/roundtrip) tests, 0 fail + typecheck.