### PR TITLE
docs: audit sweep complete (R1 fixed)

### DIFF
--- a/docs/internal/40-hardening-followups-specs.md
+++ b/docs/internal/40-hardening-followups-specs.md
@@ -189,7 +189,7 @@ embedded. Full-attention PR.
 
 ### Data-integrity + correctness audit backlog (2026-07-21)
 
-**Update (2026-07-21, later):** R2 → #342, R3 → #345, R5 → #344, R6 → #343 are now **fixed** (each with a regression test). Remaining below: **R1** (architectural) and **D4** (defensive) plus the runners-up.
+**Update (2026-07-21, sweep complete):** all HIGH/MED audit findings are **fixed**, each with a regression test — R1 → #347, R2 → #342, R3 → #345, R5 → #344, R6 → #343 (plus data-integrity #338/#339/#340). Remaining: only **D4** (defensive hardening of a by-design conflict pause) and the four low-severity runners-up below.
 
 Multi-agent hunt over save/data-loss + parse/render/serialize. **Shipped:**
 File▸Open discards unsaved edits → #338; block-SDT alias/tag not XML-escaped → #339;


### PR DESCRIPTION
All HIGH/MED correctness + data-integrity audit findings are now fixed with regression tests (R1 #347, R2 #342, R3 #345, R5 #344, R6 #343, plus #338/#339/#340). Only D4 (defensive) and four low-severity runners-up remain. Docs-only.