### PR TITLE
fix(convert): nested tables lose theme-color shading

### DIFF
--- a/docx-editor/.changeset/nested-table-theme-shading.md
+++ b/docx-editor/.changeset/nested-table-theme-shading.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix nested tables losing theme-based cell shading and border colors (they fell back to the default Office palette). Theme colors now resolve for nested tables the same as top-level ones.

--- a/docx-editor/packages/core/src/prosemirror/conversion/__tests__/nested-table-theme-shading.test.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/__tests__/nested-table-theme-shading.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * A nested table's cell shading that references a theme color (e.g.
+ * `themeColor="accent1"`) must resolve to the document palette, just like a
+ * top-level table. The nested convertTable call omitted the `theme` arg, so
+ * `resolveColorToHex(themeFill, null)` returned undefined and the cell lost its
+ * shading (fell back to no fill / the default palette).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { toProseDoc } from '../toProseDoc';
+import type { Node as PMNode } from 'prosemirror-model';
+import type { Document, Theme } from '../../../types/document';
+
+const THEME = {
+  colorScheme: {
+    dk1: '000000',
+    lt1: 'FFFFFF',
+    dk2: '44546A',
+    lt2: 'E7E6E6',
+    accent1: '4472C4',
+    accent2: 'ED7D31',
+    accent3: 'A5A5A5',
+    accent4: 'FFC000',
+    accent5: '5B9BD5',
+    accent6: '70AD47',
+    hlink: '0563C1',
+    folHlink: '954F72',
+  },
+} as unknown as Theme;
+
+function para(text: string) {
+  return { type: 'paragraph', content: [{ type: 'run', content: [{ type: 'text', text }] }] };
+}
+
+// Outer table → cell → NESTED table → cell shaded with themeColor accent1.
+function docWithNestedThemedTable(): Document {
+  const innerCell = {
+    type: 'tableCell',
+    content: [para('inner')],
+    formatting: { shading: { fill: { themeColor: 'accent1' } } },
+  };
+  const nested = {
+    type: 'table',
+    rows: [{ type: 'tableRow', cells: [innerCell] }],
+  };
+  const outerCell = { type: 'tableCell', content: [nested], formatting: {} };
+  const outer = { type: 'table', rows: [{ type: 'tableRow', cells: [outerCell] }] };
+  return {
+    package: { document: { content: [outer] }, theme: THEME },
+  } as unknown as Document;
+}
+
+function cellBackgrounds(doc: PMNode): (string | null)[] {
+  const bg: (string | null)[] = [];
+  doc.descendants((n) => {
+    if (n.type.name === 'tableCell') bg.push((n.attrs.backgroundColor as string) ?? null);
+    return true;
+  });
+  return bg;
+}
+
+describe('nested table theme-color shading', () => {
+  test('a nested cell resolves its themeColor fill to the document palette', () => {
+    const backgrounds = cellBackgrounds(toProseDoc(docWithNestedThemedTable()));
+    // The inner cell's accent1 fill must resolve to 4472C4 (was undefined before
+    // the theme arg was threaded into the nested convertTable call).
+    expect(
+      backgrounds.some((c) => typeof c === 'string' && c.toUpperCase().includes('4472C4'))
+    ).toBe(true);
+  });
+});

--- a/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -1122,7 +1122,11 @@ function convertTableCell(
       contentNodes.push(convertParagraph(content, styleResolver, undefined, conditionalStyle?.rPr));
     } else if (content.type === 'table') {
       // Nested tables - recursively convert
-      contentNodes.push(convertTable(content, styleResolver));
+      // Thread `theme` so a nested table's themeColor shading/borders resolve to
+      // the document palette — the top-level and header/footer paths already
+      // pass it; without it, nested tables fell back to the default Office
+      // palette (wrong shading/border colors).
+      contentNodes.push(convertTable(content, styleResolver, theme));
     }
   }
 


### PR DESCRIPTION
**Bug (audit runner-up):** the nested-table `convertTable` call omitted the `theme` arg that the top-level and header/footer paths pass. A nested cell's `themeColor` shading/border therefore resolved against no theme (`resolveColorToHex → undefined`) and fell back to the default Office palette — wrong colors. One-line fix threads `theme` through.

**Verified:** regression test (a nested `accent1` fill resolves to `4472C4`; fails without the arg) + 425 conversion/docx tests, 0 fail + typecheck.