### PR TITLE
refactor(editor): extract the load path into useDocumentLoad (Spec #6 pt 1)

### DIFF
--- a/docx-editor/.changeset/use-document-load.md
+++ b/docx-editor/.changeset/use-document-load.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Internal: extract the document-load path (buffer parsing, generation guard, server-version restore) out of the DocxEditor component into a `useDocumentLoad` hook. No behaviour change.

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -59,7 +59,7 @@ import { TablePropertiesSection } from './sidebar/TablePropertiesSection';
 import { TextBoxPropertiesSection } from './sidebar/TextBoxPropertiesSection';
 import { useEditHistory } from '../hooks/useEditHistory';
 import { useVersionHistoryCapture } from '../version-history/useVersionHistoryCapture';
-import { downloadServerVersion, type ServerVersionBackend } from '../version-history/server-source';
+import { type ServerVersionBackend } from '../version-history/server-source';
 import { useVoiceTyping } from '../hooks/useVoiceTyping';
 import { VoiceTypingIndicator } from './ui/VoiceTypingIndicator';
 import { UnifiedSidebar } from './UnifiedSidebar';
@@ -289,8 +289,8 @@ import { getBuiltinTableStyle, type TableStylePreset } from './ui/TableStyleGall
 import { DocumentAgent } from '@eigenpal/docx-core/agent';
 import { DefaultLoadingIndicator, DefaultPlaceholder, ParseError } from './DocxEditorHelpers';
 import { useDialogs } from '../hooks/useDialogs';
+import { useDocumentLoad } from '../hooks/useDocumentLoad';
 import {
-  parseDocx,
   getFootnoteText,
   setFootnotePlainText,
   getEndnoteText,
@@ -3553,10 +3553,6 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   const [hyperlinkPopupData, setHyperlinkPopupData] = useState<HyperlinkPopupData | null>(null);
 
   // Monotonically increasing generation counter to discard stale async loads
-  const loadGenerationRef = useRef(0);
-  // Real on-disk byte size of the most recently loaded document (Properties).
-  const loadedSizeRef = useRef<number | null>(null);
-
   // Reset internal state when loading a new document (clears stale refs, comments, tracked changes, etc.)
   const resetForNewDocument = useCallback(() => {
     commentsLoadedRef.current = false;
@@ -3592,77 +3588,11 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     [resetForNewDocument, history]
   );
 
-  // Load a DOCX buffer (used by ref method and internally)
-  const loadBuffer = useCallback(
-    async (buffer: DocxInput) => {
-      // Capture the REAL on-disk size of the loaded bytes (not an in-memory
-      // serialization estimate) for the Properties dialog.
-      loadedSizeRef.current =
-        buffer instanceof Blob
-          ? buffer.size
-          : buffer instanceof ArrayBuffer
-            ? buffer.byteLength
-            : ArrayBuffer.isView(buffer)
-              ? buffer.byteLength
-              : null;
-      const generation = ++loadGenerationRef.current;
-      resetForNewDocument();
-      // Loading a fresh buffer wipes the prior edit state, so the new
-      // document starts clean.
-      markDirty(false);
-      setState((prev) => ({ ...prev, isLoading: true, parseError: null }));
-      try {
-        const doc = await parseDocx(buffer);
-        // Discard result if a newer load was started while we were parsing
-        if (loadGenerationRef.current !== generation) return;
-        loadParsedDocument(doc);
-      } catch (error) {
-        if (loadGenerationRef.current !== generation) return;
-        const message = error instanceof Error ? error.message : 'Failed to parse document';
-        setState((prev) => ({
-          ...prev,
-          isLoading: false,
-          parseError: message,
-        }));
-        emitError(error instanceof Error ? error : new Error(message));
-      }
-    },
-    [resetForNewDocument, loadParsedDocument, emitError]
-  );
-
-  // Restore a server-persisted revision: download its .docx from the
-  // host and load it into the editor. In a live collab room the load
-  // flows through the same PM path, so peers converge on the restored
-  // content. Surfaces failures via onError rather than throwing.
-  const handleRestoreServerVersion = useCallback(
-    (version: number) => {
-      if (!versionBackend) return;
-      void (async () => {
-        try {
-          const buf = await downloadServerVersion(versionBackend, version);
-          await loadBuffer(buf);
-        } catch (err) {
-          emitError(err instanceof Error ? err : new Error(String(err)));
-        }
-      })();
-    },
-    [versionBackend, loadBuffer, emitError]
-  );
-
-  // React to document/documentBuffer prop changes
-  useEffect(() => {
-    // External content mode: caller (e.g. ySyncPlugin) populates PM directly — skip the load.
-    if (externalContent) return;
-
-    if (!documentBuffer) {
-      if (initialDocument) {
-        loadParsedDocument(initialDocument);
-      }
-      return;
-    }
-
-    loadBuffer(documentBuffer);
-  }, [documentBuffer, initialDocument, externalContent]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Load path (buffer parse, generation guard, server-version restore, and the
+  // documentBuffer/initialDocument effect) lives in useDocumentLoad — see the
+  // hook call further below, after markDirty is defined. `resetForNewDocument`
+  // and `loadParsedDocument` stay here because the imperative ref API and the
+  // agent bridge reuse them.
 
   // Create/update agent when document changes
   useEffect(() => {
@@ -3738,6 +3668,32 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     },
     [onDirtyChange, emitEvent]
   );
+
+  // Document load path (Spec #6): buffer parse + generation guard + Properties
+  // size + server-version restore + the documentBuffer/initialDocument effect.
+  // State writes go through narrow callbacks so the hook never touches the
+  // component's giant state object directly.
+  const handleLoadStart = useCallback(
+    () => setState((prev) => ({ ...prev, isLoading: true, parseError: null })),
+    []
+  );
+  const handleLoadError = useCallback(
+    (message: string) => setState((prev) => ({ ...prev, isLoading: false, parseError: message })),
+    []
+  );
+  const { loadBuffer, handleRestoreServerVersion, loadedSizeRef } = useDocumentLoad({
+    documentBuffer,
+    initialDocument,
+    externalContent,
+    versionBackend,
+    resetForNewDocument,
+    loadParsedDocument,
+    markDirty,
+    emitError,
+    onLoadStart: handleLoadStart,
+    onLoadError: handleLoadError,
+  });
+
   // True while a save / download is in flight — drives the
   // "Saving…" indicator in the title bar.
   const [isSaving, setIsSaving] = useState(false);

--- a/docx-editor/packages/react/src/hooks/useDocumentLoad.ts
+++ b/docx-editor/packages/react/src/hooks/useDocumentLoad.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * useDocumentLoad — the document *load* path extracted out of the DocxEditor
+ * god-component (Spec #6, part 1 — the lower-risk half of `useDocumentIO`; the
+ * save path stays in the component for a dedicated pass since a bug there is
+ * data-loss, not a recoverable failed load).
+ *
+ * Owns: parsing a .docx buffer into the editor, the generation guard that
+ * discards a slow parse superseded by a newer load, the real on-disk size for
+ * the Properties dialog, restoring a server version, and the effect that reacts
+ * to `documentBuffer` / `initialDocument` prop changes.
+ *
+ * The shared, reused pieces (`resetForNewDocument`, `loadParsedDocument`) stay
+ * in the component — the imperative ref API and the agent bridge also call them
+ * — and are passed in. State writes go through narrow callbacks so the hook
+ * never touches the component's giant state object directly.
+ */
+
+import { useCallback, useEffect, useRef, type MutableRefObject } from 'react';
+import { parseDocx } from '@eigenpal/docx-core/docx';
+import { type DocxInput } from '@eigenpal/docx-core/utils';
+import type { Document } from '@eigenpal/docx-core/types/document';
+import { downloadServerVersion, type ServerVersionBackend } from '../version-history/server-source';
+
+export interface UseDocumentLoadOptions {
+  /** Raw .docx bytes to load; null/undefined loads `initialDocument` instead. */
+  documentBuffer?: DocxInput | null;
+  /** Pre-parsed document to load when there is no `documentBuffer`. */
+  initialDocument?: Document | null;
+  /** When true the caller populates PM directly (e.g. y-prosemirror) — skip loading. */
+  externalContent?: boolean;
+  /** Version-history backend for `handleRestoreServerVersion`. */
+  versionBackend?: ServerVersionBackend;
+  /** Reset per-document state (comments, tracked changes, refs). Shared. */
+  resetForNewDocument: () => void;
+  /** Commit a parsed document into the editor. Shared with the ref API/agent. */
+  loadParsedDocument: (doc: Document) => void;
+  /** Mark the editor dirty/clean — a fresh load starts clean. */
+  markDirty: (dirty: boolean) => void;
+  /** Surface a load/parse error to the host. */
+  emitError: (err: Error) => void;
+  /** Enter the loading state (isLoading: true, parseError: null). */
+  onLoadStart: () => void;
+  /** Enter the error state (isLoading: false, parseError: message). */
+  onLoadError: (message: string) => void;
+}
+
+export interface UseDocumentLoadReturn {
+  loadBuffer: (buffer: DocxInput) => Promise<void>;
+  handleRestoreServerVersion: (version: number) => void;
+  /** Real on-disk byte size of the most recently loaded document (Properties). */
+  loadedSizeRef: MutableRefObject<number | null>;
+}
+
+export function useDocumentLoad(opts: UseDocumentLoadOptions): UseDocumentLoadReturn {
+  const {
+    documentBuffer,
+    initialDocument,
+    externalContent,
+    versionBackend,
+    resetForNewDocument,
+    loadParsedDocument,
+    markDirty,
+    emitError,
+    onLoadStart,
+    onLoadError,
+  } = opts;
+
+  // Monotonic generation so a slow parse of an old buffer can't clobber a newer
+  // load; internal to the load path.
+  const loadGenerationRef = useRef(0);
+  const loadedSizeRef = useRef<number | null>(null);
+
+  const loadBuffer = useCallback(
+    async (buffer: DocxInput) => {
+      // Capture the REAL on-disk size of the loaded bytes (not an in-memory
+      // serialization estimate) for the Properties dialog.
+      loadedSizeRef.current =
+        buffer instanceof Blob
+          ? buffer.size
+          : buffer instanceof ArrayBuffer
+            ? buffer.byteLength
+            : ArrayBuffer.isView(buffer)
+              ? buffer.byteLength
+              : null;
+      const generation = ++loadGenerationRef.current;
+      resetForNewDocument();
+      // Loading a fresh buffer wipes the prior edit state, so the new document
+      // starts clean.
+      markDirty(false);
+      onLoadStart();
+      try {
+        const doc = await parseDocx(buffer);
+        // Discard result if a newer load was started while we were parsing.
+        if (loadGenerationRef.current !== generation) return;
+        loadParsedDocument(doc);
+      } catch (error) {
+        if (loadGenerationRef.current !== generation) return;
+        const message = error instanceof Error ? error.message : 'Failed to parse document';
+        onLoadError(message);
+        emitError(error instanceof Error ? error : new Error(message));
+      }
+    },
+    [resetForNewDocument, loadParsedDocument, markDirty, emitError, onLoadStart, onLoadError]
+  );
+
+  // Restore a server-persisted revision: download its .docx and load it. In a
+  // live collab room the load flows through the same PM path, so peers converge
+  // on the restored content. Failures surface via onError rather than throwing.
+  const handleRestoreServerVersion = useCallback(
+    (version: number) => {
+      if (!versionBackend) return;
+      void (async () => {
+        try {
+          const buf = await downloadServerVersion(versionBackend, version);
+          await loadBuffer(buf);
+        } catch (err) {
+          emitError(err instanceof Error ? err : new Error(String(err)));
+        }
+      })();
+    },
+    [versionBackend, loadBuffer, emitError]
+  );
+
+  // React to document / documentBuffer prop changes.
+  useEffect(() => {
+    // External content mode: caller populates PM directly — skip the load.
+    if (externalContent) return;
+
+    if (!documentBuffer) {
+      if (initialDocument) {
+        loadParsedDocument(initialDocument);
+      }
+      return;
+    }
+
+    void loadBuffer(documentBuffer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [documentBuffer, initialDocument, externalContent]);
+
+  return { loadBuffer, handleRestoreServerVersion, loadedSizeRef };
+}


### PR DESCRIPTION
First, **lower-risk** slice of the `useDocumentIO` decomposition. Moves the document **load** path out of the 12k-line DocxEditor god-component into a `useDocumentLoad` hook: `loadBuffer` (parse + generation guard + Properties byte size), the `documentBuffer`/`initialDocument` effect, and `handleRestoreServerVersion`.

**Deliberately not the save path** — a bug there is data-loss, not a recoverable failed load (I fixed a data-loss bug in `handleSave` this cycle, #340), so it stays in the component for a dedicated pass. The shared `resetForNewDocument`/`loadParsedDocument` also stay (the imperative ref API + agent bridge reuse them) and are passed in; state writes go through narrow callbacks so the hook never touches the component's giant state object.

Verbatim behaviour move. The load effect now re-registers after the `[history.state]`-driven agent effect — benign, since an async load changes `history.state` and re-creates the agent regardless of mount order.

**Verified:** typecheck + eslint (rules-of-hooks) + 439 react unit tests + the 39-fixture round-trip gate **pristine** + **46 e2e** including real document load (`demo-docx` render/round-trip, `open-unsaved-guard`), 0 fail.