### PR TITLE
feat(collab): offline persistence via y-indexeddb

### DIFF
--- a/docx-editor/.changeset/offline-persistence.md
+++ b/docx-editor/.changeset/offline-persistence.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Add offline persistence for collaborative sessions: the Y.Doc is mirrored into IndexedDB (keyed by room), so edits survive a page reload or an offline session and merge back up on reconnect. The autosave safety gate is unchanged — it still waits for the server, so there is no blank-document overwrite.

--- a/docx-editor/bun.lock
+++ b/docx-editor/bun.lock
@@ -121,11 +121,13 @@
         "katex": "^0.17.0",
         "nspell": "^2.1.5",
         "sonner": "^2.0.7",
+        "y-indexeddb": "^9.0.12",
       },
       "devDependencies": {
         "@hocuspocus/provider": "^2.15.0",
         "@schnsrw/design-system": "file:../../vendor/design-system",
         "@types/katex": "^0.16.8",
+        "fake-indexeddb": "^6",
         "prosemirror-commands": "^1.5.2",
         "prosemirror-dropcursor": "^1.8.2",
         "prosemirror-history": "^1.4.0",
@@ -763,8 +765,6 @@
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": "7.24.6" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
-    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
-
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "3.2.3" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "19.2.14" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
@@ -1144,6 +1144,8 @@
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
+
+    "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -1857,6 +1859,8 @@
 
     "y-codemirror.next": ["y-codemirror.next@0.3.5", "", { "dependencies": { "lib0": "^0.2.42" }, "peerDependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "yjs": "^13.5.6" } }, "sha512-VluNu3e5HfEXybnypnsGwKAj+fKLd4iAnR7JuX1Sfyydmn1jCBS5wwEL/uS04Ch2ib0DnMAOF6ZRR/8kK3wyGw=="],
 
+    "y-indexeddb": ["y-indexeddb@9.0.12", "", { "dependencies": { "lib0": "^0.2.74" }, "peerDependencies": { "yjs": "^13.0.0" } }, "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg=="],
+
     "y-leveldb": ["y-leveldb@0.1.2", "", { "dependencies": { "level": "6.0.1", "lib0": "0.2.117" }, "peerDependencies": { "yjs": "13.6.30" } }, "sha512-6ulEn5AXfXJYi89rXPEg2mMHAyyw8+ZfeMMdOtBbV8FJpQ1NOrcgi6DTAcXof0dap84NjHPT2+9d0rb6cFsjEg=="],
 
     "y-prosemirror": ["y-prosemirror@1.3.7", "", { "dependencies": { "lib0": "0.2.117" }, "peerDependencies": { "prosemirror-model": "1.25.4", "prosemirror-state": "1.4.4", "prosemirror-view": "1.41.8", "y-protocols": "1.0.7", "yjs": "13.6.30" } }, "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg=="],
@@ -1883,7 +1887,7 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@casualoffice/docs/@schnsrw/design-system": ["@schnsrw/design-system@file:vendor/design-system", { "devDependencies": { "@types/react": "^18.3.12", "@types/react-dom": "^18.3.1", "react": "^18.3.1", "react-dom": "^18.3.1", "tsup": "^8.3.5", "typescript": "^5.6.3" }, "peerDependencies": { "react": ">=18.0.0 <20.0.0", "react-dom": ">=18.0.0 <20.0.0" } }],
+    "@casualoffice/docs/@schnsrw/design-system": ["@schnsrw/design-system@file:vendor/design-system", {}],
 
     "@changesets/apply-release-plan/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
@@ -1993,14 +1997,6 @@
 
     "y-websocket/ws": ["ws@6.2.4", "", { "dependencies": { "async-limiter": "1.0.1" } }, "sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw=="],
 
-    "@casualoffice/docs/@schnsrw/design-system/@types/react": ["@types/react@18.3.31", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw=="],
-
-    "@casualoffice/docs/@schnsrw/design-system/@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
-
-    "@casualoffice/docs/@schnsrw/design-system/react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
-
-    "@casualoffice/docs/@schnsrw/design-system/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
-
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
@@ -2024,8 +2020,6 @@
     "tsup/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "@casualoffice/docs/@schnsrw/design-system/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "2.3.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/docx-editor/e2e/tests/offline-persistence-browser.spec.ts
+++ b/docx-editor/e2e/tests/offline-persistence-browser.spec.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/*
+ * BROWSER verification of the offline-persistence wiring (useCollab +
+ * IndexeddbPersistence). Drives the real editor in collab mode against an
+ * in-process Hocuspocus server (the same server the convergence test uses),
+ * with REAL browser IndexedDB — closing the gate the fake-indexeddb unit test
+ * can't (the full editor reload flow).
+ *
+ * The collab room seed normally comes from the collab server's
+ * `/api/rooms/:room/seed` REST surface (the CasualOffice/collab submodule,
+ * not running in this repo's e2e). We route-mock that ONE endpoint with a
+ * blank .docx so the editor mounts; everything else — the Y.Doc, the WS
+ * provider, and the IndexeddbPersistence under test — is the real thing.
+ *
+ * Covers the two safety-critical checks:
+ *   1. Edits survive a page reload.
+ *   2. Edits survive a reload with the server DOWN — content is restored from
+ *      IndexedDB, not the server (true offline durability), and the editor
+ *      still mounts (no hang, no blank-doc overwrite).
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { test, expect } from '@playwright/test';
+import { Hocuspocus } from '@hocuspocus/server';
+import { EditorPage } from '../helpers/editor-page';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BLANK_DOCX = readFileSync(join(__dirname, '../fixtures/empty.docx'));
+
+const PORT = 8899;
+let server: Hocuspocus;
+
+test.beforeAll(async () => {
+  server = new Hocuspocus({ port: PORT, quiet: true });
+  await server.listen();
+});
+
+test.afterAll(async () => {
+  await server.destroy().catch(() => {});
+});
+
+const PAGES = '.paged-editor__pages';
+
+function collabUrl(room: string): string {
+  return `/?e2e=1&room=${room}&backend=ws://localhost:${PORT}`;
+}
+
+// Serve the blank room seed for the /api/rooms/:room/seed download so CollabApp
+// mounts the editor without the collab server running.
+async function mockSeed(page: import('@playwright/test').Page): Promise<void> {
+  await page.route('**/api/rooms/**/seed', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType:
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      body: BLANK_DOCX,
+    })
+  );
+}
+
+test.describe('offline persistence — real browser + IndexedDB', () => {
+  test('an edit survives a page reload (collab + IndexedDB)', async ({ page }) => {
+    const room = `idb-reload-${Date.now()}`;
+    const editor = new EditorPage(page);
+    await mockSeed(page);
+
+    await page.goto(collabUrl(room));
+    await page.waitForSelector('[data-testid="docx-editor"]', { timeout: 30000 });
+    await page.waitForTimeout(1200); // let the provider + IDB sync settle
+
+    const UNIQUE = `IDBRELOAD${Date.now()}`;
+    await editor.focus();
+    await editor.typeText(UNIQUE);
+    await page.waitForTimeout(1500); // flush to IndexedDB + server
+
+    await page.reload();
+    await page.waitForSelector('[data-testid="docx-editor"]', { timeout: 30000 });
+    await page.waitForTimeout(1800);
+
+    await expect(page.locator(PAGES)).toContainText(UNIQUE);
+  });
+
+  test('an edit survives a reload with the server DOWN (offline → IndexedDB restores)', async ({
+    page,
+  }) => {
+    const room = `idb-offline-${Date.now()}`;
+    const editor = new EditorPage(page);
+    await mockSeed(page);
+
+    await page.goto(collabUrl(room));
+    await page.waitForSelector('[data-testid="docx-editor"]', { timeout: 30000 });
+    await page.waitForTimeout(1200);
+
+    const UNIQUE = `IDBOFFLINE${Date.now()}`;
+    await editor.focus();
+    await editor.typeText(UNIQUE);
+    await page.waitForTimeout(1500); // ensure it's flushed to IndexedDB
+
+    // Take the server offline, then reload — content must come from IndexedDB.
+    await server.destroy();
+    await page.reload();
+    await page.waitForSelector('[data-testid="docx-editor"]', { timeout: 30000 });
+    await page.waitForTimeout(2000);
+
+    await expect(page.locator(PAGES)).toContainText(UNIQUE);
+
+    // Restart the server so afterAll's destroy() and any later tests are happy.
+    server = new Hocuspocus({ port: PORT, quiet: true });
+    await server.listen();
+  });
+});

--- a/docx-editor/packages/react/package.json
+++ b/docx-editor/packages/react/package.json
@@ -133,12 +133,14 @@
     "dictionary-en": "^4.0.0",
     "katex": "^0.17.0",
     "nspell": "^2.1.5",
-    "sonner": "^2.0.7"
+    "sonner": "^2.0.7",
+    "y-indexeddb": "^9.0.12"
   },
   "devDependencies": {
     "@hocuspocus/provider": "^2.15.0",
     "@schnsrw/design-system": "file:../../vendor/design-system",
     "@types/katex": "^0.16.8",
+    "fake-indexeddb": "^6",
     "prosemirror-commands": "^1.5.2",
     "prosemirror-dropcursor": "^1.8.2",
     "prosemirror-history": "^1.4.0",

--- a/docx-editor/packages/react/src/collab/offline-persistence.test.ts
+++ b/docx-editor/packages/react/src/collab/offline-persistence.test.ts
@@ -10,8 +10,9 @@
  *
  * NOTE: this covers the y-indexeddb round-trip only. The full editor behaviour
  * (IndexedDB hydration → y-prosemirror → painted pages on a real page reload,
- * and no blank-doc overwrite when the WS reconnects) needs a real browser and
- * is the browser-verification gate on the wiring PR.
+ * including a reload with the WS server DOWN so the content can only come from
+ * IndexedDB) is verified in a real browser by
+ * `e2e/tests/offline-persistence-browser.spec.ts`.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';

--- a/docx-editor/packages/react/src/collab/offline-persistence.test.ts
+++ b/docx-editor/packages/react/src/collab/offline-persistence.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/*
+ * Verifies the persistence PRIMITIVE that useCollab's offline durability relies
+ * on: a Y.Doc's ProseMirror fragment is mirrored into IndexedDB, and a fresh
+ * Y.Doc bound to the same room restores it — the "reload / offline session"
+ * round-trip. Uses fake-indexeddb so it runs in the unit suite.
+ *
+ * NOTE: this covers the y-indexeddb round-trip only. The full editor behaviour
+ * (IndexedDB hydration → y-prosemirror → painted pages on a real page reload,
+ * and no blank-doc overwrite when the WS reconnects) needs a real browser and
+ * is the browser-verification gate on the wiring PR.
+ */
+
+import 'fake-indexeddb/auto';
+import { afterEach, describe, expect, test } from 'bun:test';
+import * as Y from 'yjs';
+import { IndexeddbPersistence } from 'y-indexeddb';
+
+// Unique room per test so the shared fake IndexedDB doesn't cross-contaminate.
+let counter = 0;
+const rooms: string[] = [];
+function freshRoom(): string {
+  const r = `offline-test-${counter++}`;
+  rooms.push(r);
+  return r;
+}
+
+afterEach(async () => {
+  // Best-effort clear of the rooms this test file created.
+  for (const r of rooms.splice(0)) {
+    const doc = new Y.Doc();
+    const p = new IndexeddbPersistence(r, doc);
+    await p.whenSynced;
+    await p.clearData();
+  }
+});
+
+describe('offline persistence (y-indexeddb round-trip)', () => {
+  test('a fragment edit survives a simulated reload in a new Y.Doc', async () => {
+    const room = freshRoom();
+
+    // Session 1: edit, then let it flush to IndexedDB.
+    const doc1 = new Y.Doc();
+    const p1 = new IndexeddbPersistence(room, doc1);
+    await p1.whenSynced;
+    const frag1 = doc1.getXmlFragment('prosemirror');
+    const para = new Y.XmlElement('paragraph');
+    para.insert(0, [new Y.XmlText('offline durable content')]);
+    frag1.insert(0, [para]);
+    await new Promise((r) => setTimeout(r, 50)); // let the update flush to IDB
+    await p1.destroy();
+
+    // Session 2 (simulated reload): fresh doc, same room → restores from IDB.
+    const doc2 = new Y.Doc();
+    const p2 = new IndexeddbPersistence(room, doc2);
+    await p2.whenSynced;
+    const frag2 = doc2.getXmlFragment('prosemirror');
+    expect(frag2.toString()).toContain('offline durable content');
+    await p2.destroy();
+  });
+
+  test('an empty room restores to an empty fragment (no phantom content)', async () => {
+    const room = freshRoom();
+    const doc = new Y.Doc();
+    const p = new IndexeddbPersistence(room, doc);
+    await p.whenSynced;
+    expect(doc.getXmlFragment('prosemirror').length).toBe(0);
+    await p.destroy();
+  });
+
+  test('two separate rooms do not share persisted content', async () => {
+    const roomA = freshRoom();
+    const roomB = freshRoom();
+
+    const docA = new Y.Doc();
+    const pA = new IndexeddbPersistence(roomA, docA);
+    await pA.whenSynced;
+    const el = new Y.XmlElement('paragraph');
+    el.insert(0, [new Y.XmlText('only in A')]);
+    docA.getXmlFragment('prosemirror').insert(0, [el]);
+    await new Promise((r) => setTimeout(r, 50));
+    await pA.destroy();
+
+    const docB = new Y.Doc();
+    const pB = new IndexeddbPersistence(roomB, docB);
+    await pB.whenSynced;
+    expect(docB.getXmlFragment('prosemirror').toString()).not.toContain('only in A');
+    await pB.destroy();
+  });
+});

--- a/docx-editor/packages/react/src/collab/offline-persistence.test.ts
+++ b/docx-editor/packages/react/src/collab/offline-persistence.test.ts
@@ -14,33 +14,26 @@
  * is the browser-verification gate on the wiring PR.
  */
 
-import 'fake-indexeddb/auto';
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb';
 import * as Y from 'yjs';
 import { IndexeddbPersistence } from 'y-indexeddb';
 
-// Unique room per test so the shared fake IndexedDB doesn't cross-contaminate.
-let counter = 0;
-const rooms: string[] = [];
-function freshRoom(): string {
-  const r = `offline-test-${counter++}`;
-  rooms.push(r);
-  return r;
-}
-
-afterEach(async () => {
-  // Best-effort clear of the rooms this test file created.
-  for (const r of rooms.splice(0)) {
-    const doc = new Y.Doc();
-    const p = new IndexeddbPersistence(r, doc);
-    await p.whenSynced;
-    await p.clearData();
-  }
+// A fresh fake IndexedDB per test, set explicitly (not via the import-time
+// `fake-indexeddb/auto` global) so it survives other suites in the same `bun
+// test` process clobbering globals (e.g. happy-dom's register/unregister).
+beforeEach(() => {
+  (globalThis as unknown as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+  (globalThis as unknown as { IDBKeyRange: typeof IDBKeyRange }).IDBKeyRange = IDBKeyRange;
+});
+afterEach(() => {
+  // Drop the fake DB so nothing leaks into the next test / suite.
+  (globalThis as unknown as { indexedDB?: IDBFactory }).indexedDB = new IDBFactory();
 });
 
 describe('offline persistence (y-indexeddb round-trip)', () => {
   test('a fragment edit survives a simulated reload in a new Y.Doc', async () => {
-    const room = freshRoom();
+    const room = 'offline-room';
 
     // Session 1: edit, then let it flush to IndexedDB.
     const doc1 = new Y.Doc();
@@ -63,20 +56,16 @@ describe('offline persistence (y-indexeddb round-trip)', () => {
   });
 
   test('an empty room restores to an empty fragment (no phantom content)', async () => {
-    const room = freshRoom();
     const doc = new Y.Doc();
-    const p = new IndexeddbPersistence(room, doc);
+    const p = new IndexeddbPersistence('empty-room', doc);
     await p.whenSynced;
     expect(doc.getXmlFragment('prosemirror').length).toBe(0);
     await p.destroy();
   });
 
   test('two separate rooms do not share persisted content', async () => {
-    const roomA = freshRoom();
-    const roomB = freshRoom();
-
     const docA = new Y.Doc();
-    const pA = new IndexeddbPersistence(roomA, docA);
+    const pA = new IndexeddbPersistence('room-a', docA);
     await pA.whenSynced;
     const el = new Y.XmlElement('paragraph');
     el.insert(0, [new Y.XmlText('only in A')]);
@@ -85,7 +74,7 @@ describe('offline persistence (y-indexeddb round-trip)', () => {
     await pA.destroy();
 
     const docB = new Y.Doc();
-    const pB = new IndexeddbPersistence(roomB, docB);
+    const pB = new IndexeddbPersistence('room-b', docB);
     await pB.whenSynced;
     expect(docB.getXmlFragment('prosemirror').toString()).not.toContain('only in A');
     await pB.destroy();

--- a/docx-editor/packages/react/src/collab/useCollab.ts
+++ b/docx-editor/packages/react/src/collab/useCollab.ts
@@ -27,6 +27,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import * as Y from 'yjs';
 import { HocuspocusProvider } from '@hocuspocus/provider';
+import { IndexeddbPersistence } from 'y-indexeddb';
 import { ySyncPlugin, yCursorPlugin, yUndoPlugin, ySyncPluginKey } from 'y-prosemirror';
 import type { Plugin } from 'prosemirror-state';
 import { createStrictCoEditingPlugin } from './strictCoEditing';
@@ -183,60 +184,86 @@ export interface UseCollabOptions {
  * loader doesn't overwrite the Yjs-populated PM state.
  */
 export function useCollab({ room, backend, user, token }: UseCollabOptions): CollabState {
-  const { ydoc, provider, plugins, metaMap, footnotesMap, endnotesMap, propsMap, commentsMap } =
-    useMemo(() => {
-      const ydoc = new Y.Doc();
-      // Hocuspocus carries the document name in the handshake (`name`),
-      // not the URL path — so `backend` is the bare ws endpoint. A
-      // truthy token lets the handshake complete past an onAuthenticate
-      // hook even for anonymous sessions.
-      const provider = new HocuspocusProvider({
-        url: backend,
-        name: room,
-        document: ydoc,
-        token: token ?? 'anon',
-      });
-      const fragment = ydoc.getXmlFragment('prosemirror');
-      // Hocuspocus creates awareness by default; guard the type union so
-      // the cursor plugin is only wired when it's actually present.
-      const awareness = provider.awareness;
-      const plugins = [
-        ySyncPlugin(fragment),
-        ...(awareness
-          ? [
-              yCursorPlugin(awareness),
-              // Strict / paragraph-lock co-editing (opt-in; off by default).
-              // Locks are derived from peers' cursor awareness; only LOCAL
-              // edits are gated — remote Yjs sync transactions pass through.
-              createStrictCoEditingPlugin({
-                getLocks: peerLocksFromAwareness(awareness),
-                subscribeToLockChanges: subscribeAwareness(awareness),
-                isRemoteTransaction: (tr) => tr.getMeta(ySyncPluginKey) != null,
-              }),
-            ]
-          : []),
-        yUndoPlugin(),
-      ];
-      const metaMap = ydoc.getMap('meta');
-      // Footnote text edits don't live in the ProseMirror document (footnotes are
-      // a separate part of the .docx), so they don't travel over ySyncPlugin.
-      // A dedicated shared map in the SAME Y.Doc gives them the same realtime
-      // sync + offline resilience as the body content. Keyed by footnote id
-      // (string) → current plain text.
-      const footnotesMap = ydoc.getMap<string>('footnotes');
-      const endnotesMap = ydoc.getMap<string>('endnotes');
-      // Core document properties (title / subject / creator / keywords /
-      // description) edited via File → Properties. Not in the PM tree; keyed by
-      // field name → value so two peers editing different fields merge.
-      const propsMap = ydoc.getMap<string>('props');
-      // Comment threads (text / replies / resolved) live in React state, not the
-      // PM tree, so the highlight marks sync but the thread content wouldn't.
-      // A shared map keyed by comment id (string) → Comment JSON gives them the
-      // same realtime sync. Replies are separate Comment entries (parentId).
-      const commentsMap = ydoc.getMap<unknown>('comments');
-      return { ydoc, provider, plugins, metaMap, footnotesMap, endnotesMap, propsMap, commentsMap };
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [room, backend, token]);
+  const {
+    ydoc,
+    provider,
+    idbPersistence,
+    plugins,
+    metaMap,
+    footnotesMap,
+    endnotesMap,
+    propsMap,
+    commentsMap,
+  } = useMemo(() => {
+    const ydoc = new Y.Doc();
+    // Hocuspocus carries the document name in the handshake (`name`),
+    // not the URL path — so `backend` is the bare ws endpoint. A
+    // truthy token lets the handshake complete past an onAuthenticate
+    // hook even for anonymous sessions.
+    const provider = new HocuspocusProvider({
+      url: backend,
+      name: room,
+      document: ydoc,
+      token: token ?? 'anon',
+    });
+    // Offline durability: mirror the Y.Doc into IndexedDB keyed by room. On
+    // reload the doc hydrates from IndexedDB immediately — so edits survive a
+    // refresh or an offline session, and reconnecting merges them up via the
+    // CRDT. This does NOT change the autosave safety gate: `synced` tracks the
+    // PROVIDER's initial sync (below), not IndexedDB, so autosave still waits
+    // for the server before it can serialize — no blank-doc overwrite.
+    const idbPersistence = new IndexeddbPersistence(room, ydoc);
+    const fragment = ydoc.getXmlFragment('prosemirror');
+    // Hocuspocus creates awareness by default; guard the type union so
+    // the cursor plugin is only wired when it's actually present.
+    const awareness = provider.awareness;
+    const plugins = [
+      ySyncPlugin(fragment),
+      ...(awareness
+        ? [
+            yCursorPlugin(awareness),
+            // Strict / paragraph-lock co-editing (opt-in; off by default).
+            // Locks are derived from peers' cursor awareness; only LOCAL
+            // edits are gated — remote Yjs sync transactions pass through.
+            createStrictCoEditingPlugin({
+              getLocks: peerLocksFromAwareness(awareness),
+              subscribeToLockChanges: subscribeAwareness(awareness),
+              isRemoteTransaction: (tr) => tr.getMeta(ySyncPluginKey) != null,
+            }),
+          ]
+        : []),
+      yUndoPlugin(),
+    ];
+    const metaMap = ydoc.getMap('meta');
+    // Footnote text edits don't live in the ProseMirror document (footnotes are
+    // a separate part of the .docx), so they don't travel over ySyncPlugin.
+    // A dedicated shared map in the SAME Y.Doc gives them the same realtime
+    // sync + offline resilience as the body content. Keyed by footnote id
+    // (string) → current plain text.
+    const footnotesMap = ydoc.getMap<string>('footnotes');
+    const endnotesMap = ydoc.getMap<string>('endnotes');
+    // Core document properties (title / subject / creator / keywords /
+    // description) edited via File → Properties. Not in the PM tree; keyed by
+    // field name → value so two peers editing different fields merge.
+    const propsMap = ydoc.getMap<string>('props');
+    // Comment threads (text / replies / resolved) live in React state, not the
+    // PM tree, so the highlight marks sync but the thread content wouldn't.
+    // A shared map keyed by comment id (string) → Comment JSON gives them the
+    // same realtime sync. Replies are separate Comment entries (parentId).
+    const commentsMap = ydoc.getMap<unknown>('comments');
+    return {
+      ydoc,
+      provider,
+      idbPersistence,
+      plugins,
+      metaMap,
+      footnotesMap,
+      endnotesMap,
+      propsMap,
+      commentsMap,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [room, backend, token]);
 
   const [status, setStatus] = useState<CollabStatus>('connecting');
   // True once the provider has completed its INITIAL sync with the server —
@@ -329,10 +356,13 @@ export function useCollab({ room, backend, user, token }: UseCollabOptions): Col
   // destruction closes the WS and frees the awareness listeners.
   useEffect(() => {
     return () => {
+      // Close the IndexedDB connection but KEEP the persisted data for the next
+      // load; then tear down the provider (WS + awareness) and the Y.Doc.
+      idbPersistence.destroy();
       provider.destroy();
       ydoc.destroy();
     };
-  }, [provider, ydoc]);
+  }, [provider, ydoc, idbPersistence]);
 
   return {
     plugins,

--- a/docx-editor/packages/react/src/components/sidebar/ImagePropertiesSection.tsx
+++ b/docx-editor/packages/react/src/components/sidebar/ImagePropertiesSection.tsx
@@ -9,7 +9,7 @@
  * options. Reuses the editor's existing wrap + resize commands; this is a
  * presentation layer, not a new command path.
  */
-import { useEffect, useState, type CSSProperties } from 'react';
+import { useEffect, useState, type CSSProperties, type JSX } from 'react';
 
 interface WrapOption {
   value: string;


### PR DESCRIPTION
Wires `IndexeddbPersistence` into `useCollab` so a collab room's Y.Doc is mirrored to IndexedDB — edits survive a reload and an offline session, and re-sync on reconnect. The `synced` flag still tracks the WS provider (not IndexedDB), so the blank-doc-overwrite gate is preserved.

Verification:
- Unit (`offline-persistence.test.ts`, fake-indexeddb): y-indexeddb round-trip, empty-room = empty fragment, room isolation.
- Browser (`e2e/tests/offline-persistence-browser.spec.ts`, real IndexedDB): edit survives a reload; and survives a reload with the WS server **down** — with a blank seed + full reload, the restored text can only come from IndexedDB.