### PR TITLE
fix(parser): keep hyperlink text from a wrapped simple field

### DIFF
--- a/docx-editor/.changeset/hyperlink-fldsimple-text.md
+++ b/docx-editor/.changeset/hyperlink-fldsimple-text.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Preserve hyperlink text when the link wraps a simple field (`<w:fldSimple>`), e.g. a PAGEREF/REF cross-reference or TOC entry — previously such links rendered empty and lost their text on round-trip.

--- a/docx-editor/packages/core/src/docx/__tests__/hyperlink-simple-field-text.test.ts
+++ b/docx-editor/packages/core/src/docx/__tests__/hyperlink-simple-field-text.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * A hyperlink whose display text is a simple field (<w:fldSimple>) — e.g. a
+ * PAGEREF/REF cross-reference or a TOC entry — used to render as an empty link:
+ * the hyperlink child loop only handled <w:r>/<w:bookmark*>/<w:ins>/<w:del> and
+ * let fldSimple fall through, dropping the text on round-trip. The field's
+ * display runs are now flattened so the link text survives.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { XmlElement } from '../xmlParser';
+import { parseXmlDocument } from '../xmlParser';
+import { parseParagraph } from '../paragraphParser';
+import type { Hyperlink, Run } from '../../types/document';
+
+const W = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+function linkFrom(xml: string): Hyperlink | undefined {
+  const root = parseXmlDocument(xml) as XmlElement;
+  const para = parseParagraph(root, null, null, null, null, null);
+  return para.content.find((c) => c.type === 'hyperlink') as Hyperlink | undefined;
+}
+
+function linkText(link: Hyperlink | undefined): string {
+  if (!link) return '';
+  return (link.children as Run[])
+    .filter((c) => c.type === 'run')
+    .flatMap((r) => (r.content ?? []).map((c) => (c.type === 'text' ? c.text : '')))
+    .join('');
+}
+
+describe('hyperlink display text from a simple field', () => {
+  test('a hyperlink wrapping <w:fldSimple> keeps the field result text', () => {
+    const link = linkFrom(`
+      <w:p ${W}>
+        <w:hyperlink w:anchor="_Ref123" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+          <w:fldSimple w:instr=" PAGEREF _Ref123 \\h ">
+            <w:r><w:t>42</w:t></w:r>
+          </w:fldSimple>
+        </w:hyperlink>
+      </w:p>`);
+    expect(link).toBeDefined();
+    expect(linkText(link)).toContain('42');
+  });
+
+  test('a plain (<w:r>) link is unaffected', () => {
+    const link = linkFrom(`
+      <w:p ${W}>
+        <w:hyperlink r:id="rId1" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+          <w:r><w:t>Plain link</w:t></w:r>
+        </w:hyperlink>
+      </w:p>`);
+    expect(linkText(link)).toContain('Plain link');
+  });
+});

--- a/docx-editor/packages/core/src/docx/hyperlinkParser.ts
+++ b/docx-editor/packages/core/src/docx/hyperlinkParser.ts
@@ -205,8 +205,19 @@ export function parseHyperlink(
         break;
       }
 
-      // Note: hyperlinks can technically contain other elements like
-      // fldSimple, but these are rare. Add support as needed.
+      case 'fldSimple': {
+        // A hyperlink can wrap a simple field whose result is the link text —
+        // e.g. a PAGEREF/REF used as a cross-reference or TOC entry.
+        // `hyperlink.children` doesn't model fields, so flatten to the field's
+        // display runs; without this the link rendered empty and the text was
+        // lost on round-trip.
+        for (const gc of getChildElements(child)) {
+          if (getLocalName(gc.name) === 'r') {
+            hyperlink.children.push(parseRun(gc, styles, theme, rels, media));
+          }
+        }
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
A `<w:hyperlink>` whose display text is a `<w:fldSimple>` (a PAGEREF/REF cross-reference or TOC entry) rendered empty and lost its text on round-trip — the child loop only handled r/bookmark/ins/del. Flattens the field's display runs, mirroring the existing ins/del handling. Unit test added; round-trip audit unchanged (no drops).