### PR TITLE
feat(paged-editor): draggable touch selection handles

### DIFF
--- a/docx-editor/.changeset/touch-selection-handles.md
+++ b/docx-editor/.changeset/touch-selection-handles.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': minor
+---
+
+Add draggable start/end selection handles on touch devices: after selecting text, drag the pills to adjust either end of the selection.

--- a/docx-editor/e2e/tests/touch-selection.spec.ts
+++ b/docx-editor/e2e/tests/touch-selection.spec.ts
@@ -144,3 +144,90 @@ test.describe('Paged Editor - Touch drag-select', () => {
     expect(body).toContain('DDDD');
   });
 });
+
+/**
+ * Touch selection handles (Slice 2) — the draggable start/end pills. After a
+ * range is selected the handles appear; dragging the end handle extends the
+ * selection. Driven through CDP touch events.
+ */
+test.describe('Paged Editor - Selection handles', () => {
+  let editor: EditorPage;
+
+  test.beforeEach(async ({ page }) => {
+    editor = new EditorPage(page);
+    await editor.goto();
+    await editor.waitForReady();
+    await editor.newDocument();
+    await editor.focus();
+    await editor.typeText('AAAA BBBB CCCC DDDD');
+    await page.waitForTimeout(200);
+  });
+
+  async function longPressSelect(
+    page: import('@playwright/test').Page,
+    fromX: number,
+    toX: number,
+    y: number
+  ): Promise<void> {
+    const cdp = await page.context().newCDPSession(page);
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      touchPoints: [{ x: fromX, y }],
+    });
+    await page.waitForTimeout(600); // arm long-press
+    for (let i = 1; i <= 5; i++) {
+      await cdp.send('Input.dispatchTouchEvent', {
+        type: 'touchMove',
+        touchPoints: [{ x: fromX + ((toX - fromX) * i) / 5, y }],
+      });
+      await page.waitForTimeout(15);
+    }
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+    await page.waitForTimeout(150);
+  }
+
+  test('handles appear on a range and dragging the end handle extends it', async ({ page }) => {
+    const span = page.locator('.layout-page-content span', { hasText: 'AAAA' }).first();
+    const box = await span.boundingBox();
+    if (!box) throw new Error('no span box');
+    const y = box.y + box.height / 2;
+
+    // Select just "AAAA" (the first ~20% of the line) via long-press drag.
+    await longPressSelect(page, box.x + box.width * 0.02, box.x + box.width * 0.2, y);
+
+    // Both handles should now be visible.
+    const endHandle = page.locator('[data-testid="selection-handle-end"]');
+    await expect(page.locator('[data-testid="selection-handle-start"]')).toBeVisible();
+    await expect(endHandle).toBeVisible();
+
+    // Drag the end handle rightward to mid-"CCCC", extending the selection.
+    const hb = await endHandle.boundingBox();
+    if (!hb) throw new Error('no end-handle box');
+    const targetX = box.x + box.width * 0.62;
+    const cdp = await page.context().newCDPSession(page);
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      touchPoints: [{ x: hb.x + hb.width / 2, y: hb.y + hb.height / 2 }],
+    });
+    const startX = hb.x + hb.width / 2;
+    for (let i = 1; i <= 6; i++) {
+      await cdp.send('Input.dispatchTouchEvent', {
+        type: 'touchMove',
+        touchPoints: [{ x: startX + ((targetX - startX) * i) / 6, y }],
+      });
+      await page.waitForTimeout(20);
+    }
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+    await page.waitForTimeout(150);
+
+    // Typing replaces the extended selection (AAAA → mid-CCCC). If the handle
+    // had NOT extended it, only AAAA would be replaced and BBBB would survive.
+    await page.keyboard.type('X');
+    await page.waitForTimeout(150);
+    const body = (await page.locator('.paged-editor__pages').innerText()).trim();
+    expect(body.startsWith('X')).toBe(true);
+    expect(body).not.toContain('AAAA');
+    expect(body).not.toContain('BBBB');
+    expect(body).toContain('DDDD');
+  });
+});

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -38,6 +38,7 @@ import type { EditorView } from 'prosemirror-view';
 // Internal components
 import { HiddenProseMirror, type HiddenProseMirrorRef } from './HiddenProseMirror';
 import { SelectionOverlay } from './SelectionOverlay';
+import { SelectionHandles, type HandleAnchor } from './SelectionHandles';
 import { MobileFormatBar } from '../components/ui/MobileFormatBar';
 import { usePinchZoom } from '../components/hooks/usePinchZoom';
 import { ImageSelectionOverlay, type ImageSelectionInfo } from './ImageSelectionOverlay';
@@ -1690,6 +1691,11 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     const touchLongPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const touchSelectActiveRef = useRef(false);
     const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+
+    // Touch selection-handle drag: which handle is moving + the pinned
+    // (opposite) endpoint's document position it extends from.
+    const handleDraggingRef = useRef<'start' | 'end' | null>(null);
+    const handleFixedPosRef = useRef<number | null>(null);
 
     // Store callbacks in refs to avoid infinite re-render loops
     // when parent passes unstable callback references
@@ -4119,6 +4125,59 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       setSelectedImageInfo,
     ]);
 
+    // Selection-handle drag (touch). Pin the endpoint NOT being dragged, then
+    // move the other to the finger. Reuses the same pixel→position mapper and
+    // setSelection the mouse/touch selection paths use.
+    const handleSelectionHandleDragStart = useCallback((which: 'start' | 'end') => {
+      const view = hiddenPMRef.current?.getView();
+      if (!view) return;
+      const { from, to } = view.state.selection;
+      handleDraggingRef.current = which;
+      handleFixedPosRef.current = which === 'start' ? to : from;
+    }, []);
+
+    const handleSelectionHandleDragMove = useCallback(
+      (clientX: number, clientY: number) => {
+        if (handleDraggingRef.current === null || handleFixedPosRef.current === null) return;
+        if (!hiddenPMRef.current) return;
+        const pmPos = getPositionFromMouse(clientX, clientY);
+        if (pmPos === null) return;
+        hiddenPMRef.current.setSelection(handleFixedPosRef.current, pmPos);
+        updateDragScroll(clientX, clientY);
+      },
+      [getPositionFromMouse, updateDragScroll]
+    );
+
+    const handleSelectionHandleDragEnd = useCallback(() => {
+      handleDraggingRef.current = null;
+      handleFixedPosRef.current = null;
+      stopDragAutoScroll();
+      hiddenPMRef.current?.focus();
+    }, [stopDragAutoScroll]);
+
+    // Anchor points for the two handles, in pages-container-relative coords
+    // (same space SelectionOverlay paints in). First rect = selection start,
+    // last rect = selection end.
+    const selectionHandleAnchors = useMemo<{
+      start: HandleAnchor | null;
+      end: HandleAnchor | null;
+    }>(() => {
+      if (selectionRects.length === 0) return { start: null, end: null };
+      const first = selectionRects[0];
+      const last = selectionRects[selectionRects.length - 1];
+      return {
+        start: { x: first.x, y: first.y, height: first.height },
+        end: { x: last.x + last.width, y: last.y, height: last.height },
+      };
+    }, [selectionRects]);
+
+    // Only offer touch handles on touch-capable devices — on a mouse-only
+    // desktop they'd be visual noise.
+    const isTouchCapable = useMemo(
+      () => typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0,
+      []
+    );
+
     /**
      * Handle mousemove on pages to show table row/column insert buttons.
      * Detects proximity to table row/column boundaries and shows a floating "+" button.
@@ -5099,6 +5158,18 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             pageGap={pageGap}
             readOnly={readOnly}
           />
+
+          {/* Draggable start/end selection handles (touch only) */}
+          {!readOnly && isTouchCapable && (
+            <SelectionHandles
+              start={selectionHandleAnchors.start}
+              end={selectionHandleAnchors.end}
+              visible={isFocused && selectionRects.length > 0}
+              onDragStart={handleSelectionHandleDragStart}
+              onDragMove={handleSelectionHandleDragMove}
+              onDragEnd={handleSelectionHandleDragEnd}
+            />
+          )}
 
           {/* Floating format chip — appears above a non-collapsed
            *  selection. Two variants render simultaneously; the

--- a/docx-editor/packages/react/src/paged-editor/SelectionHandles.tsx
+++ b/docx-editor/packages/react/src/paged-editor/SelectionHandles.tsx
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * Touch selection handles — the draggable start/end pills shown at the ends of
+ * a range selection on touch devices (Google-Docs style). Dragging a handle
+ * moves that endpoint while the opposite one stays fixed.
+ *
+ * Presentational + gesture only: it knows nothing about ProseMirror. The parent
+ * supplies the two anchor points (in pages-container-relative coordinates, the
+ * same space `SelectionOverlay` paints in) and receives viewport-space
+ * `clientX/clientY` on each drag move, which it maps back to a document
+ * position. Native non-passive `touchmove` listeners (attached on the window
+ * for the duration of a drag) let us `preventDefault()` so the page doesn't
+ * scroll while a handle is being dragged.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import type { CSSProperties, JSX } from 'react';
+
+export interface HandleAnchor {
+  /** Pages-container-relative x of the selection endpoint. */
+  x: number;
+  /** Pages-container-relative y (top of the endpoint's line box). */
+  y: number;
+  /** Height of the endpoint's line box. */
+  height: number;
+}
+
+export interface SelectionHandlesProps {
+  /** Start endpoint anchor, or null when there is no range selection. */
+  start: HandleAnchor | null;
+  /** End endpoint anchor, or null when there is no range selection. */
+  end: HandleAnchor | null;
+  /** Whether the handles should be shown (touch device + focused range). */
+  visible: boolean;
+  /** Called when a handle drag begins so the parent can pin the opposite end. */
+  onDragStart: (which: 'start' | 'end') => void;
+  /** Called on each drag move with viewport coordinates. */
+  onDragMove: (clientX: number, clientY: number) => void;
+  /** Called when the drag ends (touchend / touchcancel). */
+  onDragEnd: () => void;
+  /** Handle knob colour (defaults to the Google-blue selection colour). */
+  color?: string;
+}
+
+const KNOB = 14; // visible knob diameter
+const PAD = 30; // transparent touch target around the knob
+const DEFAULT_COLOR = '#4285f4';
+
+export function SelectionHandles({
+  start,
+  end,
+  visible,
+  onDragStart,
+  onDragMove,
+  onDragEnd,
+  color = DEFAULT_COLOR,
+}: SelectionHandlesProps): JSX.Element | null {
+  const draggingRef = useRef<'start' | 'end' | null>(null);
+  // Latest callbacks, read by the window listeners without re-binding them.
+  const moveRef = useRef(onDragMove);
+  const endRef = useRef(onDragEnd);
+  moveRef.current = onDragMove;
+  endRef.current = onDragEnd;
+
+  // Window listeners live for the duration of a drag. Bound imperatively (not
+  // via React props) so touchmove is non-passive and can preventDefault().
+  const detachRef = useRef<(() => void) | null>(null);
+  const detach = useCallback(() => {
+    detachRef.current?.();
+    detachRef.current = null;
+    draggingRef.current = null;
+  }, []);
+
+  useEffect(() => detach, [detach]);
+
+  const beginDrag = useCallback(
+    (which: 'start' | 'end', e: React.TouchEvent) => {
+      // Ignore multi-touch — a 2nd finger means pinch, not a handle drag.
+      if (e.touches.length !== 1) return;
+      e.preventDefault();
+      e.stopPropagation();
+      draggingRef.current = which;
+      onDragStart(which);
+
+      const onMove = (ev: TouchEvent) => {
+        if (draggingRef.current === null) return;
+        if (ev.touches.length !== 1) {
+          detach();
+          endRef.current();
+          return;
+        }
+        ev.preventDefault();
+        const t = ev.touches[0];
+        moveRef.current(t.clientX, t.clientY);
+      };
+      const onEnd = () => {
+        detach();
+        endRef.current();
+      };
+
+      window.addEventListener('touchmove', onMove, { passive: false });
+      window.addEventListener('touchend', onEnd);
+      window.addEventListener('touchcancel', onEnd);
+      detachRef.current = () => {
+        window.removeEventListener('touchmove', onMove);
+        window.removeEventListener('touchend', onEnd);
+        window.removeEventListener('touchcancel', onEnd);
+      };
+    },
+    [onDragStart, detach]
+  );
+
+  if (!visible || start === null || end === null) return null;
+
+  // Knob just outside the selection: start above its top-left, end below its
+  // bottom-right (matches the platform convention).
+  const startCx = start.x;
+  const startCy = start.y - KNOB / 2;
+  const endCx = end.x;
+  const endCy = end.y + end.height + KNOB / 2;
+
+  const padStyle = (cx: number, cy: number): CSSProperties => ({
+    position: 'absolute',
+    left: cx - PAD / 2,
+    top: cy - PAD / 2,
+    width: PAD,
+    height: PAD,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    pointerEvents: 'auto',
+    touchAction: 'none',
+    zIndex: 11,
+  });
+
+  const knobStyle: CSSProperties = {
+    width: KNOB,
+    height: KNOB,
+    borderRadius: '50%',
+    backgroundColor: color,
+    boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
+  };
+
+  return (
+    <>
+      <div
+        style={padStyle(startCx, startCy)}
+        data-testid="selection-handle-start"
+        onTouchStart={(e) => beginDrag('start', e)}
+      >
+        <div style={knobStyle} />
+      </div>
+      <div
+        style={padStyle(endCx, endCy)}
+        data-testid="selection-handle-end"
+        onTouchStart={(e) => beginDrag('end', e)}
+      >
+        <div style={knobStyle} />
+      </div>
+    </>
+  );
+}
+
+export default SelectionHandles;


### PR DESCRIPTION
Slice 2 of touch selection (follows #359). After selecting text on a touch device, two draggable pills appear at the selection ends; dragging one adjusts that endpoint while the other stays pinned.

Additive overlay (`SelectionHandles`) reusing the existing `getPositionFromMouse` + `setSelection` core — the desktop mouse path is untouched, all desktop selection + pinch specs stay green. Handles render only on touch-capable devices. Verified with CDP `Input.dispatchTouchEvent` e2e (handles appear; end-handle drag extends the selection).