### PR TITLE
fix(comments): correct comment range placement around hyperlinks

### DIFF
--- a/docs/internal/27-production-grade-tracker.md
+++ b/docs/internal/27-production-grade-tracker.md
@@ -24,7 +24,7 @@ artifact; the concrete gates and their status are tracked here.
 | 4 | Personal-mode optimistic concurrency (If-Match) unwired → silent last-write-wins | critical | **Fixed 2026-07-19 (PR #311)** — etag threaded through `useFileSourceAutoSave`; conflict now 412s instead of clobbering |
 | 5 | WOPI 409 conflict wedges autosave into permanent silent edit loss | high | **Fixed 2026-07-19 (PR #311)** — 409 adopts host version; hook enters a durable conflict pause instead of infinite stale-retry |
 | 6 | Share permissions are an unenforced client-side `?role=` hint; no access UI | high | **Open (Next)** — server-enforced share tokens + collaborator management (overlaps P1.7/P1.9) |
-| 7 | Offline edits volatile despite banner promising "saved locally" | high | **Open (Next)** — add `y-indexeddb` (overlaps P1.6) or correct the banner copy |
+| 7 | Offline edits volatile despite banner promising "saved locally" | high | **Fixed 2026-07-21 (PR #358)** — `IndexeddbPersistence` mirrors the room Y.Doc to IndexedDB; edits survive reload/offline and replay on reconnect. Browser-verified in real Chromium incl. a reload with the WS server **down** (restore can only come from IndexedDB). `synced` still gates on the WS provider, preserving gate 1's blank-doc-overwrite protection |
 
 Feedback follow-ups: **Fixed 2026-07-19 (PR #313)** — manual-save failure toast + no false
 "Saved X ago" after a failed autosave (`pendingError` → "Unsaved changes"). Remaining audit
@@ -43,12 +43,19 @@ hooks, #352–#355); and the **roving-tabindex a11y toolbar** (#356). Dimension 
 correctness 4→5, architecture 2→4, a11y 3→4, security/collaboration held at 4 — readiness
 **70 → 81**. Full ledger in the readiness-proof artifact.
 
-**Remaining work** is infra-gated or large & delicate. Each has a ready-to-execute spec in
-[40-hardening-followups-specs.md](./40-hardening-followups-specs.md): offline persistence
-(needs a real-browser IndexedDB pass), touch drag-select, screenshot suite (Linux runner),
+**Then (2026-07-21, cont.):** the two remaining browser-verifiable slices shipped —
+**offline persistence** (y-indexeddb, gate 7; verified in real Chromium incl. a server-down
+reload, #358) and the full **touch selection** story: long-press **drag-select** (#359) plus
+draggable **selection handles** (#361), all CDP-touch e2e'd with the desktop path untouched.
+Plus a contained fidelity fix — hyperlink text from a wrapped `fldSimple` (#360). Dimension
+rises: mobile 3→4, and gate 7 (last durability gate) closed — readiness **81 → 84**.
+
+**Remaining work** is infra-gated or large & delicate: screenshot suite (Linux runner),
 server-enforced share tokens (separate collab repo), 100-page performance (O(doc-size)/keystroke
-layout), the off-screen `role=textbox` magnifier a11y fix, and the remaining ViewState/Formatting
-context extraction. The clean, self-contained, verifiable-in-repo slices are all shipped.
+layout), the off-screen `role=textbox` magnifier a11y fix, soft-keyboard viewport handling, and
+the remaining ViewState/Formatting context extraction (assessed as largely lateral churn — the
+props are already context-fed via `EditorToolbarContext`, not drilled). The clean,
+self-contained, verifiable-in-repo slices are all shipped.
 
 ### Status reconciliations (2026-07-19)
 

--- a/docx-editor/.changeset/comment-range-hyperlink-alignment.md
+++ b/docx-editor/.changeset/comment-range-hyperlink-alignment.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix comment anchors being lost around hyperlinks: a comment covering or immediately following a hyperlink no longer collapses to an empty range or drops its anchor on load/save.

--- a/docx-editor/packages/core/src/prosemirror/conversion/__tests__/comment-range-hyperlink-alignment.test.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/__tests__/comment-range-hyperlink-alignment.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * A comment anchored just AFTER a hyperlink used to lose its anchor on save.
+ * `extractParagraphContent` coalesces a multi-node hyperlink into ONE content
+ * item, but `insertCommentRanges` walked PM children 1:1 into that (shorter)
+ * array — so after a multi-node link the index desynced and the
+ * commentRangeStart/End landed around the wrong item, collapsing to an empty
+ * range with the commented text left outside it. These round-trip the OOXML
+ * model → PM → model and assert the commented run sits INSIDE its range.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { toProseDoc } from '../toProseDoc';
+import { fromProseDoc } from '../fromProseDoc';
+import type {
+  Document,
+  Paragraph,
+  Hyperlink,
+  Run,
+  ParagraphContent,
+} from '../../../types/document';
+
+function docFrom(content: ParagraphContent[]): Document {
+  const paragraph: Paragraph = { type: 'paragraph', content };
+  return { package: { document: { content: [paragraph] } } } as unknown as Document;
+}
+
+function rebuiltContent(content: ParagraphContent[]): ParagraphContent[] {
+  const rebuilt = fromProseDoc(toProseDoc(docFrom(content)));
+  return (rebuilt.package.document.content[0] as Paragraph).content;
+}
+
+const runText = (i: ParagraphContent, text: string): boolean =>
+  i.type === 'run' && (i.content ?? []).some((c) => c.type === 'text' && c.text === text);
+
+// A hyperlink whose two children have different formatting → two PM text nodes
+// sharing one href → coalesced back into a single Hyperlink content item.
+function multiNodeLink(): Hyperlink {
+  return {
+    type: 'hyperlink',
+    href: 'http://example.com',
+    children: [
+      { type: 'run', content: [{ type: 'text', text: 'foo' }], formatting: { bold: true } } as Run,
+      { type: 'run', content: [{ type: 'text', text: 'bar' }] } as Run,
+    ],
+  };
+}
+
+describe('comment range alignment across a coalesced hyperlink', () => {
+  test('a comment right after a multi-node hyperlink wraps the correct run', () => {
+    const items = rebuiltContent([
+      multiNodeLink(),
+      { type: 'commentRangeStart', id: 5 } as ParagraphContent,
+      { type: 'run', content: [{ type: 'text', text: 'X' }] } as Run,
+      { type: 'commentRangeEnd', id: 5 } as ParagraphContent,
+    ]);
+
+    const startIdx = items.findIndex((i) => i.type === 'commentRangeStart' && i.id === 5);
+    const endIdx = items.findIndex((i) => i.type === 'commentRangeEnd' && i.id === 5);
+    const xIdx = items.findIndex((i) => runText(i, 'X'));
+
+    expect(startIdx).toBeGreaterThanOrEqual(0);
+    expect(xIdx).toBeGreaterThanOrEqual(0);
+    // The commented run must sit strictly INSIDE the range (start < X < end).
+    // Before the fix the range collapsed to empty with X before both markers.
+    expect(startIdx).toBeLessThan(xIdx);
+    expect(endIdx).toBeGreaterThan(xIdx);
+  });
+
+  test('a comment covering the hyperlink itself keeps the link inside the range', () => {
+    const items = rebuiltContent([
+      { type: 'commentRangeStart', id: 7 } as ParagraphContent,
+      multiNodeLink(),
+      { type: 'commentRangeEnd', id: 7 } as ParagraphContent,
+    ]);
+
+    const startIdx = items.findIndex((i) => i.type === 'commentRangeStart' && i.id === 7);
+    const endIdx = items.findIndex((i) => i.type === 'commentRangeEnd' && i.id === 7);
+    const linkIdx = items.findIndex((i) => i.type === 'hyperlink');
+
+    expect(startIdx).toBeGreaterThanOrEqual(0);
+    expect(linkIdx).toBeGreaterThan(startIdx);
+    expect(endIdx).toBeGreaterThan(linkIdx);
+  });
+
+  test('a plain comment (no hyperlink) still wraps its run', () => {
+    const items = rebuiltContent([
+      { type: 'run', content: [{ type: 'text', text: 'before' }] } as Run,
+      { type: 'commentRangeStart', id: 9 } as ParagraphContent,
+      { type: 'run', content: [{ type: 'text', text: 'inside' }] } as Run,
+      { type: 'commentRangeEnd', id: 9 } as ParagraphContent,
+    ]);
+
+    const startIdx = items.findIndex((i) => i.type === 'commentRangeStart' && i.id === 9);
+    const endIdx = items.findIndex((i) => i.type === 'commentRangeEnd' && i.id === 9);
+    const insideIdx = items.findIndex((i) => runText(i, 'inside'));
+
+    expect(startIdx).toBeLessThan(insideIdx);
+    expect(endIdx).toBeGreaterThan(insideIdx);
+  });
+});

--- a/docx-editor/packages/core/src/prosemirror/conversion/fromProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/fromProseDoc.ts
@@ -205,9 +205,47 @@ function insertCommentRanges(content: ParagraphContent[], paragraph: PMNode): Pa
   // and wrap with commentRangeStart/End
   const result: ParagraphContent[] = [];
   const openedComments = new Set<number>();
-  let nodeIndex = 0;
+  // `content` is the COALESCED item array from extractParagraphContent, which
+  // folds consecutive same-href hyperlink nodes into ONE item, so it is shorter
+  // than paragraph.childCount. Walking PM children 1:1 into content[nodeIndex]
+  // therefore desynced after a multi-node hyperlink and dropped comment anchors
+  // (empty range, commented text left outside it). We instead advance
+  // `contentIndex` only when a PM node starts a NEW content item — mirroring the
+  // builder's grouping: only non-empty hrefs coalesce; anchor-only links and
+  // tracked-change (ins/del) runs stay 1:1.
+  let contentIndex = -1;
+  // Mirror extractParagraphContent's hyperlink grouping so we know when a PM
+  // node folds into the SAME coalesced item as the previous one. The builder
+  // keys a group by the first node's `href` (else `#anchor`) and continues it
+  // while a subsequent link node's `href` equals that key — so external
+  // (rId-based, empty-href) links coalesce via ''==='' while anchor-only links
+  // do not. A non-link or tracked-change (ins/del) node ends the group.
+  let inHyperlink = false;
+  let groupKey = '';
 
   paragraph.forEach((node) => {
+    const isTracked = node.marks.some(
+      (m) => m.type.name === 'insertion' || m.type.name === 'deletion'
+    );
+    const linkMark = isTracked ? undefined : node.marks.find((m) => m.type.name === 'hyperlink');
+
+    let continuesHyperlink = false;
+    if (linkMark) {
+      const nodeHref = (linkMark.attrs.href as string) || '';
+      if (inHyperlink && groupKey === nodeHref) {
+        continuesHyperlink = true;
+      } else {
+        const anchor = linkMark.attrs.anchor as string | undefined;
+        groupKey = nodeHref || (anchor ? `#${anchor}` : '');
+        inHyperlink = true;
+      }
+    } else {
+      inHyperlink = false;
+      groupKey = '';
+    }
+
+    if (!continuesHyperlink) contentIndex++;
+
     const nodeCommentIds = new Set<number>();
     for (const mark of node.marks) {
       if (mark.type.name === 'comment') {
@@ -232,12 +270,10 @@ function insertCommentRanges(content: ParagraphContent[], paragraph: PMNode): Pa
       }
     }
 
-    // Push the actual content item
-    if (nodeIndex < content.length) {
-      result.push(content[nodeIndex]);
+    // Push the actual content item — once, on the first PM node that forms it.
+    if (!continuesHyperlink && contentIndex < content.length) {
+      result.push(content[contentIndex]);
     }
-
-    nodeIndex++;
   });
 
   // Close any remaining open comments

--- a/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
+++ b/docx-editor/packages/core/src/prosemirror/conversion/toProseDoc.ts
@@ -187,7 +187,13 @@ function convertParagraph(
       }
       inlineNodes.push(...runNodes);
     } else if (content.type === 'hyperlink') {
-      const linkNodes = convertHyperlink(content, mergedStyleRunFormatting, styleResolver);
+      let linkNodes = convertHyperlink(content, mergedStyleRunFormatting, styleResolver);
+      // A comment range can cover a hyperlink; without this its display text
+      // carried no comment mark, so the anchor was dropped on load (and again
+      // on save). Mirrors the run/insertion/deletion branches.
+      if (commentIds.size > 0) {
+        linkNodes = applyCommentMarks(linkNodes, commentIds);
+      }
       inlineNodes.push(...linkNodes);
     } else if (content.type === 'simpleField' || content.type === 'complexField') {
       const fieldNode = convertField(content, mergedStyleRunFormatting);


### PR DESCRIPTION
Two related anchor-loss bugs at the comments × hyperlinks boundary, found via a correctness hunt:

- **Save (fromProseDoc):** `insertCommentRanges` walked PM children 1:1 into the content array, but `extractParagraphContent` coalesces a multi-node hyperlink into one item — so a comment right after a link desynced and its range collapsed to empty with the commented text left outside. Now advances the content index using the builder's own hyperlink grouping (href / #anchor / empty external-link keys all handled).
- **Load (toProseDoc):** the hyperlink branch never applied comment marks (unlike run/insertion/deletion), so a comment covering a link was dropped on open.

Deterministic model→PM→model round-trip tests added; 39-fixture round-trip audit and the full conversion suite unchanged.