### PR TITLE
fix(editor): route .md/.txt/.rtf/.eml from File → Open to the host

### DIFF
--- a/docx-editor/.changeset/open-source-file.md
+++ b/docx-editor/.changeset/open-source-file.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': minor
+---
+
+Add an `onOpenSourceFile` prop to `DocxEditor`: when File → Open picks a plain-source file (`.md`/`.txt`/`.rtf`/`.eml`), the host can open it in a dedicated markdown/source viewer instead of the editor converting it to DOCX. Fixes `.md` files opening as garbled DOCX from the in-editor File → Open.

--- a/docx-editor/e2e/tests/open-md-routes-to-markdown.spec.ts
+++ b/docx-editor/e2e/tests/open-md-routes-to-markdown.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/*
+ * Opening a Markdown file via the in-editor File → Open used to convert it to
+ * DOCX and show it in the DOCX editor (garbled), unlike the Home open path
+ * which routes .md to the markdown/source editor. The editor now offers such
+ * source files (.md/.txt/.rtf/.eml) to the host via `onOpenSourceFile`, and the
+ * example app routes them to its markdown editor. This drives the hidden
+ * File → Open input with a .md and asserts the switch.
+ */
+
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test('File → Open of a .md routes to the markdown editor, not the DOCX editor', async ({
+  page,
+}) => {
+  // Opening replaces the in-window doc; auto-accept the unsaved-changes confirm.
+  page.on('dialog', (d) => d.accept());
+
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+
+  // Drive the hidden File → Open input (accepts .md/.markdown) directly.
+  await page.locator('input[type="file"][accept*=".markdown"]').setInputFiles({
+    name: 'notes.md',
+    mimeType: 'text/markdown',
+    buffer: Buffer.from('# Hello Markdown\n\nSome **bold** text.'),
+  });
+
+  // The app switches to the markdown/source editor instead of loading it as DOCX.
+  await expect(page.locator('[data-testid="markdown-editor"]')).toBeVisible({ timeout: 15000 });
+  await expect(page.locator('[data-testid="docx-editor"]')).toHaveCount(0);
+});

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -1590,6 +1590,13 @@ export function App() {
           // in-window, so a later Save can't overwrite the previous file.
           onFileOpened={isDesktop ? onFileOpenedDesktop : undefined}
           onRequestOpen={isDesktop ? onRequestOpenDesktop : undefined}
+          // Route .md/.txt/.rtf/.eml picked from the in-editor File → Open to
+          // the same source/markdown viewer the Home open path uses, instead of
+          // converting them to DOCX and showing them here.
+          onOpenSourceFile={async (file) => {
+            await handleOpenFromHome(file);
+            return true;
+          }}
           // Dismiss the boot splash after DocxEditor has parsed the DOCX and
           // created its PM view, avoiding the blank-editor flash that occurred
           // when dismissBoot fired immediately after setDocumentBuffer.

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -540,6 +540,13 @@ export interface DocxEditorProps {
    *  back into the editor. Falls back to the in-window browser picker when
    *  absent (web). */
   onRequestOpen?: () => void;
+  /** Called when File → Open picks a plain-source file (.md / .txt / .rtf /
+   *  .eml) — formats a host may prefer to open in a dedicated markdown/source
+   *  viewer rather than convert to DOCX. Return `true` (or a Promise of it) if
+   *  the host handled it; the editor then skips its own convert-and-load.
+   *  Return falsy / omit the prop to keep the default behaviour (convert to
+   *  DOCX and load in-window). `.docx`/`.odt` never route here. */
+  onOpenSourceFile?: (file: File) => boolean | Promise<boolean>;
   /** Author name used for comments and track changes */
   author?: string;
   /** People the host (e.g. Drive) knows about, surfaced in the comment
@@ -1739,6 +1746,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     onNew,
     onFileOpened,
     onRequestOpen,
+    onOpenSourceFile,
     onExportPdf,
     author = 'User',
     mentionableUsers,
@@ -7683,11 +7691,21 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         if (!proceed) return;
       }
       try {
+        const { formatFromFilename, toDocxBytes } = await import('../lib/format-converter');
+        // Plain-source files (.md / .txt / .rtf / .eml) can be handled by the
+        // host in a dedicated markdown/source viewer instead of being converted
+        // to DOCX and shown here. Give it first refusal; if it takes the file
+        // (returns true) we stop. .docx/.odt never route here — they load in
+        // this editor as before.
+        const fmt = formatFromFilename(file.name);
+        if (onOpenSourceFile && (fmt === 'md' || fmt === 'txt' || fmt === 'rtf' || fmt === 'eml')) {
+          const handled = await onOpenSourceFile(file);
+          if (handled) return;
+        }
         const buffer = await file.arrayBuffer();
         // .odt / .md / .txt → DOCX via the WASM worker, then feed the existing
         // parser (PDF is intentionally not handled). Shared with the
         // FileSource/home open path so both convert identically.
-        const { toDocxBytes } = await import('../lib/format-converter');
         const docxBuffer = await toDocxBytes(buffer, file.name);
         await loadBuffer(docxBuffer);
         const cleanName = file.name.replace(/\.(docx|odt|md|markdown|txt)$/i, '');
@@ -7716,7 +7734,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         emitError(error instanceof Error ? error : new Error('Failed to open document'));
       }
     },
-    [loadBuffer, onDocumentNameChange, emitError, onFileOpened, t]
+    [loadBuffer, onDocumentNameChange, emitError, onFileOpened, onOpenSourceFile, t]
   );
 
   // ============================================================================


### PR DESCRIPTION
Opening a Markdown file via the **in-editor File → Open** converted it to DOCX and showed it (garbled) in the DOCX editor — unlike the Home open path, which routes .md to the markdown editor. Reported by the user.

Adds an optional `onOpenSourceFile(file)` prop to `DocxEditor`: for `.md`/`.txt`/`.rtf`/`.eml`, the editor offers the file to the host first and skips its own convert-and-load if the host handles it (returns true). `.docx`/`.odt` are unaffected. The example app wires it to the same source/markdown viewer the Home path already uses.

Verified with an e2e that drives the File → Open input with a .md and asserts the app switches to the markdown editor (`data-testid=markdown-editor`).