### PR TITLE
fix(layout): convert header/footer text-box anchor offsets EMU→px

### DIFF
--- a/docx-editor/.changeset/header-textbox-emu.md
+++ b/docx-editor/.changeset/header-textbox-emu.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix anchored text boxes in headers/footers rendering far off the page: their `offsetH`/`offsetV` (EMUs) were used raw as pixels instead of converted, throwing the box and its text/tags ~9525× too far. Now converted via `emuToPixels` like every other anchor offset.

--- a/docx-editor/.changeset/open-source-file.md
+++ b/docx-editor/.changeset/open-source-file.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': minor
+---
+
+Add an `onOpenSourceFile` prop to `DocxEditor`: when File → Open picks a plain-source file (`.md`/`.txt`/`.rtf`/`.eml`), the host can open it in a dedicated markdown/source viewer instead of the editor converting it to DOCX. Fixes `.md` files opening as garbled DOCX from the in-editor File → Open.

--- a/docx-editor/e2e/tests/open-md-routes-to-markdown.spec.ts
+++ b/docx-editor/e2e/tests/open-md-routes-to-markdown.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/*
+ * Opening a Markdown file via the in-editor File → Open used to convert it to
+ * DOCX and show it in the DOCX editor (garbled), unlike the Home open path
+ * which routes .md to the markdown/source editor. The editor now offers such
+ * source files (.md/.txt/.rtf/.eml) to the host via `onOpenSourceFile`, and the
+ * example app routes them to its markdown editor. This drives the hidden
+ * File → Open input with a .md and asserts the switch.
+ */
+
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test('File → Open of a .md routes to the markdown editor, not the DOCX editor', async ({
+  page,
+}) => {
+  // Opening replaces the in-window doc; auto-accept the unsaved-changes confirm.
+  page.on('dialog', (d) => d.accept());
+
+  const editor = new EditorPage(page);
+  await editor.goto();
+  await editor.waitForReady();
+
+  // Drive the hidden File → Open input (accepts .md/.markdown) directly.
+  await page.locator('input[type="file"][accept*=".markdown"]').setInputFiles({
+    name: 'notes.md',
+    mimeType: 'text/markdown',
+    buffer: Buffer.from('# Hello Markdown\n\nSome **bold** text.'),
+  });
+
+  // The app switches to the markdown/source editor instead of loading it as DOCX.
+  await expect(page.locator('[data-testid="markdown-editor"]')).toBeVisible({ timeout: 15000 });
+  await expect(page.locator('[data-testid="docx-editor"]')).toHaveCount(0);
+});

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -1590,6 +1590,13 @@ export function App() {
           // in-window, so a later Save can't overwrite the previous file.
           onFileOpened={isDesktop ? onFileOpenedDesktop : undefined}
           onRequestOpen={isDesktop ? onRequestOpenDesktop : undefined}
+          // Route .md/.txt/.rtf/.eml picked from the in-editor File → Open to
+          // the same source/markdown viewer the Home open path uses, instead of
+          // converting them to DOCX and showing them here.
+          onOpenSourceFile={async (file) => {
+            await handleOpenFromHome(file);
+            return true;
+          }}
           // Dismiss the boot splash after DocxEditor has parsed the DOCX and
           // created its PM view, avoiding the blank-editor flash that occurred
           // when dismissBoot fired immediately after setDocumentBuffer.

--- a/docx-editor/packages/core/src/layout-painter/__tests__/header-textbox-anchor-emu.test.ts
+++ b/docx-editor/packages/core/src/layout-painter/__tests__/header-textbox-anchor-emu.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/*
+ * An anchored text box in a header/footer positions from `anchor.offsetH/offsetV`,
+ * which are in EMUs (914400/inch). The header painter used them RAW as pixels,
+ * so a 0.5" offset (457200) placed the box ~9525× too far — hurling the text box
+ * and its text/tags right off the page. It must convert via emuToPixels like the
+ * body text-box and header-image paths do.
+ */
+
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { PAGE_CLASS_NAMES, renderPage, type HeaderFooterContent } from '../renderPage';
+import type {
+  Page,
+  ParagraphBlock,
+  ParagraphMeasure,
+  TextBoxBlock,
+  TextBoxMeasure,
+} from '../../layout-engine/types';
+
+beforeAll(() => GlobalRegistrator.register());
+afterAll(() => GlobalRegistrator.unregister());
+
+function makePage(): Page {
+  return {
+    number: 1,
+    fragments: [],
+    margins: { top: 96, right: 96, bottom: 96, left: 96, header: 48, footer: 48 },
+    size: { w: 816, h: 1056 },
+  };
+}
+
+// Header holding one page-anchored text box offset by `offsetEmu` on both axes.
+function headerWithAnchoredTextBox(offsetEmu: number): HeaderFooterContent {
+  const innerPara: ParagraphBlock = {
+    kind: 'paragraph',
+    id: 'tb-para',
+    runs: [],
+    attrs: { defaultFontSize: 11, defaultFontFamily: 'Calibri' },
+  };
+  const innerMeasure: ParagraphMeasure = {
+    kind: 'paragraph',
+    lines: [
+      {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 0,
+        toChar: 0,
+        width: 0,
+        ascent: 11,
+        descent: 4,
+        lineHeight: 17.9,
+      },
+    ],
+    totalHeight: 17.9,
+  };
+  const block: TextBoxBlock = {
+    kind: 'textBox',
+    id: 'tb1',
+    width: 200,
+    height: 100,
+    content: [innerPara],
+    anchor: { offsetH: offsetEmu, offsetV: offsetEmu, relFromH: 'page', relFromV: 'page' },
+  };
+  const measure: TextBoxMeasure = {
+    kind: 'textBox',
+    width: 200,
+    height: 100,
+    innerMeasures: [innerMeasure],
+  };
+  return { blocks: [block], measures: [measure], height: 100, visualTop: 0, visualBottom: 100 };
+}
+
+describe('renderPage header anchored text box positioning', () => {
+  test('offsetH/offsetV are converted EMU→px so the box stays on the page', () => {
+    const page = makePage();
+    // 1 inch = 914400 EMU = 96px. Page-relative → left = 96 - margins.left(96) = 0.
+    const el = renderPage(
+      page,
+      { pageNumber: 1, totalPages: 1, section: 'body' },
+      { document, headerContent: headerWithAnchoredTextBox(914400) }
+    );
+
+    const headerEl = el.querySelector(`.${PAGE_CLASS_NAMES.header}`);
+    const tb = headerEl?.querySelector('.layout-textbox') as HTMLElement | null;
+    expect(tb).toBeTruthy();
+
+    const left = parseFloat(tb!.style.left);
+    const top = parseFloat(tb!.style.top);
+
+    // Before the fix these were ~914304 (raw EMU), far outside the 816×1056 page.
+    expect(Math.abs(left)).toBeLessThanOrEqual(page.size.w);
+    expect(Math.abs(top)).toBeLessThanOrEqual(page.size.h);
+    // Concretely: 1" page-anchored, 1" left margin → left is exactly 0.
+    expect(left).toBe(0);
+  });
+});

--- a/docx-editor/packages/core/src/layout-painter/renderPage.ts
+++ b/docx-editor/packages/core/src/layout-painter/renderPage.ts
@@ -1139,8 +1139,12 @@ function renderHeaderFooterContent(
       let tbLeft = 0;
       let tbTop = cursorY;
       if (anchored) {
-        const offH = a!.offsetH ?? 0;
-        const offV = a!.offsetV ?? 0;
+        // offsetH/offsetV are in EMUs (like every other anchor offset); the
+        // margin/flow values below are already pixels, so convert first. Prior
+        // to this the raw EMU (e.g. 457200 for 0.5") was used as pixels, hurling
+        // the text box (and its text/tags) ~9525× too far, right off the page.
+        const offH = emuToPixels(a!.offsetH ?? 0);
+        const offV = emuToPixels(a!.offsetV ?? 0);
         tbLeft = a!.relFromH === 'page' ? offH - layout.margins.left : offH;
         if (a!.relFromV === 'page') tbTop = offV - layout.flowTop;
         else if (a!.relFromV === 'margin') tbTop = layout.margins.top + offV - layout.flowTop;

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -540,6 +540,13 @@ export interface DocxEditorProps {
    *  back into the editor. Falls back to the in-window browser picker when
    *  absent (web). */
   onRequestOpen?: () => void;
+  /** Called when File → Open picks a plain-source file (.md / .txt / .rtf /
+   *  .eml) — formats a host may prefer to open in a dedicated markdown/source
+   *  viewer rather than convert to DOCX. Return `true` (or a Promise of it) if
+   *  the host handled it; the editor then skips its own convert-and-load.
+   *  Return falsy / omit the prop to keep the default behaviour (convert to
+   *  DOCX and load in-window). `.docx`/`.odt` never route here. */
+  onOpenSourceFile?: (file: File) => boolean | Promise<boolean>;
   /** Author name used for comments and track changes */
   author?: string;
   /** People the host (e.g. Drive) knows about, surfaced in the comment
@@ -1739,6 +1746,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     onNew,
     onFileOpened,
     onRequestOpen,
+    onOpenSourceFile,
     onExportPdf,
     author = 'User',
     mentionableUsers,
@@ -7683,11 +7691,21 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         if (!proceed) return;
       }
       try {
+        const { formatFromFilename, toDocxBytes } = await import('../lib/format-converter');
+        // Plain-source files (.md / .txt / .rtf / .eml) can be handled by the
+        // host in a dedicated markdown/source viewer instead of being converted
+        // to DOCX and shown here. Give it first refusal; if it takes the file
+        // (returns true) we stop. .docx/.odt never route here — they load in
+        // this editor as before.
+        const fmt = formatFromFilename(file.name);
+        if (onOpenSourceFile && (fmt === 'md' || fmt === 'txt' || fmt === 'rtf' || fmt === 'eml')) {
+          const handled = await onOpenSourceFile(file);
+          if (handled) return;
+        }
         const buffer = await file.arrayBuffer();
         // .odt / .md / .txt → DOCX via the WASM worker, then feed the existing
         // parser (PDF is intentionally not handled). Shared with the
         // FileSource/home open path so both convert identically.
-        const { toDocxBytes } = await import('../lib/format-converter');
         const docxBuffer = await toDocxBytes(buffer, file.name);
         await loadBuffer(docxBuffer);
         const cleanName = file.name.replace(/\.(docx|odt|md|markdown|txt)$/i, '');
@@ -7716,7 +7734,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
         emitError(error instanceof Error ? error : new Error('Failed to open document'));
       }
     },
-    [loadBuffer, onDocumentNameChange, emitError, onFileOpened, t]
+    [loadBuffer, onDocumentNameChange, emitError, onFileOpened, onOpenSourceFile, t]
   );
 
   // ============================================================================


### PR DESCRIPTION
An anchored text box in a **header/footer** is positioned from `anchor.offsetH/offsetV`, which are in EMUs (914400/inch). The header painter used them **raw as pixels** while mixing them with pixel margin/flow values — so a 0.5" offset (457200) placed the box ~9525× too far, throwing the text box and its text/tags right off the page. (Reported: header text boxes/images going out of the canvas.)

Converts via `emuToPixels`, matching the body text-box path (`renderTextBox.ts`), the header-image path (`renderPage.ts:526`), and the `TextBoxBlock.anchor` type's own documented contract.

Regression test renders a page-anchored header text box and asserts it lands within the page (left/top bounded; exactly 0 for a 1" page offset with a 1" margin). Full layout-painter suite (55) + 39-fixture round-trip audit unchanged.