### PR TITLE
fix(save): don't clear a paragraph re-edited during the serialize window

### DIFF
--- a/docx-editor/.changeset/selective-save-reedit.md
+++ b/docx-editor/.changeset/selective-save-reedit.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix a selective-save data-loss window: a paragraph re-edited while the previous save was still serializing could have its change-tracker entry cleared, dropping that edit from the next save. Re-edited paragraphs are now retained until they're actually serialized.

--- a/docx-editor/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/features/ParagraphChangeTrackerExtension.ts
@@ -17,6 +17,7 @@ import {
   RemoveMarkStep,
   RemoveNodeMarkStep,
 } from 'prosemirror-transform';
+import type { Node as PMNode } from 'prosemirror-model';
 import { createExtension } from '../create';
 import type { ExtensionRuntime } from '../types';
 
@@ -446,6 +447,53 @@ export function clearTrackedChanges(state: EditorState, servedParaIds?: Set<stri
     return state.tr.setMeta(paragraphChangeTrackerKey, { clearServed: [...servedParaIds] });
   }
   return state.tr.setMeta(paragraphChangeTrackerKey, 'clear');
+}
+
+/**
+ * Of `servedParaIds` — the paragraphs a selective save serialized from a t0
+ * document snapshot — return the subset SAFE to clear from the change tracker:
+ * those whose paragraph is structurally unchanged between the snapshot
+ * (`servedDoc`) and the current doc (`currentDoc`).
+ *
+ * A paragraph re-edited during the async serialize window has different content
+ * in `currentDoc`; clearing it would silently drop that re-edit — it wasn't in
+ * the saved bytes, and a selective save only re-serializes still-tracked
+ * paragraphs. Such paragraphs are RETAINED so the next save picks them up. A
+ * paragraph that vanished (deleted/merged) is safe to clear (its tracked change
+ * is moot). When nothing changed during the window (`servedDoc === currentDoc`)
+ * the whole set is returned unchanged.
+ */
+export function paraIdsSafeToClear(
+  servedDoc: PMNode,
+  currentDoc: PMNode,
+  servedParaIds: Set<string>
+): Set<string> {
+  if (servedDoc === currentDoc) return servedParaIds;
+
+  const findPara = (doc: PMNode, id: string): PMNode | null => {
+    let found: PMNode | null = null;
+    doc.descendants((node) => {
+      if (found) return false;
+      if (node.isTextblock && node.attrs?.paraId === id) {
+        found = node;
+        return false;
+      }
+      return true;
+    });
+    return found;
+  };
+
+  const safe = new Set<string>();
+  for (const id of servedParaIds) {
+    const before = findPara(servedDoc, id);
+    const after = findPara(currentDoc, id);
+    // Gone now (deleted/merged) → safe. Present and deep-equal → safe.
+    // Present but re-edited mid-serialize → retain so it re-serializes next save.
+    if (!after || (before !== null && before.eq(after))) {
+      safe.add(id);
+    }
+  }
+  return safe;
 }
 
 export const ParagraphChangeTrackerExtension = createExtension({

--- a/docx-editor/packages/core/src/prosemirror/extensions/features/paraIdsSafeToClear.test.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/features/paraIdsSafeToClear.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/**
+ * paraIdsSafeToClear guards the selective-save data-loss window: a paragraph
+ * re-edited while the async serialize is in flight must NOT have its tracker
+ * entry cleared, or the re-edit is silently dropped (it wasn't in the saved
+ * bytes and a selective save only re-serializes still-tracked paragraphs).
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { Schema } from 'prosemirror-model';
+import { paraIdsSafeToClear } from './ParagraphChangeTrackerExtension';
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      group: 'block',
+      content: 'inline*',
+      attrs: { paraId: { default: null } },
+      toDOM: () => ['p', 0],
+    },
+    text: { group: 'inline' },
+  },
+});
+
+function doc(...paras: Array<{ text: string; paraId: string }>) {
+  return schema.node(
+    'doc',
+    null,
+    paras.map((p) =>
+      schema.node('paragraph', { paraId: p.paraId }, p.text ? [schema.text(p.text)] : [])
+    )
+  );
+}
+
+describe('paraIdsSafeToClear', () => {
+  test('a paragraph re-edited during the window is retained (not cleared)', () => {
+    const served = doc({ text: 'hello', paraId: 'a' }, { text: 'world', paraId: 'b' });
+    // 'a' got more text while serialize was in flight; 'b' is untouched.
+    const current = doc({ text: 'hello!!', paraId: 'a' }, { text: 'world', paraId: 'b' });
+
+    const safe = paraIdsSafeToClear(served, current, new Set(['a', 'b']));
+    expect(safe.has('a')).toBe(false); // re-edited → keep tracked
+    expect(safe.has('b')).toBe(true); // unchanged → safe to clear
+  });
+
+  test('the same doc reference short-circuits to the whole set', () => {
+    const served = doc({ text: 'x', paraId: 'a' });
+    const safe = paraIdsSafeToClear(served, served, new Set(['a']));
+    expect([...safe]).toEqual(['a']);
+  });
+
+  test('a paragraph unchanged in content is safe to clear even if the doc changed elsewhere', () => {
+    const served = doc({ text: 'keep', paraId: 'a' }, { text: 'edit', paraId: 'b' });
+    const current = doc({ text: 'keep', paraId: 'a' }, { text: 'edited', paraId: 'b' });
+    const safe = paraIdsSafeToClear(served, current, new Set(['a']));
+    expect(safe.has('a')).toBe(true);
+  });
+
+  test('a paragraph deleted during the window is safe to clear (its change is moot)', () => {
+    const served = doc({ text: 'gone', paraId: 'a' }, { text: 'stay', paraId: 'b' });
+    const current = doc({ text: 'stay', paraId: 'b' });
+    const safe = paraIdsSafeToClear(served, current, new Set(['a']));
+    expect(safe.has('a')).toBe(true);
+  });
+
+  test('a mark-only re-edit (bold) is detected and retained', () => {
+    const boldSchema = new Schema({
+      nodes: schema.spec.nodes,
+      marks: { bold: { toDOM: () => ['strong', 0] } },
+    });
+    const mk = (bold: boolean) =>
+      boldSchema.node('doc', null, [
+        boldSchema.node('paragraph', { paraId: 'a' }, [
+          boldSchema.text('hi', bold ? [boldSchema.mark('bold')] : []),
+        ]),
+      ]);
+    const safe = paraIdsSafeToClear(mk(false), mk(true), new Set(['a']));
+    expect(safe.has('a')).toBe(false);
+  });
+});

--- a/docx-editor/packages/core/src/prosemirror/extensions/index.ts
+++ b/docx-editor/packages/core/src/prosemirror/extensions/index.ts
@@ -72,6 +72,7 @@ export {
   getChangedBlockTypes,
   hasNonParagraphBlockChanges,
   clearTrackedChanges,
+  paraIdsSafeToClear,
 } from './features/ParagraphChangeTrackerExtension';
 export {
   TableNodeExtension,

--- a/docx-editor/packages/react/src/hooks/useDocumentSave.ts
+++ b/docx-editor/packages/react/src/hooks/useDocumentSave.ts
@@ -31,6 +31,7 @@ import {
   hasUntrackedChanges,
   hasNonParagraphBlockChanges,
   clearTrackedChanges,
+  paraIdsSafeToClear,
 } from '@eigenpal/docx-core/prosemirror/extensions';
 import type { DocumentAgent } from '@eigenpal/docx-core/agent';
 import type { Comment, BlockContent, ParagraphContent } from '@eigenpal/docx-core/types/content';
@@ -315,11 +316,21 @@ export function useDocumentSave(opts: UseDocumentSaveOptions): UseDocumentSaveRe
             ? selective.changedParaIds
             : undefined;
 
+        // Snapshot the doc we're about to serialize. If an edit lands during the
+        // async serialize below, `view.state.doc` will differ afterwards.
+        const servedDoc = view?.state.doc;
         const buffer = await agentRef.current.toBuffer(selectiveOptions);
 
-        // Clear change tracker after successful save
+        // Clear change tracker after successful save. If a served paragraph was
+        // re-edited during the serialize window, don't clear it — that edit
+        // isn't in the saved bytes, and a selective save only re-serializes
+        // still-tracked paragraphs, so clearing would drop it silently.
         if (view) {
-          view.dispatch(clearTrackedChanges(view.state, servedParaIds));
+          const clearIds =
+            servedParaIds && servedDoc && view.state.doc !== servedDoc
+              ? paraIdsSafeToClear(servedDoc, view.state.doc, servedParaIds)
+              : servedParaIds;
+          view.dispatch(clearTrackedChanges(view.state, clearIds));
         }
 
         onSave?.(buffer);


### PR DESCRIPTION
Found via the correctness hunt. A selective save serializes a t0 snapshot of the changed paragraphs, then clears exactly those paraIds. If one is **re-edited during the async `toBuffer`** (a real window — serialize awaits zip work, and autosave fires on a 30s timer), the re-edit is neither in the saved bytes nor still tracked after the clear — so the next selective save skips it and the edit is **silently lost**.

Adds `paraIdsSafeToClear(servedDoc, currentDoc, servedParaIds)`: of the served paragraphs, clear only those structurally unchanged since the snapshot (deep `node.eq`); retain any re-edited one so the next save re-serializes it. Deleted paragraphs stay safe to clear; an unchanged doc short-circuits to the full set, so the common path is unchanged.

The decision is a pure function, deterministically unit-tested (text edit / mark-only edit / delete / unchanged / same-ref). The handleSave characterization e2e and the tracker suite (28 tests) stay green.