### PR TITLE
fix(find): search as you type; result tracks the current query

### DIFF
--- a/docx-editor/.changeset/find-as-you-type.md
+++ b/docx-editor/.changeset/find-as-you-type.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Fix Find so it searches as you type: editing the query now re-runs the search (debounced) and keeps the result in sync, instead of requiring Enter and getting stuck showing a stale "No results found" for text that actually matches (or navigating the previous term's matches).

--- a/docx-editor/e2e/tests/find-as-you-type.spec.ts
+++ b/docx-editor/e2e/tests/find-as-you-type.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/*
+ * Find should search as you type — no Enter required — and its "No results"
+ * status must always reflect the current query. Previously typing didn't
+ * trigger a search until Enter, so the status line could show a stale
+ * "No results found" for text that actually matches.
+ */
+
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+const OVERLAY = '.paged-editor__decoration-overlay';
+const FIND = '[data-testid="find-input"]';
+const NO_RESULTS = 'No results found';
+
+test('find searches as you type, and "No results" tracks the current query', async ({ page }) => {
+  test.setTimeout(60000);
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('apple banana apple cherry apple');
+  await page.waitForTimeout(200);
+
+  const mod = /Mac/i.test(await page.evaluate(() => navigator.platform)) ? 'Meta' : 'Control';
+  await page.keyboard.press(`${mod}+f`);
+  await page.locator('[data-testid="find-replace-dialog"]').waitFor({ timeout: 3000 });
+
+  // Type WITHOUT pressing Enter — the debounced search runs and highlights.
+  await page.locator(FIND).fill('apple');
+  await page.waitForTimeout(500);
+  expect(await page.locator(`${OVERLAY} .find-match`).count()).toBeGreaterThanOrEqual(3);
+  await expect(page.getByText(NO_RESULTS)).toHaveCount(0);
+
+  // A genuinely-absent query shows "No results" (freshly, not stale).
+  await page.locator(FIND).fill('zzzznope');
+  await page.waitForTimeout(500);
+  await expect(page.getByText(NO_RESULTS)).toBeVisible();
+
+  // Back to a matching query — results return, the stale "No results" is gone.
+  await page.locator(FIND).fill('banana');
+  await page.waitForTimeout(500);
+  await expect(page.getByText(NO_RESULTS)).toHaveCount(0);
+  expect(await page.locator(`${OVERLAY} .find-match`).count()).toBeGreaterThanOrEqual(1);
+});

--- a/docx-editor/packages/react/src/components/dialogs/FindReplaceDialog.tsx
+++ b/docx-editor/packages/react/src/components/dialogs/FindReplaceDialog.tsx
@@ -377,18 +377,9 @@ export function FindReplaceDialog({
         searchInputRef.current?.focus();
         searchInputRef.current?.select();
       }, 100);
-
-      if (initialSearchText) {
-        const searchResult = onFind(initialSearchText, {
-          matchCase,
-          matchWholeWord,
-          useRegex,
-        });
-        setResult(searchResult);
-        if (searchResult?.matches && onHighlightMatches) {
-          onHighlightMatches(searchResult.matches);
-        }
-      }
+      // The search itself (including the initial prefilled query) runs through
+      // the debounced find-as-you-type effect below, so results stay in sync
+      // with what's in the box.
     } else {
       if (onClearHighlights) {
         onClearHighlights();
@@ -423,14 +414,30 @@ export function FindReplaceDialog({
     onClearHighlights,
   ]);
 
+  // Find-as-you-type: search on every query/option change (debounced), so the
+  // result — and the "No results" state — always reflect what's in the box.
+  // Previously typing didn't search until Enter, so the status line could show
+  // a stale "No results" for text that actually matches. Enter still forces an
+  // immediate search (see handleSearchKeyDown).
+  //
+  // `performSearch` (which already clears the result for an empty query) is held
+  // in a ref so this effect depends only on the actual query/options — not on
+  // callback identities that may change every render, which would reset the
+  // debounce timer and stop it ever firing.
+  const performSearchRef = useRef(performSearch);
+  performSearchRef.current = performSearch;
   useEffect(() => {
-    if (isOpen && searchText.trim()) {
-      performSearch();
-    }
-  }, [matchCase, matchWholeWord, useRegex]);
+    if (!isOpen) return;
+    const id = setTimeout(() => performSearchRef.current(), 180);
+    return () => clearTimeout(id);
+  }, [isOpen, searchText, matchCase, matchWholeWord, useRegex]);
 
   const handleSearchChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setSearchText(e.target.value);
+    // Invalidate the previous result so the "No results" status and the
+    // Enter/next handlers (which gate on `!result`) can't act on a stale query
+    // in the brief window before the debounced re-search lands.
+    setResult(null);
   }, []);
 
   const handleSearchKeyDown = useCallback(


### PR DESCRIPTION
**UI/UX bug fix (found via a UX-bug hunt on main).**

Editing the Find query after a search never re-searched — the `result` was kept even for a new term:
- type a term with no matches → **"No results found"**; change it to a word that IS in the doc → **stuck on "No results"** (never searches the new term);
- or type `foo` then change to `bar` → Enter/Next navigate the old **foo** matches while the box reads `bar`.

Fix: a **debounced find-as-you-type** effect re-runs the search on every query/option change (held in a ref so unstable callback props can't reset the debounce), and `handleSearchChange` invalidates the stale result on edit so the "No results" status and the `!result`-gated Enter/Next handlers can't act on a stale query. Enter still forces an immediate search.

New e2e (`find-as-you-type.spec.ts`: searches on type; "No results" tracks the live query) plus the existing find specs (highlight, apply, shortcuts) all green.