### PR TITLE
fix(ui): align menu labels via reserved icon gutter; strengthen toolbar dividers

### DIFF
--- a/docx-editor/.changeset/toolbar-menu-polish.md
+++ b/docx-editor/.changeset/toolbar-menu-polish.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Menu and toolbar polish: reserve a fixed icon gutter in dropdown menus so labels align on a common left edge when only some rows have icons, and strengthen the toolbar group dividers (they were nearly invisible).

--- a/docx-editor/e2e/tests/menu-icon-alignment.spec.ts
+++ b/docx-editor/e2e/tests/menu-icon-alignment.spec.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/*
+ * In a menu where only some rows carry an icon (e.g. Insert), every label
+ * must start at the same left edge. Previously an iconless row's label
+ * collapsed left into the vacated icon slot, giving a ragged edge. The
+ * MenuDropdown now reserves a fixed icon gutter for all rows once the menu
+ * has at least one icon.
+ */
+
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test('menu labels align even when some rows have no icon', async ({ page }) => {
+  const ed = new EditorPage(page);
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+
+  await page.getByTestId('title-bar').getByRole('button', { name: 'Insert' }).click();
+
+  // "Image" has an icon; "Watermark…" does not. Their label spans must share
+  // a left edge now that the gutter is reserved for both.
+  const labelLeft = (name: string) =>
+    page.getByRole('menuitem', { name }).locator('span', { hasText: name }).first().boundingBox();
+
+  const withIcon = await labelLeft('Image');
+  const withoutIcon = await labelLeft('Watermark');
+  expect(withIcon).not.toBeNull();
+  expect(withoutIcon).not.toBeNull();
+  expect(Math.abs(withIcon!.x - withoutIcon!.x)).toBeLessThanOrEqual(1);
+});

--- a/docx-editor/packages/react/src/components/Toolbar.tsx
+++ b/docx-editor/packages/react/src/components/Toolbar.tsx
@@ -539,13 +539,14 @@ export function ToolbarGroup({ label, children, className }: ToolbarGroupProps) 
     <div
       className={cn(
         // Visual rhythm: gap-0.5 between buttons (2 px) gives quiet
-        // breathing room without spreading the bar; px-2 around the
-        // group + a soft --doc-border-light divider on the right makes
-        // each group read as its own unit. The first group has no
+        // breathing room without spreading the bar; px-2.5 around the
+        // group + a --doc-border divider on the right makes each group
+        // read as its own unit. The lighter --doc-border-light was too
+        // faint — groups blurred into one strip. The first group has no
         // left padding so it sits flush with the bar's leading edge,
         // and the last group drops its divider so the bar doesn't end
         // with a phantom line.
-        'flex items-center gap-0.5 px-2 border-r border-[color:var(--doc-border-light)] last:border-r-0 first:pl-0',
+        'flex items-center gap-0.5 px-2.5 border-r border-[color:var(--doc-border)] last:border-r-0 first:pl-0',
         className
       )}
       role="group"
@@ -562,7 +563,7 @@ export function ToolbarGroup({ label, children, className }: ToolbarGroupProps) 
 export function ToolbarSeparator() {
   // Use the shared border token (like ToolbarGroup's divider), not hardcoded
   // slate — so it stays consistent across light/dark and any theme retint.
-  return <div className="w-px h-6 mx-1.5 bg-[color:var(--doc-border-light)]" role="separator" />;
+  return <div className="w-px h-6 mx-2 bg-[color:var(--doc-border)]" role="separator" />;
 }
 
 // ============================================================================

--- a/docx-editor/packages/react/src/components/ui/MenuDropdown.tsx
+++ b/docx-editor/packages/react/src/components/ui/MenuDropdown.tsx
@@ -107,6 +107,16 @@ const shortcutStyle: CSSProperties = {
   color: 'var(--doc-text-muted, #9ca3af)',
 };
 
+// Fixed-width leading slot so labels align on a common left edge even when
+// only some rows in a menu carry an icon. Without it a missing icon collapses
+// the flex gap and that row's label jumps left, giving a ragged edge.
+const iconSlotStyle: CSSProperties = {
+  width: 18,
+  flexShrink: 0,
+  display: 'inline-flex',
+  justifyContent: 'center',
+};
+
 const submenuPanelStyle: CSSProperties = {
   position: 'absolute',
   left: '100%',
@@ -164,6 +174,9 @@ export function MenuDropdown({ label, items, disabled, id }: MenuDropdownProps) 
   // boolean and the component keeps its old isolated behavior.
   const bar = useMenuBar();
   const menuId = id ?? label;
+  // Reserve the icon gutter for every row only when this menu actually has
+  // at least one icon — fully-textual menus (e.g. Format) stay tight.
+  const hasAnyIcon = items.some((entry) => !isSeparator(entry) && !!entry.icon);
   const [localOpen, setLocalOpen] = useState(false);
   const isOpen = bar ? bar.openId === menuId : localOpen;
   const setIsOpen = useCallback(
@@ -442,7 +455,11 @@ export function MenuDropdown({ label, items, disabled, id }: MenuDropdownProps) 
                     }}
                     disabled={item.disabled}
                   >
-                    {item.icon && <MaterialSymbol name={item.icon} size={18} />}
+                    {hasAnyIcon && (
+                      <span style={iconSlotStyle}>
+                        {item.icon ? <MaterialSymbol name={item.icon} size={18} /> : null}
+                      </span>
+                    )}
                     <span>{item.label}</span>
                     {item.shortcut && (
                       <span style={shortcutStyle}>{formatShortcut(item.shortcut)}</span>


### PR DESCRIPTION
Two menu/toolbar visual fixes from a UX pass.

- Dropdown menus with a mix of icon and iconless rows (File, Insert, Tools) had a ragged left edge — a missing icon collapsed the flex gap so that row's label jumped left. MenuDropdown now reserves a fixed icon gutter for every row whenever the menu has at least one icon; fully-textual menus (Format) stay tight.
- Toolbar group dividers used the palest `--doc-border-light` token and were nearly invisible, so clusters blurred together. Switched to `--doc-border` with slightly wider group padding.

Regression test asserts an iconless Insert row ("Watermark") shares a label left-edge with an icon'd row ("Image").