### PR TITLE
fix(example): re-fit zoom on resize/doc-open; clean blank-template empty-state

### DIFF
--- a/docx-editor/e2e/tests/home-blank-card.spec.ts
+++ b/docx-editor/e2e/tests/home-blank-card.spec.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/*
+ * Blank templates have no photographic render. They must show a clean
+ * empty-state (a glyph tile), not an <img> whose SVG placeholder cropped to
+ * flat grey and read as a broken thumbnail. The glyph must also be present in
+ * the self-hosted Material Symbols subset — an absent one renders as wide raw
+ * ligature text (e.g. "ARTICLE") instead of an icon.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test('blank template cards show an icon empty-state, not a broken image', async ({ page }) => {
+  await page.goto('/');
+  const blank = page.getByTestId('template-card-blank').first();
+  await blank.waitFor({ timeout: 10000 });
+  await page.evaluate(() => (document as unknown as { fonts?: { ready: Promise<unknown> } }).fonts?.ready);
+
+  // No <img> in a blank card — it's an empty-state, not a thumbnail.
+  await expect(blank.locator('img')).toHaveCount(0);
+
+  // The Material Symbols glyph resolved to an icon (narrow), not raw ligature
+  // text (wide). A 34px glyph is ~34px wide; unresolved text is far wider.
+  const icon = blank.locator('.material-symbols-outlined').first();
+  const box = await icon.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.width).toBeLessThan(60);
+});

--- a/docx-editor/e2e/tests/mobile-refit-zoom.spec.ts
+++ b/docx-editor/e2e/tests/mobile-refit-zoom.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/*
+ * Fit-to-width zoom must re-apply when the viewport changes size, not only on
+ * first mount. Previously `initialZoom` seeded the editor once and a later
+ * resize/rotation never reached the live zoom, so on a phone the page could
+ * overflow the viewport and clip off the right edge.
+ */
+
+import { test, expect } from '@playwright/test';
+import { EditorPage } from '../helpers/editor-page';
+
+test('page re-fits to width when the viewport shrinks to a phone', async ({ page }) => {
+  test.setTimeout(60000);
+  const ed = new EditorPage(page);
+
+  // Start wide so the auto-fit zoom seeds at 1.0, then add enough text to
+  // make horizontal overflow observable.
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await ed.goto();
+  await ed.waitForReady();
+  await ed.newDocument();
+  await ed.focus();
+  await ed.typeText('The quick brown fox jumps over the lazy dog. '.repeat(6));
+  await page.waitForTimeout(400);
+
+  const getZoom = () =>
+    page.evaluate(
+      () => (window as unknown as { __editorRef?: { current?: { getZoom(): number } } }).__editorRef?.current?.getZoom() ?? 1
+    );
+  expect(await getZoom()).toBeCloseTo(1, 1);
+
+  // Shrink to a phone width — the effect must re-apply fit-to-width.
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.waitForTimeout(500);
+
+  expect(await getZoom()).toBeLessThan(1);
+  const overflow = await page.evaluate(
+    () => document.scrollingElement!.scrollWidth - document.scrollingElement!.clientWidth
+  );
+  expect(overflow).toBeLessThanOrEqual(2);
+});

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -678,6 +678,17 @@ export function App() {
 
   const { zoom: autoZoom, isMobile } = useResponsiveLayout();
 
+  // `initialZoom` only seeds the editor's zoom on first mount — a later
+  // recompute (viewport resize/rotation, or opening a different document)
+  // never reached the live zoom, so on mobile the page could overflow the
+  // viewport and clip off the right edge. Re-apply the fit-to-width zoom
+  // imperatively whenever it changes or a new document loads (via either the
+  // buffer path or the template `currentDocument` path). First paint is still
+  // covered by `initialZoom={autoZoom}` below, so there's no flash.
+  useEffect(() => {
+    editorRef.current?.setZoom(autoZoom);
+  }, [autoZoom, documentBuffer, currentDocument]);
+
   // Auto-seed a blank doc only when we land straight in the editor
   // (e.g. ?e2e=1 / ?skipHome=1). Home view lets the user pick a
   // template instead — no need for a placeholder doc.

--- a/docx-editor/examples/vite/src/Home.tsx
+++ b/docx-editor/examples/vite/src/Home.tsx
@@ -269,6 +269,28 @@ const styles: Record<string, CSSProperties> = {
   cardThumbHover: {
     transform: 'scale(1.025)',
   },
+  // Blank templates have no photographic render — a landscape SVG cover-cropped
+  // into the portrait frame just showed flat grey and read as a broken image.
+  // Render a real empty-state instead: the entry's own glyph in a dashed tile.
+  cardThumbEmpty: {
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: `linear-gradient(180deg, ${COLORS.surface} 0%, ${COLORS.surface2} 100%)`,
+  },
+  cardThumbEmptyIcon: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 60,
+    height: 60,
+    borderRadius: 16,
+    background: COLORS.paper,
+    border: `1px dashed ${COLORS.borderHover}`,
+    color: COLORS.inkMuted,
+  },
   cardIconBadge: {
     position: 'absolute',
     top: '8px',
@@ -374,6 +396,9 @@ function TemplateCard({
   isMobile: boolean;
 }): React.JSX.Element {
   const [hovered, setHovered] = useState(false);
+  // Blank entries ship an SVG placeholder rather than a PNG render; give them
+  // a clean empty-state instead of an image that crops to grey.
+  const isBlank = entry.thumbnail.endsWith('.svg');
   return (
     <button
       type="button"
@@ -387,22 +412,37 @@ function TemplateCard({
       aria-label={`${entry.name} — ${entry.category}`}
     >
       <div style={{ ...styles.cardThumbWrap, ...(isMobile && mobile.cardThumbWrap) }}>
-        <img
-          src={entry.thumbnail}
-          alt=""
-          aria-hidden="true"
-          draggable={false}
-          loading="lazy"
-          style={{ ...styles.cardThumb, ...(hovered ? styles.cardThumbHover : null) }}
-        />
-        <span
-          style={{ ...styles.cardIconBadge, ...(isMobile && mobile.cardIconBadge) }}
-          aria-hidden="true"
-        >
-          <span className="material-symbols-outlined" style={{ fontSize: isMobile ? 14 : 16 }}>
-            {entry.icon}
-          </span>
-        </span>
+        {isBlank ? (
+          <div style={styles.cardThumbEmpty}>
+            <span style={styles.cardThumbEmptyIcon} aria-hidden="true">
+              <span
+                className="material-symbols-outlined"
+                style={{ fontSize: isMobile ? 28 : 34 }}
+              >
+                {entry.icon}
+              </span>
+            </span>
+          </div>
+        ) : (
+          <>
+            <img
+              src={entry.thumbnail}
+              alt=""
+              aria-hidden="true"
+              draggable={false}
+              loading="lazy"
+              style={{ ...styles.cardThumb, ...(hovered ? styles.cardThumbHover : null) }}
+            />
+            <span
+              style={{ ...styles.cardIconBadge, ...(isMobile && mobile.cardIconBadge) }}
+              aria-hidden="true"
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: isMobile ? 14 : 16 }}>
+                {entry.icon}
+              </span>
+            </span>
+          </>
+        )}
       </div>
       <div style={{ ...styles.cardBody, ...(isMobile && mobile.cardBody) }}>
         <div style={{ ...styles.cardTitle, ...(isMobile && mobile.cardTitle) }}>{entry.name}</div>

--- a/docx-editor/examples/vite/src/templates/manifest.ts
+++ b/docx-editor/examples/vite/src/templates/manifest.ts
@@ -63,7 +63,10 @@ export const TEMPLATES: TemplateEntry[] = [
     name: 'Blank Markdown',
     description: 'A .md file with live preview and notebook mode.',
     category: 'Personal',
-    icon: 'article',
+    // Must be a glyph present in the self-hosted Material Symbols subset
+    // (examples/vite/public/fonts) — 'article'/'subject' aren't, so they
+    // rendered as raw ligature text.
+    icon: 'description',
     thumbnail: '/templates/thumbs/blank.svg',
     source: { kind: 'text', textKind: 'markdown' },
     defaultFileName: 'Untitled.md',
@@ -74,7 +77,8 @@ export const TEMPLATES: TemplateEntry[] = [
     name: 'Blank Text',
     description: 'A plain .txt file — source editor, no formatting.',
     category: 'Personal',
-    icon: 'subject',
+    // In-subset glyph (see note on blank-markdown above); 'subject' is absent.
+    icon: 'format_align_left',
     thumbnail: '/templates/thumbs/blank.svg',
     source: { kind: 'text', textKind: 'text' },
     defaultFileName: 'Untitled.txt',


### PR DESCRIPTION
Two example-app UX fixes found in a mobile/landing pass. Example-app only — no published-package changes, so no changeset.

**Mobile fit-to-width** — `initialZoom` only seeded the editor's zoom on first mount. A later viewport resize/rotation (or opening a different document) recomputed the fit but never re-applied it to the live zoom, so on a phone the page overflowed and clipped off the right edge. An effect now re-applies the auto-fit zoom via `editorRef.setZoom` whenever it or the open document changes. Regression test shrinks 1280→390px and asserts zoom drops below 1 with no horizontal overflow.

**Blank template cards** — the blank entries ship an SVG placeholder, not a PNG render; cover-cropping that landscape SVG into the portrait card frame showed flat grey and read as a broken image. Blank cards now render a real empty-state (the entry glyph in a dashed tile). Also retargeted the `article`/`subject` icons — absent from the self-hosted Material Symbols subset, they rendered as raw ligature text ("ARTICLE") — to in-subset glyphs.