### PR TITLE
fix(editor): suppress selection format bar while a menu is open

### DIFF
--- a/docx-editor/.changeset/suppress-format-bar-when-menu-open.md
+++ b/docx-editor/.changeset/suppress-format-bar-when-menu-open.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Hide the floating selection format bar while a menu-bar dropdown is open, so the two floating UIs no longer overlap (e.g. Insert → Table's grid picker sitting on top of the B/I/U bar).

--- a/docx-editor/e2e/tests/format-bar-menu-overlap.spec.ts
+++ b/docx-editor/e2e/tests/format-bar-menu-overlap.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/*
+ * The floating selection format bar and an open menu-bar dropdown must not
+ * show at the same time — a menu (e.g. Insert -> Table's grid picker) opened
+ * over a live selection used to overlap the B/I/U bar. Opening any menu now
+ * suppresses the format bar; closing it restores the bar.
+ */
+
+import { test, expect } from '@playwright/test';
+import { modifierKey } from '../helpers/keyboard';
+
+test('opening a menu hides the selection format bar; closing restores it', async ({ page }) => {
+  await page.goto('/?e2e=1');
+  await page.waitForSelector('[data-testid="docx-editor"]');
+  await page.waitForTimeout(500);
+
+  const bar = page.locator('[data-testid="desktop-format-bar"]');
+  const formatMenu = page.getByTestId('title-bar').getByRole('button', { name: 'Format' });
+
+  await page.locator('.ProseMirror').focus();
+  await page.keyboard.type('Overlapping floating UI test');
+  await page.keyboard.press(`${await modifierKey(page)}+a`);
+  await expect(bar).toBeVisible({ timeout: 2000 });
+
+  // Open a menu — the format bar must disappear while it's open.
+  await formatMenu.click();
+  await expect(page.getByRole('menuitem').first()).toBeVisible();
+  await expect(bar).toHaveCount(0);
+
+  // Close the menu and re-select — the bar comes back (suppression released).
+  await page.keyboard.press('Escape');
+  await page.locator('.ProseMirror').focus();
+  await page.keyboard.press(`${await modifierKey(page)}+a`);
+  await expect(bar).toBeVisible({ timeout: 2000 });
+});

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -1940,6 +1940,9 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
   // (and any other chrome) without TDZ errors. The keydown handler +
   // chrome conditionals further below consume the same state.
   const [focusMode, setFocusMode] = useState(false);
+  // True while a menu-bar dropdown is open — used to suppress the floating
+  // selection format bar so the two don't overlap.
+  const [menuOpen, setMenuOpen] = useState(false);
   const showRulerEffective =
     (showRulerLocal ?? showRuler) && !focusMode && isFeatureEnabled(features, 'ruler', true);
 
@@ -9532,6 +9535,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                           }}
                           currentFormatting={state.selectionFormatting}
                           onFormat={handleFormat}
+                          onMenuOpenChange={setMenuOpen}
                           onUndo={undoActiveEditor}
                           onRedo={redoActiveEditor}
                           canUndo={canUndoActiveEditor}
@@ -9969,6 +9973,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                               wordCompat={wordCompat}
                               showFormattingMarks={showFormattingMarks}
                               readOnly={readOnly}
+                              suppressSelectionBar={menuOpen}
                               extensionManager={extensionManager}
                               contentLabel={t('editor.contentLabel')}
                               selectionFormatting={state.selectionFormatting}

--- a/docx-editor/packages/react/src/components/TitleBar.tsx
+++ b/docx-editor/packages/react/src/components/TitleBar.tsx
@@ -307,6 +307,7 @@ export function MenuBar() {
     onToggleOutline,
     outlineVisible,
     onRefocusEditor,
+    onMenuOpenChange,
   } = ctx;
 
   // Dialog-open handlers now arrive via DialogActionsContext instead of ~16
@@ -364,7 +365,7 @@ export function MenuBar() {
     hasExport;
 
   return (
-    <MenuBarProvider>
+    <MenuBarProvider onOpenChange={onMenuOpenChange}>
       <div
         className="flex items-center overflow-x-auto whitespace-nowrap min-w-0"
         style={{ scrollbarWidth: 'none' }}

--- a/docx-editor/packages/react/src/components/Toolbar.tsx
+++ b/docx-editor/packages/react/src/components/Toolbar.tsx
@@ -333,6 +333,10 @@ export interface ToolbarProps {
   onExportTxt?: () => void;
   /** Help → Report a bug — opens the GitHub issue template prefilled with env info. */
   onReportBug?: () => void;
+  /** Fired when a menu bar dropdown opens (true) or all close (false). Lets the
+   *  editor suppress other floating UI (e.g. the selection format bar) while a
+   *  menu is open, so the two don't overlap. */
+  onMenuOpenChange?: (open: boolean) => void;
   /** Help → About — opens the About dialog. */
   onShowAbout?: () => void;
   /** Help → Search the menus — opens the command palette. */

--- a/docx-editor/packages/react/src/components/ui/MenuBarContext.tsx
+++ b/docx-editor/packages/react/src/components/ui/MenuBarContext.tsx
@@ -17,7 +17,15 @@
  * its existing isolated behavior.
  */
 
-import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { ReactNode } from 'react';
 
 export interface MenuBarContextValue {
@@ -45,11 +53,19 @@ export function useMenuBar(): MenuBarContextValue | null {
 
 export interface MenuBarProviderProps {
   children: ReactNode;
+  /** Notified when any menu in the bar opens (true) or all close (false). */
+  onOpenChange?: (open: boolean) => void;
 }
 
-export function MenuBarProvider({ children }: MenuBarProviderProps) {
+export function MenuBarProvider({ children, onOpenChange }: MenuBarProviderProps) {
   const [openId, setOpenIdState] = useState<string | null>(null);
   const triggersRef = useRef(new Map<string, HTMLElement>());
+
+  // Report open/closed transitions. Covers every path that mutates openId
+  // (click, hover-switch, arrow-key move), not just setOpenId.
+  useEffect(() => {
+    onOpenChange?.(openId !== null);
+  }, [openId, onOpenChange]);
 
   const setOpenId = useCallback((id: string | null) => {
     setOpenIdState(id);

--- a/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
+++ b/docx-editor/packages/react/src/paged-editor/PagedEditor.tsx
@@ -261,6 +261,9 @@ export interface PagedEditorProps {
   firstPageFooterContent?: HeaderFooter | null;
   /** Whether the editor is read-only. */
   readOnly?: boolean;
+  /** Hide the floating selection format bar while another floating UI (e.g. an
+   *  open menu-bar dropdown) is showing, so the two don't overlap. */
+  suppressSelectionBar?: boolean;
   /** Gap between pages in pixels. */
   pageGap?: number;
   /** Zoom level (1 = 100%). */
@@ -1571,6 +1574,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       firstPageHeaderContent,
       firstPageFooterContent,
       readOnly = false,
+      suppressSelectionBar = false,
       pageGap = DEFAULT_PAGE_GAP,
       zoom = 1,
       wordCompat = false,
@@ -5183,7 +5187,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
                 rects={selectionRects}
                 formatting={selectionFormatting}
                 onFormat={onFormat}
-                visible={isFocused && selectionRects.length > 0}
+                visible={isFocused && selectionRects.length > 0 && !suppressSelectionBar}
                 zoom={zoom}
                 variant="mobile"
               />
@@ -5191,7 +5195,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
                 rects={selectionRects}
                 formatting={selectionFormatting}
                 onFormat={onFormat}
-                visible={isFocused && selectionRects.length > 0}
+                visible={isFocused && selectionRects.length > 0 && !suppressSelectionBar}
                 zoom={zoom}
                 variant="desktop"
               />


### PR DESCRIPTION
Two floating UIs could overlap: opening a menu-bar dropdown over a live text selection (e.g. Insert → Table's grid picker) left the floating B/I/U selection bar showing underneath it.

`MenuBarProvider` now reports open/close via an optional `onOpenChange`. `DocxEditor` tracks that as `menuOpen` and threads `suppressSelectionBar` to `PagedEditor`, which gates both format-bar variants. Fully additive — no change to menu keyboard nav/hover-switch, and no effect on standalone `EditorToolbar` consumers (the provider stays where it is).

Regression test: with a selection active, opening a menu drops the format bar to count 0; closing it restores the bar.