### PR TITLE
fix(ui): collapse the menu bar into a hamburger at phone widths

### DIFF
--- a/docx-editor/.changeset/mobile-menu-overflow.md
+++ b/docx-editor/.changeset/mobile-menu-overflow.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Collapse the menu bar into a single hamburger on phone-width viewports (≤720px) so File/Edit/…/Help stay reachable instead of truncating off-screen; desktop still renders the seven menus inline. Also exports a reusable `MenuEntries` renderer from MenuDropdown.

--- a/docx-editor/e2e/tests/mobile-menu-overflow.spec.ts
+++ b/docx-editor/e2e/tests/mobile-menu-overflow.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+/*
+ * At phone widths the seven-across menu bar (File/Edit/…/Help) truncated with
+ * Insert/Tools/Help unreachable. Below 720px it now collapses into a single
+ * hamburger whose items re-expose each menu as a submenu; on desktop the
+ * seven menus render inline as before.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('menu bar responsive overflow', () => {
+  test.describe('phone viewport', () => {
+    test.use({ viewport: { width: 390, height: 844 } });
+
+    test('collapses to a hamburger and every menu stays reachable', async ({ page }) => {
+      await page.goto('/?e2e=1');
+      await page.waitForSelector('[data-testid="docx-editor"]');
+      await page.waitForTimeout(400);
+
+      const titleBar = page.getByTestId('title-bar');
+      // The inline top-level menu buttons are gone at this width…
+      await expect(titleBar.getByRole('button', { name: 'Format', exact: true })).toHaveCount(0);
+      // …replaced by the hamburger.
+      await expect(page.getByTestId('menu-overflow')).toBeVisible();
+
+      // Open it: all seven menus appear as rows, including the ones that used
+      // to be off-screen (Insert/Tools/Help).
+      await page.getByRole('button', { name: 'Menus' }).click();
+      for (const name of ['File', 'Edit', 'Format', 'View', 'Insert', 'Tools', 'Help']) {
+        await expect(page.getByRole('menuitem', { name, exact: true })).toBeVisible();
+      }
+
+      // Hovering a menu row opens its submenu with the real items.
+      await page.getByRole('menuitem', { name: 'Insert', exact: true }).hover();
+      await expect(page.getByRole('menuitem', { name: 'Image', exact: true })).toBeVisible();
+    });
+  });
+
+  test.describe('desktop viewport', () => {
+    test.use({ viewport: { width: 1280, height: 800 } });
+
+    test('renders the seven menus inline, no hamburger', async ({ page }) => {
+      await page.goto('/?e2e=1');
+      await page.waitForSelector('[data-testid="docx-editor"]');
+      await page.waitForTimeout(400);
+      await expect(page.getByTestId('menu-overflow')).toHaveCount(0);
+      const titleBar = page.getByTestId('title-bar');
+      await expect(titleBar.getByRole('button', { name: 'Format', exact: true })).toBeVisible();
+      await expect(titleBar.getByRole('button', { name: 'Insert', exact: true })).toBeVisible();
+    });
+  });
+});

--- a/docx-editor/packages/react/src/components/TitleBar.tsx
+++ b/docx-editor/packages/react/src/components/TitleBar.tsx
@@ -12,9 +12,9 @@
  * - TitleBarRight: right-aligned actions slot
  */
 
-import React, { useCallback, useState, Children, isValidElement } from 'react';
+import React, { useCallback, useEffect, useState, Children, isValidElement } from 'react';
 import type { ReactNode } from 'react';
-import { MenuDropdown, SubMenuItem } from './ui/MenuDropdown';
+import { MenuDropdown, MenuEntries, SubMenuItem } from './ui/MenuDropdown';
 import type { MenuEntry } from './ui/MenuDropdown';
 import { MenuBarProvider } from './ui/MenuBarContext';
 import { MaterialSymbol } from './ui/Icons';
@@ -245,6 +245,28 @@ function ThemeToggleButton() {
 // MenuBar
 // ============================================================================
 
+/**
+ * True on phone-width viewports (<=720px), where the seven inline menus don't
+ * fit and get collapsed behind a single hamburger overflow menu. SSR-safe:
+ * defaults to false when `window` is unavailable, then syncs on mount. Same
+ * breakpoint as MobileFormatBar's `useIsTouchPhone`.
+ */
+function useIsNarrow(): boolean {
+  const [match, setMatch] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(max-width: 720px)').matches;
+  });
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mql = window.matchMedia('(max-width: 720px)');
+    const handler = (e: MediaQueryListEvent) => setMatch(e.matches);
+    setMatch(mql.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+  return match;
+}
+
 export function MenuBar() {
   const { t } = useTranslation();
   const ctx = useEditorToolbar();
@@ -364,6 +386,759 @@ export function MenuBar() {
     onFileProperties ||
     hasExport;
 
+  // Collapse the seven inline menus behind a single hamburger on phone widths,
+  // where they otherwise truncate ("Fo…") and hide Insert/Tools/Help.
+  const isNarrow = useIsNarrow();
+
+  const fileItems: MenuEntry[] = [
+    ...(onNew
+      ? [
+          {
+            icon: 'note_add',
+            label: 'New',
+            shortcut: 'Ctrl+N',
+            onClick: onNew,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onOpen
+      ? [
+          {
+            icon: 'file_upload',
+            label: t('toolbar.open'),
+            shortcut: t('toolbar.openShortcut'),
+            onClick: onOpen,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onSave
+      ? [
+          {
+            icon: 'file_download',
+            label: t('toolbar.save'),
+            shortcut: t('toolbar.saveShortcut'),
+            onClick: onSave,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onMakeCopy
+      ? [
+          {
+            icon: 'content_copy',
+            label: t('toolbar.makeCopy'),
+            onClick: onMakeCopy,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onEmailAsAttachment
+      ? [
+          {
+            label: t('toolbar.emailAsAttachment'),
+            onClick: onEmailAsAttachment,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onOpenVersionHistory
+      ? [
+          {
+            icon: 'history',
+            label: t('toolbar.versionHistory'),
+            onClick: onOpenVersionHistory,
+          } as MenuEntry,
+        ]
+      : []),
+    ...((onOpen || onSave || onMakeCopy || onEmailAsAttachment || onOpenVersionHistory) &&
+    (hasPrintOrPageSetup || onFileProperties || hasExport)
+      ? [{ type: 'separator' as const } as MenuEntry]
+      : []),
+    ...(showPrintButton && onPrint
+      ? [
+          {
+            icon: 'print',
+            label: t('toolbar.print'),
+            shortcut: t('toolbar.printShortcut'),
+            onClick: onPrint,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onExportPdf
+      ? [
+          {
+            icon: 'file_download',
+            label: 'Export as PDF',
+            onClick: onExportPdf,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onExportOdt
+      ? [
+          {
+            icon: 'file_download',
+            label: 'Export as ODT',
+            onClick: onExportOdt,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onExportMd
+      ? [
+          {
+            icon: 'file_download',
+            label: 'Export as Markdown',
+            onClick: onExportMd,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onExportTxt
+      ? [
+          {
+            icon: 'file_download',
+            label: 'Export as Plain Text',
+            onClick: onExportTxt,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onPageSetup
+      ? [
+          {
+            icon: 'settings',
+            label: t('toolbar.pageSetup'),
+            onClick: onPageSetup,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onFileProperties
+      ? [
+          {
+            icon: 'tune',
+            label: 'Properties',
+            onClick: onFileProperties,
+          } as MenuEntry,
+        ]
+      : []),
+  ];
+
+  const editItems: MenuEntry[] = [
+    {
+      icon: 'undo',
+      label: 'Undo',
+      shortcut: 'Ctrl+Z',
+      onClick: onUndo ?? (() => {}),
+      disabled: !canUndo,
+    } as MenuEntry,
+    {
+      icon: 'redo',
+      label: 'Redo',
+      shortcut: 'Ctrl+Y',
+      onClick: onRedo ?? (() => {}),
+      disabled: !canRedo,
+    } as MenuEntry,
+    { type: 'separator' as const } as MenuEntry,
+    // Clipboard ops — execCommand only works while the editor has focus,
+    // so refocus first. Modern browsers block JS-initiated paste; the
+    // shortcut label educates users to fall back to ⌘V.
+    {
+      icon: 'content_cut',
+      label: 'Cut',
+      shortcut: 'Ctrl+X',
+      onClick: () => {
+        onRefocusEditor?.();
+        document.execCommand('cut');
+      },
+    } as MenuEntry,
+    {
+      icon: 'content_copy',
+      label: 'Copy',
+      shortcut: 'Ctrl+C',
+      onClick: () => {
+        onRefocusEditor?.();
+        document.execCommand('copy');
+      },
+    } as MenuEntry,
+    {
+      icon: 'content_paste',
+      label: 'Paste',
+      shortcut: 'Ctrl+V',
+      onClick: () => {
+        onRefocusEditor?.();
+        document.execCommand('paste');
+      },
+    } as MenuEntry,
+    {
+      icon: 'content_paste_go',
+      label: 'Paste without formatting',
+      shortcut: 'Ctrl+Shift+V',
+      onClick: async () => {
+        onRefocusEditor?.();
+        try {
+          const text = await navigator.clipboard.readText();
+          if (text) document.execCommand('insertText', false, text);
+        } catch {
+          // Browser blocked the read; user can fall back to ⌘⇧V.
+        }
+      },
+    } as MenuEntry,
+    { type: 'separator' as const } as MenuEntry,
+    ...(onOpenFind
+      ? [
+          {
+            icon: 'search',
+            label: 'Find…',
+            shortcut: 'Ctrl+F',
+            onClick: onOpenFind,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onOpenFindReplace
+      ? [
+          {
+            icon: 'find_replace',
+            label: 'Find and replace…',
+            shortcut: 'Ctrl+H',
+            onClick: onOpenFindReplace,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onOpenFind || onOpenFindReplace ? [{ type: 'separator' as const } as MenuEntry] : []),
+    {
+      icon: 'select_all',
+      label: 'Select all',
+      shortcut: 'Ctrl+A',
+      onClick: () => handleFormat('selectAll'),
+    } as MenuEntry,
+    // Word count lives in Tools → Word count (Google Docs
+    // convention). Removed from Edit on the Phase-4 menu pass
+    // — duplication confused users about which entry the
+    // Ctrl+Shift+C shortcut targeted.
+    ...(onToggleVoiceTyping
+      ? [
+          {
+            icon: 'mic',
+            label: voiceTypingActive ? '✓ Voice typing' : 'Voice typing',
+            onClick: onToggleVoiceTyping,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onToggleSpellCheck
+      ? [
+          { type: 'separator' as const } as MenuEntry,
+          {
+            icon: 'spellcheck',
+            label: spellCheckEnabled ? '✓ Spelling' : 'Spelling',
+            onClick: onToggleSpellCheck,
+          } as MenuEntry,
+        ]
+      : []),
+  ];
+
+  const formatItems: MenuEntry[] = [
+    {
+      label: `${currentFormatting?.bold ? '✓ ' : ''}Bold`,
+      shortcut: 'Ctrl+B',
+      onClick: () => handleFormat('bold'),
+    } as MenuEntry,
+    {
+      label: `${currentFormatting?.italic ? '✓ ' : ''}Italic`,
+      shortcut: 'Ctrl+I',
+      onClick: () => handleFormat('italic'),
+    } as MenuEntry,
+    {
+      label: `${currentFormatting?.underline ? '✓ ' : ''}Underline`,
+      shortcut: 'Ctrl+U',
+      onClick: () => handleFormat('underline'),
+    } as MenuEntry,
+    {
+      label: `${currentFormatting?.strike ? '✓ ' : ''}Strikethrough`,
+      onClick: () => handleFormat('strikethrough'),
+    } as MenuEntry,
+    { type: 'separator' as const } as MenuEntry,
+    {
+      label: `${currentFormatting?.smallCaps ? '✓ ' : ''}Small Caps`,
+      onClick: () => handleFormat('toggleSmallCaps'),
+    } as MenuEntry,
+    {
+      label: `${currentFormatting?.allCaps ? '✓ ' : ''}All Caps`,
+      onClick: () => handleFormat('toggleAllCaps'),
+    } as MenuEntry,
+    { type: 'separator' as const } as MenuEntry,
+    {
+      icon: 'format_line_spacing',
+      label: t('toolbar.customSpacing'),
+      onClick: onOpenParagraphDialog,
+      disabled: !onOpenParagraphDialog,
+    } as MenuEntry,
+    {
+      icon: 'border_outer',
+      label: t('toolbar.bordersAndShading'),
+      onClick: onOpenBordersShading,
+      disabled: !onOpenBordersShading,
+    } as MenuEntry,
+    { type: 'separator' as const } as MenuEntry,
+    {
+      icon: 'format_clear',
+      label: 'Clear formatting',
+      shortcut: 'Ctrl+\\',
+      onClick: () => handleFormat('clearFormatting'),
+    } as MenuEntry,
+    { type: 'separator' as const } as MenuEntry,
+    {
+      icon: 'format_textdirection_l_to_r',
+      label: t('toolbar.leftToRight'),
+      onClick: () => handleFormat('setLtr'),
+    } as MenuEntry,
+    {
+      icon: 'format_textdirection_r_to_l',
+      label: t('toolbar.rightToLeft'),
+      onClick: () => handleFormat('setRtl'),
+    } as MenuEntry,
+  ];
+
+  const viewItems: MenuEntry[] = [
+    ...(onZoomChange
+      ? [
+          {
+            icon: 'add',
+            label: 'Zoom in',
+            shortcut: 'Ctrl+=',
+            onClick: () => onZoomChange(Math.min((zoom ?? 1) * 1.1, 4)),
+          } as MenuEntry,
+          {
+            icon: 'remove',
+            label: 'Zoom out',
+            shortcut: 'Ctrl+-',
+            onClick: () => onZoomChange(Math.max((zoom ?? 1) / 1.1, 0.25)),
+          } as MenuEntry,
+          {
+            icon: 'restart_alt',
+            label: 'Reset zoom (100%)',
+            shortcut: 'Ctrl+0',
+            onClick: () => onZoomChange(1),
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onZoomChange && onToggleShowRuler ? [{ type: 'separator' as const } as MenuEntry] : []),
+    ...(onToggleShowRuler
+      ? [
+          {
+            icon: 'straighten',
+            label: `${rulerVisible ? '✓ ' : ''}Show ruler`,
+            onClick: onToggleShowRuler,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onToggleShowFormattingMarks
+      ? [
+          {
+            label: `${showFormattingMarks ? '✓ ' : ''}${t('toolbar.showFormattingMarks')}`,
+            onClick: onToggleShowFormattingMarks,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onToggleOutline
+      ? [
+          {
+            label: `${outlineVisible ? '✓ ' : ''}${t('toolbar.showOutline')}`,
+            shortcut: 'Ctrl+Shift+H',
+            onClick: onToggleOutline,
+          } as MenuEntry,
+        ]
+      : []),
+    ...((onZoomChange || onToggleShowRuler) && onSetColorTheme
+      ? [{ type: 'separator' as const } as MenuEntry]
+      : []),
+    ...(onSetColorTheme
+      ? [
+          {
+            icon: 'contrast',
+            label: `${colorTheme === 'auto' || !colorTheme ? '✓ ' : ''}Theme: match system`,
+            onClick: () => onSetColorTheme('auto'),
+          } as MenuEntry,
+          {
+            icon: 'light_mode',
+            label: `${colorTheme === 'light' ? '✓ ' : ''}Theme: light`,
+            onClick: () => onSetColorTheme('light'),
+          } as MenuEntry,
+          {
+            icon: 'dark_mode',
+            label: `${colorTheme === 'dark' ? '✓ ' : ''}Theme: dark`,
+            onClick: () => onSetColorTheme('dark'),
+          } as MenuEntry,
+        ]
+      : []),
+  ];
+
+  const insertItems: MenuEntry[] = [
+    ...(onInsertImage
+      ? [{ icon: 'image', label: t('toolbar.image'), onClick: onInsertImage } as MenuEntry]
+      : []),
+    ...(showTableInsert && onInsertTable
+      ? [
+          {
+            icon: 'grid_on',
+            label: t('toolbar.table'),
+            submenuContent: (closeMenu: () => void) => (
+              <TableGridInline
+                onInsert={(rows: number, cols: number) => {
+                  handleTableInsert(rows, cols);
+                  closeMenu();
+                }}
+              />
+            ),
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onInsertImage || (showTableInsert && onInsertTable)
+      ? [{ type: 'separator' as const } as MenuEntry]
+      : []),
+    {
+      icon: 'page_break',
+      label: t('toolbar.pageBreak'),
+      shortcut: 'Ctrl+Enter',
+      onClick: onInsertPageBreak,
+      disabled: !onInsertPageBreak,
+    },
+    {
+      icon: 'horizontal_rule',
+      label: t('toolbar.horizontalLine'),
+      onClick: onInsertHorizontalRule,
+      disabled: !onInsertHorizontalRule,
+    },
+    {
+      icon: 'horizontal_rule',
+      label: t('toolbar.sectionBreak'),
+      disabled: !onInsertSectionBreak,
+      submenuContent: (closeMenu: () => void) => (
+        <>
+          {(
+            [
+              { label: t('toolbar.sectionBreakNextPage'), type: 'nextPage' },
+              { label: t('toolbar.sectionBreakContinuous'), type: 'continuous' },
+              { label: t('toolbar.sectionBreakEvenPage'), type: 'evenPage' },
+              { label: t('toolbar.sectionBreakOddPage'), type: 'oddPage' },
+            ] as const
+          ).map((item) => (
+            <SubMenuItem
+              key={item.type}
+              label={item.label}
+              onClick={() => onInsertSectionBreak?.(item.type)}
+              closeMenu={closeMenu}
+            />
+          ))}
+        </>
+      ),
+    },
+    ...(onInsertShape
+      ? [
+          {
+            icon: 'shapes',
+            label: t('toolbar.shape'),
+            submenuContent: (closeMenu: () => void) => (
+              <>
+                {(
+                  [
+                    { label: t('toolbar.shapeRectangle'), type: 'rectangle' },
+                    { label: t('toolbar.shapeEllipse'), type: 'ellipse' },
+                    { label: t('toolbar.shapeLine'), type: 'line' },
+                    { label: t('toolbar.shapeArrow'), type: 'arrow' },
+                  ] as const
+                ).map((item) => (
+                  <SubMenuItem
+                    key={item.type}
+                    label={item.label}
+                    onClick={() => onInsertShape(item.type)}
+                    closeMenu={closeMenu}
+                  />
+                ))}
+              </>
+            ),
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onInsertTextBox
+      ? [
+          {
+            icon: 'edit_note',
+            label: 'Text box',
+            onClick: () => onInsertTextBox('plain'),
+          } as MenuEntry,
+          {
+            icon: 'chat_bubble_outline',
+            label: 'Callout',
+            onClick: () => onInsertTextBox('callout'),
+          } as MenuEntry,
+        ]
+      : []),
+    {
+      icon: 'tag',
+      label: t('toolbar.insertField'),
+      disabled: !onInsertField,
+      submenuContent: (closeMenu: () => void) => (
+        <>
+          {(
+            [
+              { label: t('toolbar.fieldPage'), type: 'PAGE' },
+              { label: t('toolbar.fieldNumPages'), type: 'NUMPAGES' },
+              { label: t('toolbar.fieldDate'), type: 'DATE' },
+              { label: t('toolbar.fieldTime'), type: 'TIME' },
+              { label: t('toolbar.fieldCreateDate'), type: 'CREATEDATE' },
+              { label: t('toolbar.fieldSaveDate'), type: 'SAVEDATE' },
+              { label: t('toolbar.fieldAuthor'), type: 'AUTHOR' },
+              { label: t('toolbar.fieldFileName'), type: 'FILENAME' },
+            ] as const
+          ).map((item) => (
+            <SubMenuItem
+              key={item.type}
+              label={item.label}
+              onClick={() => onInsertField?.(item.type)}
+              closeMenu={closeMenu}
+            />
+          ))}
+        </>
+      ),
+    },
+    {
+      icon: 'format_list_numbered',
+      label: t('toolbar.tableOfContents'),
+      onClick: onInsertTOC,
+      disabled: !onInsertTOC,
+    },
+    {
+      icon: 'bookmark',
+      label: t('toolbar.bookmarks'),
+      onClick: onOpenBookmarks,
+      disabled: !onOpenBookmarks,
+    },
+    {
+      icon: 'note_add',
+      label: t('toolbar.footnote'),
+      onClick: onInsertFootnote,
+      disabled: !onInsertFootnote,
+    },
+    { type: 'separator' as const } as MenuEntry,
+    {
+      icon: 'emoji_symbols',
+      label: t('toolbar.specialCharacters'),
+      onClick: onOpenInsertSymbol,
+      disabled: !onOpenInsertSymbol,
+    },
+    ...(onOpenBuildingBlocks
+      ? [
+          {
+            label: t('toolbar.buildingBlocks'),
+            onClick: onOpenBuildingBlocks,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onConvertSelectionToTable
+      ? [
+          {
+            label: t('toolbar.convertToTable'),
+            onClick: onConvertSelectionToTable,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onConvertTableToText
+      ? [
+          {
+            label: t('toolbar.convertToText'),
+            onClick: onConvertTableToText,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onOpenWatermark
+      ? [
+          { type: 'separator' as const } as MenuEntry,
+          {
+            label: t('toolbar.watermark'),
+            onClick: onOpenWatermark,
+          } as MenuEntry,
+        ]
+      : []),
+  ];
+
+  const toolsItems: MenuEntry[] = [
+    // Word count first — matches Google Docs' Tools → Word count
+    // placement. (Edit menu still has it too for users who learned
+    // the older location.)
+    ...(onOpenWordCount
+      ? [
+          {
+            icon: 'format_list_numbered',
+            label: t('toolbar.wordCount'),
+            shortcut: 'Ctrl+Shift+C',
+            onClick: onOpenWordCount,
+          } as MenuEntry,
+          { type: 'separator' as const } as MenuEntry,
+        ]
+      : []),
+    ...(onOpenDictionary
+      ? [
+          {
+            label: t('toolbar.dictionary'),
+            shortcut: 'Ctrl+Shift+Y',
+            onClick: onOpenDictionary,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onOpenTranslate
+      ? [
+          {
+            icon: 'translate',
+            label: t('toolbar.translate'),
+            onClick: onOpenTranslate,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onTranslateDocument
+      ? [
+          {
+            icon: 'description',
+            label: 'Translate document…',
+            onClick: onTranslateDocument,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onToggleSpellcheck
+      ? [
+          {
+            icon: 'spellcheck',
+            label: spellcheckEnabled ? '✓ Spell check' : 'Spell check',
+            onClick: onToggleSpellcheck,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onToggleGrammar
+      ? [
+          {
+            icon: 'edit_note',
+            label: grammarEnabled ? '✓ Grammar check' : 'Grammar check',
+            onClick: onToggleGrammar,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onOpenWritingAssistant
+      ? [
+          {
+            icon: 'auto_awesome',
+            label: 'Writing assistant…',
+            onClick: onOpenWritingAssistant,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onOpenExplore
+      ? [
+          {
+            icon: 'explore',
+            label: t('toolbar.explore'),
+            onClick: onOpenExplore,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onOpenCitations
+      ? [
+          {
+            icon: 'format_quote',
+            label: t('toolbar.citations'),
+            onClick: onOpenCitations,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onOpenPreferences
+      ? [
+          {
+            icon: 'tune',
+            label: t('toolbar.preferences'),
+            onClick: onOpenPreferences,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onOpenAccessibility
+      ? [
+          {
+            icon: 'accessibility',
+            label: t('toolbar.accessibility'),
+            onClick: onOpenAccessibility,
+          } as MenuEntry,
+        ]
+      : []),
+  ];
+
+  const helpItems: MenuEntry[] = [
+    ...(onOpenCommandPalette
+      ? [
+          {
+            label: t('toolbar.searchMenus'),
+            onClick: onOpenCommandPalette,
+          } as MenuEntry,
+          { type: 'separator' as const } as MenuEntry,
+        ]
+      : []),
+    {
+      icon: 'bug_report',
+      label: t('toolbar.reportIssue'),
+      onClick: () => (onReportBug ? onReportBug() : openReportIssue()),
+    } as MenuEntry,
+    ...(onShowAbout
+      ? [
+          { type: 'separator' as const } as MenuEntry,
+          {
+            icon: 'info',
+            label: 'About Casual Editor',
+            onClick: onShowAbout,
+          } as MenuEntry,
+        ]
+      : []),
+    ...(onOpenKeyboardShortcuts
+      ? [
+          { type: 'separator' as const } as MenuEntry,
+          {
+            label: t('toolbar.keyboardShortcuts'),
+            onClick: onOpenKeyboardShortcuts,
+          } as MenuEntry,
+        ]
+      : []),
+  ];
+
+  // View and Tools keep their original multi-condition visibility guards;
+  // File keeps hasFileMenu. Edit/Format/Insert/Help are always shown. Order
+  // matches the previous inline order so desktop rendering is unchanged.
+  const menus = [
+    { id: 'file', label: t('toolbar.file'), items: fileItems, show: hasFileMenu },
+    { id: 'edit', label: 'Edit', items: editItems, show: true },
+    { id: 'format', label: t('toolbar.format'), items: formatItems, show: true },
+    {
+      id: 'view',
+      label: 'View',
+      items: viewItems,
+      show:
+        onZoomChange ||
+        onSetColorTheme ||
+        onToggleShowRuler ||
+        onToggleShowFormattingMarks ||
+        onToggleOutline,
+    },
+    { id: 'insert', label: t('toolbar.insert'), items: insertItems, show: true },
+    {
+      id: 'tools',
+      label: t('toolbar.tools'),
+      items: toolsItems,
+      show:
+        onOpenPreferences ||
+        onOpenAccessibility ||
+        onOpenWordCount ||
+        onOpenDictionary ||
+        onOpenTranslate ||
+        onTranslateDocument ||
+        onToggleSpellcheck ||
+        onToggleGrammar ||
+        onOpenWritingAssistant ||
+        onOpenExplore ||
+        onOpenCitations,
+    },
+    { id: 'help', label: t('toolbar.help'), items: helpItems, show: true },
+  ];
+
+  const visibleMenus = menus.filter((m) => m.show);
+
   return (
     <MenuBarProvider onOpenChange={onMenuOpenChange}>
       <div
@@ -377,772 +1152,41 @@ export function MenuBar() {
         role="toolbar"
         aria-label={t('titleBar.menuBarAriaLabel')}
       >
-        {/* File Menu */}
-        {hasFileMenu && (
+        {isNarrow ? (
+          // Phone widths: collapse all seven menus behind one hamburger, each
+          // menu re-exposed as a hover-opened submenu of the overflow panel.
           <MenuDropdown
-            label={t('toolbar.file')}
+            id="menu-overflow"
+            ariaLabel="Menus"
             disabled={disabled}
-            items={[
-              ...(onNew
-                ? [
-                    {
-                      icon: 'note_add',
-                      label: 'New',
-                      shortcut: 'Ctrl+N',
-                      onClick: onNew,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onOpen
-                ? [
-                    {
-                      icon: 'file_upload',
-                      label: t('toolbar.open'),
-                      shortcut: t('toolbar.openShortcut'),
-                      onClick: onOpen,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onSave
-                ? [
-                    {
-                      icon: 'file_download',
-                      label: t('toolbar.save'),
-                      shortcut: t('toolbar.saveShortcut'),
-                      onClick: onSave,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onMakeCopy
-                ? [
-                    {
-                      icon: 'content_copy',
-                      label: t('toolbar.makeCopy'),
-                      onClick: onMakeCopy,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onEmailAsAttachment
-                ? [
-                    {
-                      label: t('toolbar.emailAsAttachment'),
-                      onClick: onEmailAsAttachment,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onOpenVersionHistory
-                ? [
-                    {
-                      icon: 'history',
-                      label: t('toolbar.versionHistory'),
-                      onClick: onOpenVersionHistory,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...((onOpen || onSave || onMakeCopy || onEmailAsAttachment || onOpenVersionHistory) &&
-              (hasPrintOrPageSetup || onFileProperties || hasExport)
-                ? [{ type: 'separator' as const } as MenuEntry]
-                : []),
-              ...(showPrintButton && onPrint
-                ? [
-                    {
-                      icon: 'print',
-                      label: t('toolbar.print'),
-                      shortcut: t('toolbar.printShortcut'),
-                      onClick: onPrint,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onExportPdf
-                ? [
-                    {
-                      icon: 'file_download',
-                      label: 'Export as PDF',
-                      onClick: onExportPdf,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onExportOdt
-                ? [
-                    {
-                      icon: 'file_download',
-                      label: 'Export as ODT',
-                      onClick: onExportOdt,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onExportMd
-                ? [
-                    {
-                      icon: 'file_download',
-                      label: 'Export as Markdown',
-                      onClick: onExportMd,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onExportTxt
-                ? [
-                    {
-                      icon: 'file_download',
-                      label: 'Export as Plain Text',
-                      onClick: onExportTxt,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onPageSetup
-                ? [
-                    {
-                      icon: 'settings',
-                      label: t('toolbar.pageSetup'),
-                      onClick: onPageSetup,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onFileProperties
-                ? [
-                    {
-                      icon: 'tune',
-                      label: 'Properties',
-                      onClick: onFileProperties,
-                    } as MenuEntry,
-                  ]
-                : []),
-            ]}
-          />
-        )}
-
-        {/* Edit Menu */}
-        <MenuDropdown
-          label="Edit"
-          disabled={disabled}
-          items={[
-            {
-              icon: 'undo',
-              label: 'Undo',
-              shortcut: 'Ctrl+Z',
-              onClick: onUndo ?? (() => {}),
-              disabled: !canUndo,
-            } as MenuEntry,
-            {
-              icon: 'redo',
-              label: 'Redo',
-              shortcut: 'Ctrl+Y',
-              onClick: onRedo ?? (() => {}),
-              disabled: !canRedo,
-            } as MenuEntry,
-            { type: 'separator' as const } as MenuEntry,
-            // Clipboard ops — execCommand only works while the editor has focus,
-            // so refocus first. Modern browsers block JS-initiated paste; the
-            // shortcut label educates users to fall back to ⌘V.
-            {
-              icon: 'content_cut',
-              label: 'Cut',
-              shortcut: 'Ctrl+X',
-              onClick: () => {
-                onRefocusEditor?.();
-                document.execCommand('cut');
-              },
-            } as MenuEntry,
-            {
-              icon: 'content_copy',
-              label: 'Copy',
-              shortcut: 'Ctrl+C',
-              onClick: () => {
-                onRefocusEditor?.();
-                document.execCommand('copy');
-              },
-            } as MenuEntry,
-            {
-              icon: 'content_paste',
-              label: 'Paste',
-              shortcut: 'Ctrl+V',
-              onClick: () => {
-                onRefocusEditor?.();
-                document.execCommand('paste');
-              },
-            } as MenuEntry,
-            {
-              icon: 'content_paste_go',
-              label: 'Paste without formatting',
-              shortcut: 'Ctrl+Shift+V',
-              onClick: async () => {
-                onRefocusEditor?.();
-                try {
-                  const text = await navigator.clipboard.readText();
-                  if (text) document.execCommand('insertText', false, text);
-                } catch {
-                  // Browser blocked the read; user can fall back to ⌘⇧V.
-                }
-              },
-            } as MenuEntry,
-            { type: 'separator' as const } as MenuEntry,
-            ...(onOpenFind
-              ? [
-                  {
-                    icon: 'search',
-                    label: 'Find…',
-                    shortcut: 'Ctrl+F',
-                    onClick: onOpenFind,
-                  } as MenuEntry,
-                ]
-              : []),
-            ...(onOpenFindReplace
-              ? [
-                  {
-                    icon: 'find_replace',
-                    label: 'Find and replace…',
-                    shortcut: 'Ctrl+H',
-                    onClick: onOpenFindReplace,
-                  } as MenuEntry,
-                ]
-              : []),
-            ...(onOpenFind || onOpenFindReplace
-              ? [{ type: 'separator' as const } as MenuEntry]
-              : []),
-            {
-              icon: 'select_all',
-              label: 'Select all',
-              shortcut: 'Ctrl+A',
-              onClick: () => handleFormat('selectAll'),
-            } as MenuEntry,
-            // Word count lives in Tools → Word count (Google Docs
-            // convention). Removed from Edit on the Phase-4 menu pass
-            // — duplication confused users about which entry the
-            // Ctrl+Shift+C shortcut targeted.
-            ...(onToggleVoiceTyping
-              ? [
-                  {
-                    icon: 'mic',
-                    label: voiceTypingActive ? '✓ Voice typing' : 'Voice typing',
-                    onClick: onToggleVoiceTyping,
-                  } as MenuEntry,
-                ]
-              : []),
-            ...(onToggleSpellCheck
-              ? [
-                  { type: 'separator' as const } as MenuEntry,
-                  {
-                    icon: 'spellcheck',
-                    label: spellCheckEnabled ? '✓ Spelling' : 'Spelling',
-                    onClick: onToggleSpellCheck,
-                  } as MenuEntry,
-                ]
-              : []),
-          ]}
-        />
-
-        {/* Format Menu */}
-        <MenuDropdown
-          label={t('toolbar.format')}
-          disabled={disabled}
-          items={[
-            {
-              label: `${currentFormatting?.bold ? '✓ ' : ''}Bold`,
-              shortcut: 'Ctrl+B',
-              onClick: () => handleFormat('bold'),
-            } as MenuEntry,
-            {
-              label: `${currentFormatting?.italic ? '✓ ' : ''}Italic`,
-              shortcut: 'Ctrl+I',
-              onClick: () => handleFormat('italic'),
-            } as MenuEntry,
-            {
-              label: `${currentFormatting?.underline ? '✓ ' : ''}Underline`,
-              shortcut: 'Ctrl+U',
-              onClick: () => handleFormat('underline'),
-            } as MenuEntry,
-            {
-              label: `${currentFormatting?.strike ? '✓ ' : ''}Strikethrough`,
-              onClick: () => handleFormat('strikethrough'),
-            } as MenuEntry,
-            { type: 'separator' as const } as MenuEntry,
-            {
-              label: `${currentFormatting?.smallCaps ? '✓ ' : ''}Small Caps`,
-              onClick: () => handleFormat('toggleSmallCaps'),
-            } as MenuEntry,
-            {
-              label: `${currentFormatting?.allCaps ? '✓ ' : ''}All Caps`,
-              onClick: () => handleFormat('toggleAllCaps'),
-            } as MenuEntry,
-            { type: 'separator' as const } as MenuEntry,
-            {
-              icon: 'format_line_spacing',
-              label: t('toolbar.customSpacing'),
-              onClick: onOpenParagraphDialog,
-              disabled: !onOpenParagraphDialog,
-            } as MenuEntry,
-            {
-              icon: 'border_outer',
-              label: t('toolbar.bordersAndShading'),
-              onClick: onOpenBordersShading,
-              disabled: !onOpenBordersShading,
-            } as MenuEntry,
-            { type: 'separator' as const } as MenuEntry,
-            {
-              icon: 'format_clear',
-              label: 'Clear formatting',
-              shortcut: 'Ctrl+\\',
-              onClick: () => handleFormat('clearFormatting'),
-            } as MenuEntry,
-            { type: 'separator' as const } as MenuEntry,
-            {
-              icon: 'format_textdirection_l_to_r',
-              label: t('toolbar.leftToRight'),
-              onClick: () => handleFormat('setLtr'),
-            } as MenuEntry,
-            {
-              icon: 'format_textdirection_r_to_l',
-              label: t('toolbar.rightToLeft'),
-              onClick: () => handleFormat('setRtl'),
-            } as MenuEntry,
-          ]}
-        />
-
-        {/* View Menu — zoom + ruler + theme. Shown if any is wired. */}
-        {(onZoomChange ||
-          onSetColorTheme ||
-          onToggleShowRuler ||
-          onToggleShowFormattingMarks ||
-          onToggleOutline) && (
-          <MenuDropdown
-            label="View"
-            disabled={disabled}
-            items={[
-              ...(onZoomChange
-                ? [
-                    {
-                      icon: 'add',
-                      label: 'Zoom in',
-                      shortcut: 'Ctrl+=',
-                      onClick: () => onZoomChange(Math.min((zoom ?? 1) * 1.1, 4)),
-                    } as MenuEntry,
-                    {
-                      icon: 'remove',
-                      label: 'Zoom out',
-                      shortcut: 'Ctrl+-',
-                      onClick: () => onZoomChange(Math.max((zoom ?? 1) / 1.1, 0.25)),
-                    } as MenuEntry,
-                    {
-                      icon: 'restart_alt',
-                      label: 'Reset zoom (100%)',
-                      shortcut: 'Ctrl+0',
-                      onClick: () => onZoomChange(1),
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onZoomChange && onToggleShowRuler
-                ? [{ type: 'separator' as const } as MenuEntry]
-                : []),
-              ...(onToggleShowRuler
-                ? [
-                    {
-                      icon: 'straighten',
-                      label: `${rulerVisible ? '✓ ' : ''}Show ruler`,
-                      onClick: onToggleShowRuler,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onToggleShowFormattingMarks
-                ? [
-                    {
-                      label: `${showFormattingMarks ? '✓ ' : ''}${t('toolbar.showFormattingMarks')}`,
-                      onClick: onToggleShowFormattingMarks,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onToggleOutline
-                ? [
-                    {
-                      label: `${outlineVisible ? '✓ ' : ''}${t('toolbar.showOutline')}`,
-                      shortcut: 'Ctrl+Shift+H',
-                      onClick: onToggleOutline,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...((onZoomChange || onToggleShowRuler) && onSetColorTheme
-                ? [{ type: 'separator' as const } as MenuEntry]
-                : []),
-              ...(onSetColorTheme
-                ? [
-                    {
-                      icon: 'contrast',
-                      label: `${colorTheme === 'auto' || !colorTheme ? '✓ ' : ''}Theme: match system`,
-                      onClick: () => onSetColorTheme('auto'),
-                    } as MenuEntry,
-                    {
-                      icon: 'light_mode',
-                      label: `${colorTheme === 'light' ? '✓ ' : ''}Theme: light`,
-                      onClick: () => onSetColorTheme('light'),
-                    } as MenuEntry,
-                    {
-                      icon: 'dark_mode',
-                      label: `${colorTheme === 'dark' ? '✓ ' : ''}Theme: dark`,
-                      onClick: () => onSetColorTheme('dark'),
-                    } as MenuEntry,
-                  ]
-                : []),
-            ]}
-          />
-        )}
-
-        {/* Insert Menu */}
-        <MenuDropdown
-          label={t('toolbar.insert')}
-          disabled={disabled}
-          items={[
-            ...(onInsertImage
-              ? [{ icon: 'image', label: t('toolbar.image'), onClick: onInsertImage } as MenuEntry]
-              : []),
-            ...(showTableInsert && onInsertTable
-              ? [
-                  {
-                    icon: 'grid_on',
-                    label: t('toolbar.table'),
-                    submenuContent: (closeMenu: () => void) => (
-                      <TableGridInline
-                        onInsert={(rows: number, cols: number) => {
-                          handleTableInsert(rows, cols);
-                          closeMenu();
-                        }}
-                      />
-                    ),
-                  } as MenuEntry,
-                ]
-              : []),
-            ...(onInsertImage || (showTableInsert && onInsertTable)
-              ? [{ type: 'separator' as const } as MenuEntry]
-              : []),
-            {
-              icon: 'page_break',
-              label: t('toolbar.pageBreak'),
-              shortcut: 'Ctrl+Enter',
-              onClick: onInsertPageBreak,
-              disabled: !onInsertPageBreak,
-            },
-            {
-              icon: 'horizontal_rule',
-              label: t('toolbar.horizontalLine'),
-              onClick: onInsertHorizontalRule,
-              disabled: !onInsertHorizontalRule,
-            },
-            {
-              icon: 'horizontal_rule',
-              label: t('toolbar.sectionBreak'),
-              disabled: !onInsertSectionBreak,
-              submenuContent: (closeMenu: () => void) => (
-                <>
-                  {(
-                    [
-                      { label: t('toolbar.sectionBreakNextPage'), type: 'nextPage' },
-                      { label: t('toolbar.sectionBreakContinuous'), type: 'continuous' },
-                      { label: t('toolbar.sectionBreakEvenPage'), type: 'evenPage' },
-                      { label: t('toolbar.sectionBreakOddPage'), type: 'oddPage' },
-                    ] as const
-                  ).map((item) => (
-                    <SubMenuItem
-                      key={item.type}
-                      label={item.label}
-                      onClick={() => onInsertSectionBreak?.(item.type)}
-                      closeMenu={closeMenu}
-                    />
-                  ))}
-                </>
+            label={
+              <span
+                data-testid="menu-overflow"
+                aria-hidden="true"
+                style={{ fontSize: 18, lineHeight: 1, display: 'inline-flex' }}
+              >
+                ☰
+              </span>
+            }
+            items={visibleMenus.map((m) => ({
+              label: m.label,
+              submenuContent: (close: () => void) => (
+                <MenuEntries items={m.items} onClose={close} />
               ),
-            },
-            ...(onInsertShape
-              ? [
-                  {
-                    icon: 'shapes',
-                    label: t('toolbar.shape'),
-                    submenuContent: (closeMenu: () => void) => (
-                      <>
-                        {(
-                          [
-                            { label: t('toolbar.shapeRectangle'), type: 'rectangle' },
-                            { label: t('toolbar.shapeEllipse'), type: 'ellipse' },
-                            { label: t('toolbar.shapeLine'), type: 'line' },
-                            { label: t('toolbar.shapeArrow'), type: 'arrow' },
-                          ] as const
-                        ).map((item) => (
-                          <SubMenuItem
-                            key={item.type}
-                            label={item.label}
-                            onClick={() => onInsertShape(item.type)}
-                            closeMenu={closeMenu}
-                          />
-                        ))}
-                      </>
-                    ),
-                  } as MenuEntry,
-                ]
-              : []),
-            ...(onInsertTextBox
-              ? [
-                  {
-                    icon: 'edit_note',
-                    label: 'Text box',
-                    onClick: () => onInsertTextBox('plain'),
-                  } as MenuEntry,
-                  {
-                    icon: 'chat_bubble_outline',
-                    label: 'Callout',
-                    onClick: () => onInsertTextBox('callout'),
-                  } as MenuEntry,
-                ]
-              : []),
-            {
-              icon: 'tag',
-              label: t('toolbar.insertField'),
-              disabled: !onInsertField,
-              submenuContent: (closeMenu: () => void) => (
-                <>
-                  {(
-                    [
-                      { label: t('toolbar.fieldPage'), type: 'PAGE' },
-                      { label: t('toolbar.fieldNumPages'), type: 'NUMPAGES' },
-                      { label: t('toolbar.fieldDate'), type: 'DATE' },
-                      { label: t('toolbar.fieldTime'), type: 'TIME' },
-                      { label: t('toolbar.fieldCreateDate'), type: 'CREATEDATE' },
-                      { label: t('toolbar.fieldSaveDate'), type: 'SAVEDATE' },
-                      { label: t('toolbar.fieldAuthor'), type: 'AUTHOR' },
-                      { label: t('toolbar.fieldFileName'), type: 'FILENAME' },
-                    ] as const
-                  ).map((item) => (
-                    <SubMenuItem
-                      key={item.type}
-                      label={item.label}
-                      onClick={() => onInsertField?.(item.type)}
-                      closeMenu={closeMenu}
-                    />
-                  ))}
-                </>
-              ),
-            },
-            {
-              icon: 'format_list_numbered',
-              label: t('toolbar.tableOfContents'),
-              onClick: onInsertTOC,
-              disabled: !onInsertTOC,
-            },
-            {
-              icon: 'bookmark',
-              label: t('toolbar.bookmarks'),
-              onClick: onOpenBookmarks,
-              disabled: !onOpenBookmarks,
-            },
-            {
-              icon: 'note_add',
-              label: t('toolbar.footnote'),
-              onClick: onInsertFootnote,
-              disabled: !onInsertFootnote,
-            },
-            { type: 'separator' as const } as MenuEntry,
-            {
-              icon: 'emoji_symbols',
-              label: t('toolbar.specialCharacters'),
-              onClick: onOpenInsertSymbol,
-              disabled: !onOpenInsertSymbol,
-            },
-            ...(onOpenBuildingBlocks
-              ? [
-                  {
-                    label: t('toolbar.buildingBlocks'),
-                    onClick: onOpenBuildingBlocks,
-                  } as MenuEntry,
-                ]
-              : []),
-            ...(onConvertSelectionToTable
-              ? [
-                  {
-                    label: t('toolbar.convertToTable'),
-                    onClick: onConvertSelectionToTable,
-                  } as MenuEntry,
-                ]
-              : []),
-            ...(onConvertTableToText
-              ? [
-                  {
-                    label: t('toolbar.convertToText'),
-                    onClick: onConvertTableToText,
-                  } as MenuEntry,
-                ]
-              : []),
-            ...(onOpenWatermark
-              ? [
-                  { type: 'separator' as const } as MenuEntry,
-                  {
-                    label: t('toolbar.watermark'),
-                    onClick: onOpenWatermark,
-                  } as MenuEntry,
-                ]
-              : []),
-          ]}
-        />
-
-        {/* Tools Menu — gated on having at least one Tools item. */}
-        {(onOpenPreferences ||
-          onOpenAccessibility ||
-          onOpenWordCount ||
-          onOpenDictionary ||
-          onOpenTranslate ||
-          onTranslateDocument ||
-          onToggleSpellcheck ||
-          onToggleGrammar ||
-          onOpenWritingAssistant ||
-          onOpenExplore ||
-          onOpenCitations) && (
-          <MenuDropdown
-            label={t('toolbar.tools')}
-            disabled={disabled}
-            items={[
-              // Word count first — matches Google Docs' Tools → Word count
-              // placement. (Edit menu still has it too for users who learned
-              // the older location.)
-              ...(onOpenWordCount
-                ? [
-                    {
-                      icon: 'format_list_numbered',
-                      label: t('toolbar.wordCount'),
-                      shortcut: 'Ctrl+Shift+C',
-                      onClick: onOpenWordCount,
-                    } as MenuEntry,
-                    { type: 'separator' as const } as MenuEntry,
-                  ]
-                : []),
-              ...(onOpenDictionary
-                ? [
-                    {
-                      label: t('toolbar.dictionary'),
-                      shortcut: 'Ctrl+Shift+Y',
-                      onClick: onOpenDictionary,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onOpenTranslate
-                ? [
-                    {
-                      icon: 'translate',
-                      label: t('toolbar.translate'),
-                      onClick: onOpenTranslate,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onTranslateDocument
-                ? [
-                    {
-                      icon: 'description',
-                      label: 'Translate document…',
-                      onClick: onTranslateDocument,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onToggleSpellcheck
-                ? [
-                    {
-                      icon: 'spellcheck',
-                      label: spellcheckEnabled ? '✓ Spell check' : 'Spell check',
-                      onClick: onToggleSpellcheck,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onToggleGrammar
-                ? [
-                    {
-                      icon: 'edit_note',
-                      label: grammarEnabled ? '✓ Grammar check' : 'Grammar check',
-                      onClick: onToggleGrammar,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onOpenWritingAssistant
-                ? [
-                    {
-                      icon: 'auto_awesome',
-                      label: 'Writing assistant…',
-                      onClick: onOpenWritingAssistant,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onOpenExplore
-                ? [
-                    {
-                      icon: 'explore',
-                      label: t('toolbar.explore'),
-                      onClick: onOpenExplore,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onOpenCitations
-                ? [
-                    {
-                      icon: 'format_quote',
-                      label: t('toolbar.citations'),
-                      onClick: onOpenCitations,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onOpenPreferences
-                ? [
-                    {
-                      icon: 'tune',
-                      label: t('toolbar.preferences'),
-                      onClick: onOpenPreferences,
-                    } as MenuEntry,
-                  ]
-                : []),
-              ...(onOpenAccessibility
-                ? [
-                    {
-                      icon: 'accessibility',
-                      label: t('toolbar.accessibility'),
-                      onClick: onOpenAccessibility,
-                    } as MenuEntry,
-                  ]
-                : []),
-            ]}
+            }))}
           />
+        ) : (
+          // Desktop: the seven menus render inline exactly as before.
+          visibleMenus.map((m) => (
+            <MenuDropdown
+              key={m.id}
+              id={m.id}
+              label={m.label}
+              disabled={disabled}
+              items={m.items}
+            />
+          ))
         )}
-
-        {/* Help Menu */}
-        <MenuDropdown
-          label={t('toolbar.help')}
-          disabled={disabled}
-          items={[
-            ...(onOpenCommandPalette
-              ? [
-                  {
-                    label: t('toolbar.searchMenus'),
-                    onClick: onOpenCommandPalette,
-                  } as MenuEntry,
-                  { type: 'separator' as const } as MenuEntry,
-                ]
-              : []),
-            {
-              icon: 'bug_report',
-              label: t('toolbar.reportIssue'),
-              onClick: () => (onReportBug ? onReportBug() : openReportIssue()),
-            } as MenuEntry,
-            ...(onShowAbout
-              ? [
-                  { type: 'separator' as const } as MenuEntry,
-                  {
-                    icon: 'info',
-                    label: 'About Casual Editor',
-                    onClick: onShowAbout,
-                  } as MenuEntry,
-                ]
-              : []),
-            ...(onOpenKeyboardShortcuts
-              ? [
-                  { type: 'separator' as const } as MenuEntry,
-                  {
-                    label: t('toolbar.keyboardShortcuts'),
-                    onClick: onOpenKeyboardShortcuts,
-                  } as MenuEntry,
-                ]
-              : []),
-          ]}
-        />
       </div>
     </MenuBarProvider>
   );

--- a/docx-editor/packages/react/src/components/ui/MenuDropdown.tsx
+++ b/docx-editor/packages/react/src/components/ui/MenuDropdown.tsx
@@ -39,15 +39,26 @@ function isSeparator(entry: MenuEntry): entry is MenuSeparator {
 }
 
 interface MenuDropdownProps {
-  label: string;
+  /**
+   * Trigger content. Usually a string (e.g. "Edit"), but may be arbitrary
+   * ReactNode so the collapsed overflow menu can use a hamburger glyph. When
+   * it's not a string, pass `ariaLabel` + `id` so the trigger stays named and
+   * addressable.
+   */
+  label: ReactNode;
   items: MenuEntry[];
   disabled?: boolean;
   /**
    * Stable id for this menu within a MenuBarProvider. When omitted, the
-   * label is used. Needed so adjacent menus can hover-to-switch and so
-   * ArrowLeft/Right keyboard nav can move between them.
+   * label is used (requires a string label). Needed so adjacent menus can
+   * hover-to-switch and so ArrowLeft/Right keyboard nav can move between them.
    */
   id?: string;
+  /**
+   * Accessible name for the trigger and panel. Falls back to `label` when it
+   * is a string. Required when `label` is non-textual (e.g. a hamburger icon).
+   */
+  ariaLabel?: string;
 }
 
 const triggerStyle: CSSProperties = {
@@ -167,16 +178,113 @@ export function SubMenuItem({
   );
 }
 
-export function MenuDropdown({ label, items, disabled, id }: MenuDropdownProps) {
+/**
+ * MenuEntries — renders a MenuEntry[] as the body rows of a menu panel.
+ *
+ * Extracted from MenuDropdown so it can be reused standalone (e.g. as the
+ * content of a submenu inside a collapsed "hamburger" overflow menu on
+ * narrow viewports). Owns the reserved-icon-gutter logic and the
+ * hover-opened submenu state locally, computed from the `items` passed in.
+ * Clicking a leaf item runs its `onClick` then calls `onClose`.
+ */
+export function MenuEntries({ items, onClose }: { items: MenuEntry[]; onClose: () => void }) {
+  // Reserve the icon gutter for every row only when this menu actually has
+  // at least one icon — fully-textual menus (e.g. Format) stay tight.
+  const hasAnyIcon = items.some((entry) => !isSeparator(entry) && !!entry.icon);
+  const [hoveredSubmenu, setHoveredSubmenu] = useState<string | null>(null);
+
+  const handleItemClick = (item: MenuItem) => {
+    if (item.disabled || item.submenuContent) return;
+    if (!item.onClick) return;
+    item.onClick();
+    onClose();
+  };
+
+  return (
+    <>
+      {items.map((entry, i) => {
+        if (isSeparator(entry)) {
+          return <div key={`sep-${i}`} role="separator" style={separatorStyle} />;
+        }
+        const item = entry;
+        if (item.customContent) {
+          return (
+            <div key={item.label} onMouseDown={(e) => e.preventDefault()}>
+              {item.customContent}
+            </div>
+          );
+        }
+
+        const hasSubmenu = !!item.submenuContent;
+        const isSubmenuOpen = hoveredSubmenu === item.label;
+
+        return (
+          <div
+            key={item.label}
+            style={{ position: 'relative' }}
+            onMouseEnter={() => hasSubmenu && setHoveredSubmenu(item.label)}
+            onMouseLeave={() => hasSubmenu && setHoveredSubmenu(null)}
+          >
+            <button
+              type="button"
+              role="menuitem"
+              aria-haspopup={hasSubmenu ? 'menu' : undefined}
+              aria-expanded={hasSubmenu ? isSubmenuOpen : undefined}
+              aria-disabled={item.disabled || undefined}
+              style={item.disabled ? menuItemDisabledStyle : menuItemStyle}
+              onClick={() => handleItemClick(item)}
+              onMouseDown={(e) => e.preventDefault()}
+              onMouseOver={(e) => {
+                if (!item.disabled) {
+                  (e.currentTarget as HTMLButtonElement).style.backgroundColor =
+                    'var(--doc-hover, #f3f4f6)';
+                }
+              }}
+              onMouseOut={(e) => {
+                (e.currentTarget as HTMLButtonElement).style.backgroundColor = 'transparent';
+              }}
+              disabled={item.disabled}
+            >
+              {hasAnyIcon && (
+                <span style={iconSlotStyle}>
+                  {item.icon ? <MaterialSymbol name={item.icon} size={18} /> : null}
+                </span>
+              )}
+              <span>{item.label}</span>
+              {item.shortcut && <span style={shortcutStyle}>{formatShortcut(item.shortcut)}</span>}
+              {hasSubmenu && (
+                <span style={{ marginLeft: 'auto' }}>
+                  <MaterialSymbol name="keyboard_arrow_right" size={16} />
+                </span>
+              )}
+            </button>
+            {hasSubmenu && isSubmenuOpen && (
+              <div
+                role="menu"
+                aria-label={item.label}
+                style={submenuPanelStyle}
+                onMouseDown={(e) => e.preventDefault()}
+              >
+                {item.submenuContent!(onClose)}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+export function MenuDropdown({ label, items, disabled, id, ariaLabel }: MenuDropdownProps) {
   // When inside a <MenuBarProvider>, isOpen is driven by the shared
   // openId so adjacent menus can hover-to-switch and one click swaps
   // between them. Outside a provider, this falls back to a local
   // boolean and the component keeps its old isolated behavior.
   const bar = useMenuBar();
-  const menuId = id ?? label;
-  // Reserve the icon gutter for every row only when this menu actually has
-  // at least one icon — fully-textual menus (e.g. Format) stay tight.
-  const hasAnyIcon = items.some((entry) => !isSeparator(entry) && !!entry.icon);
+  // Accessible name for the trigger/panel: explicit ariaLabel wins, else the
+  // string label. Non-string labels (e.g. a hamburger glyph) must pass ariaLabel.
+  const accessibleName = ariaLabel ?? (typeof label === 'string' ? label : undefined);
+  const menuId = id ?? (typeof label === 'string' ? label : (accessibleName ?? ''));
   const [localOpen, setLocalOpen] = useState(false);
   const isOpen = bar ? bar.openId === menuId : localOpen;
   const setIsOpen = useCallback(
@@ -187,7 +295,6 @@ export function MenuDropdown({ label, items, disabled, id }: MenuDropdownProps) 
     [bar, menuId]
   );
 
-  const [hoveredSubmenu, setHoveredSubmenu] = useState<string | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number }>({
@@ -205,7 +312,6 @@ export function MenuDropdown({ label, items, disabled, id }: MenuDropdownProps) 
 
   const closeMenu = useCallback(() => {
     setIsOpen(false);
-    setHoveredSubmenu(null);
   }, [setIsOpen]);
 
   // Calculate position when opening. useLayoutEffect (not useEffect) so the
@@ -285,13 +391,6 @@ export function MenuDropdown({ label, items, disabled, id }: MenuDropdownProps) 
     };
   }, [isOpen, closeMenu]);
 
-  const handleItemClick = (item: MenuItem) => {
-    if (item.disabled || item.submenuContent) return;
-    if (!item.onClick) return;
-    item.onClick();
-    closeMenu();
-  };
-
   return (
     // The wrapper needs position:relative so the submenu panel can
     // position itself with `left: 100%`. We DO NOT set zIndex on the
@@ -312,6 +411,7 @@ export function MenuDropdown({ label, items, disabled, id }: MenuDropdownProps) 
         // type; aria-expanded tracks open state for screen readers.
         aria-haspopup="menu"
         aria-expanded={isOpen}
+        aria-label={ariaLabel}
         onClick={() => !disabled && setIsOpen(!isOpen)}
         onMouseEnter={() => {
           if (disabled || !bar) return;
@@ -396,7 +496,7 @@ export function MenuDropdown({ label, items, disabled, id }: MenuDropdownProps) 
             // "menu," aria-label gives it a name screen readers can
             // announce when focus enters.
             role="menu"
-            aria-label={label}
+            aria-label={accessibleName}
             style={{
               position: 'fixed',
               top: dropdownPos.top,
@@ -412,77 +512,7 @@ export function MenuDropdown({ label, items, disabled, id }: MenuDropdownProps) 
             }}
             onMouseDown={(e) => e.preventDefault()}
           >
-            {items.map((entry, i) => {
-              if (isSeparator(entry)) {
-                return <div key={`sep-${i}`} role="separator" style={separatorStyle} />;
-              }
-              const item = entry;
-              if (item.customContent) {
-                return (
-                  <div key={item.label} onMouseDown={(e) => e.preventDefault()}>
-                    {item.customContent}
-                  </div>
-                );
-              }
-
-              const hasSubmenu = !!item.submenuContent;
-              const isSubmenuOpen = hoveredSubmenu === item.label;
-
-              return (
-                <div
-                  key={item.label}
-                  style={{ position: 'relative' }}
-                  onMouseEnter={() => hasSubmenu && setHoveredSubmenu(item.label)}
-                  onMouseLeave={() => hasSubmenu && setHoveredSubmenu(null)}
-                >
-                  <button
-                    type="button"
-                    role="menuitem"
-                    aria-haspopup={hasSubmenu ? 'menu' : undefined}
-                    aria-expanded={hasSubmenu ? isSubmenuOpen : undefined}
-                    aria-disabled={item.disabled || undefined}
-                    style={item.disabled ? menuItemDisabledStyle : menuItemStyle}
-                    onClick={() => handleItemClick(item)}
-                    onMouseDown={(e) => e.preventDefault()}
-                    onMouseOver={(e) => {
-                      if (!item.disabled) {
-                        (e.currentTarget as HTMLButtonElement).style.backgroundColor =
-                          'var(--doc-hover, #f3f4f6)';
-                      }
-                    }}
-                    onMouseOut={(e) => {
-                      (e.currentTarget as HTMLButtonElement).style.backgroundColor = 'transparent';
-                    }}
-                    disabled={item.disabled}
-                  >
-                    {hasAnyIcon && (
-                      <span style={iconSlotStyle}>
-                        {item.icon ? <MaterialSymbol name={item.icon} size={18} /> : null}
-                      </span>
-                    )}
-                    <span>{item.label}</span>
-                    {item.shortcut && (
-                      <span style={shortcutStyle}>{formatShortcut(item.shortcut)}</span>
-                    )}
-                    {hasSubmenu && (
-                      <span style={{ marginLeft: 'auto' }}>
-                        <MaterialSymbol name="keyboard_arrow_right" size={16} />
-                      </span>
-                    )}
-                  </button>
-                  {hasSubmenu && isSubmenuOpen && (
-                    <div
-                      role="menu"
-                      aria-label={item.label}
-                      style={submenuPanelStyle}
-                      onMouseDown={(e) => e.preventDefault()}
-                    >
-                      {item.submenuContent!(closeMenu)}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
+            <MenuEntries items={items} onClose={closeMenu} />
           </div>
         </>
       )}


### PR DESCRIPTION
At ≤720px the seven-across menu bar (File/Edit/Format/View/Insert/Tools/Help) truncated at "Fo…" with Insert/Tools/Help off-screen and no overflow affordance — core commands unreachable. Below that width it now collapses into a single ☰ hamburger whose items re-expose each menu as a submenu. Desktop (>720px) renders the seven menus inline, unchanged.

Implementation:
- Extract a reusable `MenuEntries` renderer from `MenuDropdown` (preserves the icon gutter, separators, `customContent`/table-grid picker, shortcuts, and nested submenus), and render it inside the collapsed menu's submenus at full fidelity. `MenuDropdown` itself now renders `MenuEntries` internally, so existing menus/tests exercise it unchanged.
- `MenuDropdown`'s `label` widened to `ReactNode` (+ optional `ariaLabel`) for the hamburger glyph; string-label callers are byte-identical.
- The seven menus are built from one data array with their original show-guards and labels preserved verbatim.

Regression tests: phone viewport asserts the hamburger appears, the inline menu buttons are gone, and all seven menus (incl. Insert's submenu) are reachable; desktop asserts the seven inline menus render with no hamburger. Verified desktop menu specs (arrow-nav, dropdown-close, view menu, table-insert) still pass.