### PR TITLE
refactor(architecture): extract ViewStateContext from EditorToolbar props

### DIFF
--- a/docx-editor/.changeset/view-state-context.md
+++ b/docx-editor/.changeset/view-state-context.md
@@ -1,0 +1,5 @@
+---
+'@casualoffice/docs': patch
+---
+
+Internal refactor: extract the 7 view-toggle pairs (spellcheck, grammar, outline, show-ruler, show-vertical-ruler, show-formatting-marks, paint-format) from 14 individual props on the internal `<EditorToolbar>` call site into a `ViewStateContext`, matching the existing `DialogActionsContext` pattern. No public API change — the corresponding `ToolbarProps` fields are unchanged and still take precedence when explicitly passed. Part of the ongoing `DocxEditor.tsx` decomposition (docs/internal/40 §6).

--- a/docx-editor/packages/react/src/components/DocxEditor.tsx
+++ b/docx-editor/packages/react/src/components/DocxEditor.tsx
@@ -45,6 +45,7 @@ import {
 import type { FontOption } from './ui/FontPicker';
 import { EditorToolbar } from './EditorToolbar';
 import { DialogActionsContext, type DialogActions } from './DialogActionsContext';
+import { ViewStateContext, type ViewState } from './ViewStateContext';
 import { StatusBar } from './StatusBar';
 import { FocusModeBar } from './FocusModeBar';
 import { useStatPrefs } from './statbar-prefs';
@@ -7334,6 +7335,26 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
     openCitations: handleOpenCitations,
   };
 
+  // View-toggle handlers + their on/off state, grouped the same way as
+  // dialogActions above — via ViewStateContext instead of 14 individual
+  // props on the <EditorToolbar> call site below.
+  const viewState: ViewState = {
+    onPaintFormat: handleTogglePaintFormat,
+    paintFormatArmed: paintFormatMarks != null,
+    onToggleShowRuler: handleToggleShowRuler,
+    rulerVisible: showRulerEffective,
+    onToggleShowVerticalRuler: handleToggleShowVerticalRuler,
+    verticalRulerVisible: showVerticalRulerEffective,
+    onToggleShowFormattingMarks: handleToggleShowFormattingMarks,
+    showFormattingMarks,
+    onToggleOutline: handleToggleOutline,
+    outlineVisible: showOutlineEffective,
+    onToggleSpellcheck: handleToggleSpellcheck,
+    spellcheckEnabled: spellOn,
+    onToggleGrammar: handleToggleGrammar,
+    grammarEnabled: grammarOn,
+  };
+
   // Watermark apply/clear handler (C5) — writes into the doc-level
   // body.watermark slot so the painter draws the overlay on the next
   // render. `undefined` clears it. Round-trip to header XML lands in a
@@ -9537,135 +9558,125 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(function Do
                       className="z-50 flex flex-col gap-0 flex-shrink-0"
                     >
                       <DialogActionsContext.Provider value={dialogActions}>
-                        <EditorToolbar
-                          // When the agent panel is open, round the toolbar's
-                          // bottom-right corner so it mirrors the panel's top-left.
-                          // The radius transition (inline style on the inner div)
-                          // makes opening / closing ease instead of snap.
-                          className={agentPanelOpen ? 'rounded-br-2xl' : undefined}
-                          style={{
-                            transition: 'border-radius var(--doc-anim-slow)',
-                          }}
-                          currentFormatting={state.selectionFormatting}
-                          onFormat={handleFormat}
-                          onMenuOpenChange={setMenuOpen}
-                          onUndo={undoActiveEditor}
-                          onRedo={redoActiveEditor}
-                          canUndo={canUndoActiveEditor}
-                          canRedo={canRedoActiveEditor}
-                          disabled={readOnly}
-                          documentStyles={history.state?.package.styles?.styles}
-                          theme={history.state?.package.theme || theme}
-                          showPrintButton={showPrintButtonEffective}
-                          fontFamilies={fontFamilies}
-                          onPrint={handleDirectPrint}
-                          /* When the app shell is hidden (embedded), the host
+                        <ViewStateContext.Provider value={viewState}>
+                          <EditorToolbar
+                            // When the agent panel is open, round the toolbar's
+                            // bottom-right corner so it mirrors the panel's top-left.
+                            // The radius transition (inline style on the inner div)
+                            // makes opening / closing ease instead of snap.
+                            className={agentPanelOpen ? 'rounded-br-2xl' : undefined}
+                            style={{
+                              transition: 'border-radius var(--doc-anim-slow)',
+                            }}
+                            currentFormatting={state.selectionFormatting}
+                            onFormat={handleFormat}
+                            onMenuOpenChange={setMenuOpen}
+                            onUndo={undoActiveEditor}
+                            onRedo={redoActiveEditor}
+                            canUndo={canUndoActiveEditor}
+                            canRedo={canRedoActiveEditor}
+                            disabled={readOnly}
+                            documentStyles={history.state?.package.styles?.styles}
+                            theme={history.state?.package.theme || theme}
+                            showPrintButton={showPrintButtonEffective}
+                            fontFamilies={fontFamilies}
+                            onPrint={handleDirectPrint}
+                            /* When the app shell is hidden (embedded), the host
                           owns file identity/lifecycle and versions — prune the
                           File-menu entries it provides so the editing menus
                           stay without a redundant "second product" File menu.
                           A MenuBar item disappears when its callback is
                           undefined (presence-gated). */
-                          onOpen={appShellHidden ? undefined : handleOpenDocument}
-                          onSave={handleDownloadDocument}
-                          onMakeCopy={appShellHidden ? undefined : handleMakeCopy}
-                          onEmailAsAttachment={appShellHidden ? undefined : handleEmailAsAttachment}
-                          onOpenVersionHistory={
-                            appShellHidden
-                              ? undefined
-                              : () => {
-                                  if (!showVersionHistory) handleToggleVersionHistory();
-                                }
-                          }
-                          onNew={appShellHidden ? undefined : onNew}
-                          showZoomControl={showZoomControlEffective}
-                          zoom={state.zoom}
-                          onZoomChange={handleZoomChange}
-                          onRefocusEditor={focusActiveEditor}
-                          onInsertTable={handleInsertTable}
-                          showTableInsert={true}
-                          onInsertImage={handleInsertImageClick}
-                          onInsertPageBreak={handleInsertPageBreak}
-                          onInsertSectionBreak={handleInsertSectionBreak}
-                          onInsertField={handleInsertField}
-                          onInsertTOC={handleInsertTOC}
-                          onAddComment={handleStartAddComment}
-                          onPaintFormat={handleTogglePaintFormat}
-                          paintFormatArmed={paintFormatMarks != null}
-                          onInsertHorizontalRule={handleInsertHorizontalRule}
-                          onInsertFootnote={handleInsertFootnote}
-                          onToggleShowRuler={handleToggleShowRuler}
-                          rulerVisible={showRulerEffective}
-                          onToggleShowVerticalRuler={handleToggleShowVerticalRuler}
-                          verticalRulerVisible={showVerticalRulerEffective}
-                          onToggleShowFormattingMarks={handleToggleShowFormattingMarks}
-                          showFormattingMarks={showFormattingMarks}
-                          onToggleOutline={handleToggleOutline}
-                          outlineVisible={showOutlineEffective}
-                          imageContext={state.pmImageContext}
-                          onImageWrapType={handleImageWrapType}
-                          onImageTransform={handleImageTransform}
-                          // Voice typing hidden — Web Speech API is
-                          // inconsistent across browsers. Re-enable when
-                          // we standardize on a backend.
-                          onExportPdf={handleExportPdf}
-                          onExportOdt={handleExportOdt}
-                          onExportMd={handleExportMd}
-                          /* Branding/support entries the host owns in embedded. */
-                          onReportBug={appShellHidden ? undefined : handleReportBug}
-                          onConvertSelectionToTable={handleConvertSelectionToTable}
-                          onConvertTableToText={
-                            state.pmTableContext?.isInTable ? handleConvertTableToText : undefined
-                          }
-                          // LLM-stack entry points hidden: onOpenTranslate,
-                          // onTranslateDocument, onOpenWritingAssistant,
-                          // onOpenExplore. WebLLM inference blocks the main
-                          // thread on long docs; until that lands a yielding
-                          // path, these surfaces stay off. Re-wire with the
-                          // existing handlers when ready.
-                          onToggleSpellcheck={handleToggleSpellcheck}
-                          spellcheckEnabled={spellOn}
-                          onToggleGrammar={handleToggleGrammar}
-                          grammarEnabled={grammarOn}
-                          onInsertShape={handleInsertShape}
-                          onInsertTextBox={handleInsertTextBox}
-                          onSetColorTheme={handleSetColorTheme}
-                          colorTheme={colorTheme}
-                          isDirty={isDirty}
-                          isSaving={isSaving}
-                          tableContext={state.pmTableContext}
-                          onTableAction={handleTableAction}
-                        >
-                          {/* The title row (logo + document name) is the app
+                            onOpen={appShellHidden ? undefined : handleOpenDocument}
+                            onSave={handleDownloadDocument}
+                            onMakeCopy={appShellHidden ? undefined : handleMakeCopy}
+                            onEmailAsAttachment={
+                              appShellHidden ? undefined : handleEmailAsAttachment
+                            }
+                            onOpenVersionHistory={
+                              appShellHidden
+                                ? undefined
+                                : () => {
+                                    if (!showVersionHistory) handleToggleVersionHistory();
+                                  }
+                            }
+                            onNew={appShellHidden ? undefined : onNew}
+                            showZoomControl={showZoomControlEffective}
+                            zoom={state.zoom}
+                            onZoomChange={handleZoomChange}
+                            onRefocusEditor={focusActiveEditor}
+                            onInsertTable={handleInsertTable}
+                            showTableInsert={true}
+                            onInsertImage={handleInsertImageClick}
+                            onInsertPageBreak={handleInsertPageBreak}
+                            onInsertSectionBreak={handleInsertSectionBreak}
+                            onInsertField={handleInsertField}
+                            onInsertTOC={handleInsertTOC}
+                            onAddComment={handleStartAddComment}
+                            onInsertHorizontalRule={handleInsertHorizontalRule}
+                            onInsertFootnote={handleInsertFootnote}
+                            imageContext={state.pmImageContext}
+                            onImageWrapType={handleImageWrapType}
+                            onImageTransform={handleImageTransform}
+                            // Voice typing hidden — Web Speech API is
+                            // inconsistent across browsers. Re-enable when
+                            // we standardize on a backend.
+                            onExportPdf={handleExportPdf}
+                            onExportOdt={handleExportOdt}
+                            onExportMd={handleExportMd}
+                            /* Branding/support entries the host owns in embedded. */
+                            onReportBug={appShellHidden ? undefined : handleReportBug}
+                            onConvertSelectionToTable={handleConvertSelectionToTable}
+                            onConvertTableToText={
+                              state.pmTableContext?.isInTable ? handleConvertTableToText : undefined
+                            }
+                            // LLM-stack entry points hidden: onOpenTranslate,
+                            // onTranslateDocument, onOpenWritingAssistant,
+                            // onOpenExplore. WebLLM inference blocks the main
+                            // thread on long docs; until that lands a yielding
+                            // path, these surfaces stay off. Re-wire with the
+                            // existing handlers when ready.
+                            onInsertShape={handleInsertShape}
+                            onInsertTextBox={handleInsertTextBox}
+                            onSetColorTheme={handleSetColorTheme}
+                            colorTheme={colorTheme}
+                            isDirty={isDirty}
+                            isSaving={isSaving}
+                            tableContext={state.pmTableContext}
+                            onTableAction={handleTableAction}
+                          >
+                            {/* The title row (logo + document name) is the app
                           shell — hidden in `chrome:"embedded"`. The menu bar is
                           the editing surface, gated independently, so embedded
                           keeps the Insert/Format/Tools/… menus while dropping
                           only the logo/name row (doc 39). */}
-                          {(showTitleBarEffective || showMenuBarEffective) && (
-                            <EditorToolbar.TitleBar>
-                              {showTitleBarEffective && renderLogo && (
-                                <EditorToolbar.Logo>{renderLogo()}</EditorToolbar.Logo>
-                              )}
-                              {showTitleBarEffective && documentName !== undefined && (
-                                <EditorToolbar.DocumentName
-                                  value={documentName}
-                                  onChange={onDocumentNameChange}
-                                  editable={documentNameEditable}
-                                />
-                              )}
-                              {showTitleBarEffective && renderTitleBarRight && (
-                                <EditorToolbar.TitleBarRight>
-                                  {renderTitleBarRight()}
-                                </EditorToolbar.TitleBarRight>
-                              )}
-                              {showMenuBarEffective && <EditorToolbar.MenuBar />}
-                            </EditorToolbar.TitleBar>
-                          )}
-                          {showToolbarEffective && (
-                            <EditorToolbar.FormattingBar>
-                              {toolbarChildren}
-                            </EditorToolbar.FormattingBar>
-                          )}
-                        </EditorToolbar>
+                            {(showTitleBarEffective || showMenuBarEffective) && (
+                              <EditorToolbar.TitleBar>
+                                {showTitleBarEffective && renderLogo && (
+                                  <EditorToolbar.Logo>{renderLogo()}</EditorToolbar.Logo>
+                                )}
+                                {showTitleBarEffective && documentName !== undefined && (
+                                  <EditorToolbar.DocumentName
+                                    value={documentName}
+                                    onChange={onDocumentNameChange}
+                                    editable={documentNameEditable}
+                                  />
+                                )}
+                                {showTitleBarEffective && renderTitleBarRight && (
+                                  <EditorToolbar.TitleBarRight>
+                                    {renderTitleBarRight()}
+                                  </EditorToolbar.TitleBarRight>
+                                )}
+                                {showMenuBarEffective && <EditorToolbar.MenuBar />}
+                              </EditorToolbar.TitleBar>
+                            )}
+                            {showToolbarEffective && (
+                              <EditorToolbar.FormattingBar>
+                                {toolbarChildren}
+                              </EditorToolbar.FormattingBar>
+                            )}
+                          </EditorToolbar>
+                        </ViewStateContext.Provider>
                       </DialogActionsContext.Provider>
                     </div>
                   )}

--- a/docx-editor/packages/react/src/components/FormattingBar.tsx
+++ b/docx-editor/packages/react/src/components/FormattingBar.tsx
@@ -35,6 +35,7 @@ import { ToolbarButton, ToolbarGroup } from './Toolbar';
 import type { ToolbarProps, FormattingAction } from './Toolbar';
 import { EditorToolbarContext } from './EditorToolbarContext';
 import { useDialogActions } from './DialogActionsContext';
+import { useViewState } from './ViewStateContext';
 
 const ICON_SIZE = 18;
 
@@ -112,8 +113,8 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
     onInsertImage,
     onOpenParagraphDialog,
     onAddComment,
-    onPaintFormat,
-    paintFormatArmed,
+    onPaintFormat: onPaintFormatProp,
+    paintFormatArmed: paintFormatArmedProp,
     inline = false,
   } = props as FormattingBarProps;
 
@@ -123,6 +124,13 @@ export function FormattingBar(explicitProps: FormattingBarProps) {
   const dialogActions = useDialogActions();
   const openImageProperties = onOpenImageProperties ?? dialogActions.openImageProperties;
   const openParagraphDialog = onOpenParagraphDialog ?? dialogActions.openParagraphDialog;
+
+  // Same pattern, same rationale, for the paint-format toggle — now sourced
+  // from ViewStateContext when used inside <EditorToolbar> (see
+  // ViewStateContext.tsx).
+  const viewState = useViewState();
+  const onPaintFormat = onPaintFormatProp ?? viewState.onPaintFormat;
+  const paintFormatArmed = paintFormatArmedProp ?? viewState.paintFormatArmed;
 
   const barRef = useRef<HTMLDivElement>(null);
 

--- a/docx-editor/packages/react/src/components/TitleBar.tsx
+++ b/docx-editor/packages/react/src/components/TitleBar.tsx
@@ -23,6 +23,7 @@ import { TableGridInline } from './ui/TableGridInline';
 import { WriterStatusPill } from './WriterStatusPill';
 import { useEditorToolbar } from './EditorToolbarContext';
 import { useDialogActions } from './DialogActionsContext';
+import { useViewState } from './ViewStateContext';
 import type { FormattingAction } from './Toolbar';
 import { useTranslation } from '../i18n';
 import { openReportIssue } from './reportIssue';
@@ -290,10 +291,10 @@ export function MenuBar() {
     onConvertTableToText,
     onOpenTranslate,
     onTranslateDocument,
-    onToggleSpellcheck,
-    spellcheckEnabled,
-    onToggleGrammar,
-    grammarEnabled,
+    onToggleSpellcheck: onToggleSpellcheckProp,
+    spellcheckEnabled: spellcheckEnabledProp,
+    onToggleGrammar: onToggleGrammarProp,
+    grammarEnabled: grammarEnabledProp,
     onOpenWritingAssistant,
     onOpenExplore,
     onInsertShape,
@@ -322,17 +323,38 @@ export function MenuBar() {
     onInsertTOC,
     onInsertHorizontalRule,
     onInsertFootnote,
-    onToggleShowRuler,
-    rulerVisible,
-    onToggleShowVerticalRuler,
-    verticalRulerVisible,
-    onToggleShowFormattingMarks,
-    showFormattingMarks,
-    onToggleOutline,
-    outlineVisible,
+    onToggleShowRuler: onToggleShowRulerProp,
+    rulerVisible: rulerVisibleProp,
+    onToggleShowVerticalRuler: onToggleShowVerticalRulerProp,
+    verticalRulerVisible: verticalRulerVisibleProp,
+    onToggleShowFormattingMarks: onToggleShowFormattingMarksProp,
+    showFormattingMarks: showFormattingMarksProp,
+    onToggleOutline: onToggleOutlineProp,
+    outlineVisible: outlineVisibleProp,
     onRefocusEditor,
     onMenuOpenChange,
   } = ctx;
+
+  // View-toggle handlers + state now arrive via ViewStateContext instead of
+  // 14 individual props on the <EditorToolbar> call site (see
+  // ViewStateContext.tsx) — same pattern as DialogActionsContext just above.
+  // An explicitly-passed prop still wins (public ToolbarProps contract is
+  // unchanged); the context is only the fallback DocxEditor's own toolbar
+  // tree relies on internally.
+  const vs = useViewState();
+  const onToggleSpellcheck = onToggleSpellcheckProp ?? vs.onToggleSpellcheck;
+  const spellcheckEnabled = spellcheckEnabledProp ?? vs.spellcheckEnabled;
+  const onToggleGrammar = onToggleGrammarProp ?? vs.onToggleGrammar;
+  const grammarEnabled = grammarEnabledProp ?? vs.grammarEnabled;
+  const onToggleShowRuler = onToggleShowRulerProp ?? vs.onToggleShowRuler;
+  const rulerVisible = rulerVisibleProp ?? vs.rulerVisible;
+  const onToggleShowVerticalRuler = onToggleShowVerticalRulerProp ?? vs.onToggleShowVerticalRuler;
+  const verticalRulerVisible = verticalRulerVisibleProp ?? vs.verticalRulerVisible;
+  const onToggleShowFormattingMarks =
+    onToggleShowFormattingMarksProp ?? vs.onToggleShowFormattingMarks;
+  const showFormattingMarks = showFormattingMarksProp ?? vs.showFormattingMarks;
+  const onToggleOutline = onToggleOutlineProp ?? vs.onToggleOutline;
+  const outlineVisible = outlineVisibleProp ?? vs.outlineVisible;
 
   // Dialog-open handlers now arrive via DialogActionsContext instead of ~16
   // individual props on the <EditorToolbar> call site (see

--- a/docx-editor/packages/react/src/components/ViewStateContext.tsx
+++ b/docx-editor/packages/react/src/components/ViewStateContext.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+import { createContext, useContext } from 'react';
+
+/**
+ * ViewState — the view-toggle handlers + their current on/off state that
+ * the editor chrome (TitleBar's View/Tools menus, FormattingBar's paint-
+ * format button) reads.
+ *
+ * Why a dedicated context: these 7 toggle pairs (14 fields) were previously
+ * threaded as individual props on the `<EditorToolbar>` call site in
+ * DocxEditor (the god-component), inflating an already ~80-prop call. They
+ * don't vary per sub-component and are only ever produced by DocxEditor, so
+ * a single cohesive context both slims that call site and groups "is this
+ * view feature on, and how do I toggle it" into one typed surface — the
+ * same rationale as `DialogActionsContext` for the dialog-open handlers.
+ *
+ * Deliberately NOT folded into `ToolbarProps` / `EditorToolbarContext`:
+ * `ToolbarProps` (and the `Toolbar` / `FormattingBar` components) are part
+ * of the published `@casualoffice/docs` API — removing these flat props
+ * from them would be a breaking change. This context is purely internal
+ * wiring; the public prop contracts are untouched, and consumers still
+ * honour an explicitly-passed prop first (falling back to the context only
+ * when the prop is omitted) — same pattern as `DialogActionsContext`.
+ *
+ * Each field is optional: a `null` provider (or a missing key) simply means
+ * "that feature is absent", which the consumers already presence-gate on
+ * (e.g. the View menu itself only renders when at least one toggle exists).
+ */
+export interface ViewState {
+  onPaintFormat?: () => void;
+  paintFormatArmed?: boolean;
+  onToggleShowRuler?: () => void;
+  rulerVisible?: boolean;
+  onToggleShowVerticalRuler?: () => void;
+  verticalRulerVisible?: boolean;
+  onToggleSpellcheck?: () => void;
+  spellcheckEnabled?: boolean;
+  onToggleGrammar?: () => void;
+  grammarEnabled?: boolean;
+  onToggleShowFormattingMarks?: () => void;
+  showFormattingMarks?: boolean;
+  onToggleOutline?: () => void;
+  outlineVisible?: boolean;
+}
+
+const EMPTY: ViewState = {};
+
+export const ViewStateContext = createContext<ViewState | null>(null);
+
+/**
+ * Read the view-toggle handlers + state. Returns a stable empty object when
+ * no provider is present, so callers can read fields without null checks.
+ */
+export function useViewState(): ViewState {
+  return useContext(ViewStateContext) ?? EMPTY;
+}


### PR DESCRIPTION
Part of the `DocxEditor.tsx` decomposition (docs/internal/40 §6, "the architecture lever"). `DialogActionsContext` already collapsed ~18 dialog-open props into one context; this does the same for the 7 view-toggle pairs (spellcheck, grammar, outline, show-ruler, show-vertical-ruler, show-formatting-marks, paint-format) — 14 props removed from the `<EditorToolbar>` call site in `DocxEditor.tsx`.

Confirmed via direct code inspection (not the stale tracked-task note) that `DialogActionsContext` is already fully shipped — this picks the next lowest-risk step per the spec's revised risk-ranked order (self-contained UI state, no closures over stale refs, unlike the higher-risk `useDocumentIO` extraction still queued).

**No public API change.** `ToolbarProps` still declares all 14 fields; an explicitly-passed prop still wins over the context — mirrors the prop-wins pattern `FormattingBar.tsx` already uses for its two `DialogActionsContext`-sourced props. External consumers of the published `Toolbar`/`FormattingBar` are unaffected.

**Verified:** typecheck + build clean; 24 e2e specs covering all 7 toggles pass (vertical-ruler ×3, spellcheck, grammar-check, show-formatting-marks, outline ×3, view-menu-outline, format-painter) — zero behavior change, which is the whole point of this refactor.