### PR TITLE
feat: surface blank DOCX and Markdown creation

### DIFF
--- a/docx-editor/e2e/tests/home-page.spec.ts
+++ b/docx-editor/e2e/tests/home-page.spec.ts
@@ -20,7 +20,8 @@ test.describe('Home page', () => {
     await page.goto('/');
     await expect(page.locator('[data-testid="home-page"]')).toBeVisible();
     // The Blank-document card is always present (synthesized, no fetch).
-    await expect(page.locator('[data-testid="template-card-blank"]').first()).toBeVisible();
+    await expect(page.locator('[data-testid="template-card-blank"]')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Blank Markdown — Personal' })).toBeVisible();
     // Open-from-disk affordance is always there too.
     await expect(page.locator('[data-testid="home-open-from-disk"]')).toBeVisible();
     // The editor should NOT be mounted yet.
@@ -29,7 +30,7 @@ test.describe('Home page', () => {
 
   test('clicking Blank document transitions to the editor', async ({ page }) => {
     await page.goto('/');
-    await page.locator('[data-testid="template-card-blank"]').first().click();
+    await page.getByRole('button', { name: 'Blank document — Personal' }).click();
     await expect(page.locator('[data-testid="docx-editor"]')).toBeVisible({ timeout: 10_000 });
     // Home should be gone.
     await expect(page.locator('[data-testid="home-page"]')).toHaveCount(0);

--- a/docx-editor/examples/vite/src/App.new-document.test.tsx
+++ b/docx-editor/examples/vite/src/App.new-document.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+import React from 'react';
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, afterEach, expect, mock, test } from 'bun:test';
+
+GlobalRegistrator.register();
+
+mock.module('@casualoffice/docs', () => ({
+  AutosaveStatus: () => null,
+  DocxEditor: ({ document }: { document?: { children?: ReadonlyArray<unknown> } }) => (
+    <div data-testid="docx-editor" data-child-count={document?.children?.length ?? -1} />
+  ),
+  PersonalAuthGate: ({ children }: { children: React.ReactNode }) => children,
+  PresenceCluster: () => null,
+  UserMenu: () => null,
+  convertToDocx: async () => new ArrayBuffer(0),
+  createEmptyDocument: () => ({ type: 'document', children: [] }),
+  deleteRecentFile: async () => undefined,
+  formatFromFilename: () => 'docx',
+  formatSize: (size: number) => `${size} B`,
+  isForeignFormat: () => false,
+  listRecentFiles: async () => [],
+  recordRecentFile: async () => undefined,
+  useFileSourceAutoSave: () => ({ status: 'idle' }),
+}));
+mock.module('./collab/useCollab', () => ({
+  useCollab: () => ({ plugins: [], status: 'connected', peers: [], metaMap: new Map() }),
+}));
+mock.module('./collab/StatusBadge', () => ({ StatusBadge: () => null }));
+mock.module('./collab/Share', () => ({ ShareDialog: () => null }));
+mock.module('./collab/LoadingPanel', () => ({ LoadingPanel: () => null }));
+mock.module('./collab/ErrorPanel', () => ({ ErrorPanel: () => null }));
+mock.module('./collab/DisconnectedBanner', () => ({ DisconnectedBanner: () => null }));
+mock.module('./markdown/MarkdownEditor', () => ({
+  MarkdownEditor: ({ onBack }: { onBack: () => void }) => (
+    <div data-testid="markdown-editor">
+      <button type="button" onClick={onBack}>Back</button>
+    </div>
+  ),
+}));
+mock.module('./markdown/MarkdownCollabApp', () => ({ MarkdownCollabApp: () => null }));
+mock.module('./viewers/RtfViewer', () => ({ RtfViewer: () => null }));
+mock.module('./viewers/EmlViewer', () => ({ EmlViewer: () => null }));
+type LoadedTemplate = {
+  kind: 'document';
+  document: { type: string; children: ReadonlyArray<{ type: string }> };
+  fileName: string;
+};
+let loadTemplateImpl: () => Promise<LoadedTemplate> = async () => ({
+  kind: 'document' as const,
+  document: { type: 'document', children: [] },
+  fileName: 'Template.docx',
+});
+mock.module('./templates/loader', () => ({ loadTemplate: () => loadTemplateImpl() }));
+mock.module('./router', () => ({
+  navigate: () => undefined,
+  useRoute: () => ({ kind: 'home' }),
+}));
+
+const { act, cleanup, fireEvent, render } = await import('@testing-library/react');
+const { App } = await import('./App');
+
+afterEach(() => {
+  cleanup();
+  window.history.replaceState(null, '', '/');
+  delete window.__deskApp__;
+  loadTemplateImpl = async () => ({
+    kind: 'document' as const,
+    document: { type: 'document', children: [] },
+    fileName: 'Template.docx',
+  });
+});
+afterAll(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  GlobalRegistrator.unregister();
+});
+
+test('blank Markdown clears the desktop file binding', () => {
+  window.history.replaceState(null, '', '/');
+  const view = render(<App />);
+
+  window.__deskApp__ = {
+    isDesktop: true,
+    filePath: 'C:\\previous.md',
+  } as NonNullable<typeof window.__deskApp__>;
+  fireEvent.click(view.getByRole('button', { name: 'Blank Markdown — Personal' }));
+  expect(view.getByTestId('markdown-editor')).toBeTruthy();
+  expect(document.title).toBe('Untitled.md — Casual Editor');
+  expect(window.__deskApp__.filePath).toBeNull();
+});
+
+test('blank DOCX clears previous Markdown state and the desktop file binding', () => {
+  window.history.replaceState(null, '', '/');
+  window.confirm = () => true;
+  const view = render(<App />);
+
+  fireEvent.click(view.getByRole('button', { name: 'Blank Markdown — Personal' }));
+  fireEvent.click(view.getByRole('button', { name: 'Back' }));
+  window.__deskApp__ = {
+    isDesktop: true,
+    filePath: 'C:\\previous.docx',
+  } as NonNullable<typeof window.__deskApp__>;
+  fireEvent.click(view.getByRole('button', { name: 'Blank document — Personal' }));
+
+  expect(view.queryByTestId('markdown-editor')).toBeNull();
+  expect(view.getByTestId('docx-editor')).toBeTruthy();
+  expect(window.__deskApp__.filePath).toBeNull();
+});
+
+test('a late template load cannot replace a newer blank document', async () => {
+  let resolveTemplate!: (value: Awaited<ReturnType<typeof loadTemplateImpl>>) => void;
+  loadTemplateImpl = () => new Promise((resolve) => {
+    resolveTemplate = resolve;
+  });
+  const view = render(<App />);
+
+  fireEvent.click(view.getAllByRole('button', { name: 'Resume — Career' })[0]);
+  fireEvent.click(view.getByRole('button', { name: 'Blank document — Personal' }));
+  await act(async () => {
+    resolveTemplate({
+      kind: 'document',
+      document: { type: 'document', children: [{ type: 'paragraph' }] },
+      fileName: 'Resume.docx',
+    });
+    await Promise.resolve();
+  });
+
+  expect(view.getByTestId('docx-editor').getAttribute('data-child-count')).toBe('0');
+});

--- a/docx-editor/examples/vite/src/App.tsx
+++ b/docx-editor/examples/vite/src/App.tsx
@@ -396,6 +396,7 @@ export function App() {
   );
   const editorRef = useRef<DocxEditorRef>(null);
   const suppressSeedDocumentRef = useRef(false);
+  const documentLoadRequestRef = useRef(0);
   const [view, setView] = useState<'home' | 'editor'>(getInitialView);
 
   // Desktop (Tauri shell) feature flag. The host injects
@@ -805,9 +806,13 @@ export function App() {
   // gallery is the *initial* entry; users get back to it by
   // navigating to /.
   const handleNewDocument = useCallback(() => {
+    documentLoadRequestRef.current += 1;
     suppressSeedDocumentRef.current = true;
     setCurrentDocument(createEmptyDocument());
     setDocumentBuffer(null);
+    setTextDoc(null);
+    setRecoveryBuffer(null);
+    setLoadError(null);
     setFileName('Untitled.docx');
     setStatus('');
     // Desktop: a brand-new blank document must NOT stay bound to the path of
@@ -829,6 +834,7 @@ export function App() {
 
   const handleSelectTemplate = useCallback(
     async (entry: TemplateEntry) => {
+      const requestId = ++documentLoadRequestRef.current;
       try {
         // Blank markdown / text files open the source editor, not the DOCX
         // pipeline — start with an empty document.
@@ -836,14 +842,20 @@ export function App() {
           suppressSeedDocumentRef.current = true;
           setDocumentBuffer(null);
           setCurrentDocument(null);
+          setRecoveryBuffer(null);
+          setLoadError(null);
           setTextDoc({ text: '', fileName: entry.defaultFileName, kind: entry.source.textKind });
+          setFileName(entry.defaultFileName);
           setStatus('');
+          const bridge = typeof window !== 'undefined' ? window.__deskApp__ : undefined;
+          if (bridge?.isDesktop) bridge.filePath = null;
           if (!legacyForcedEditor) navigate('/document/new');
           setView('editor');
           return;
         }
         if (entry.source.kind === 'docx') setStatus('Loading template…');
         const loaded = await loadTemplate(entry);
+        if (requestId !== documentLoadRequestRef.current) return;
         suppressSeedDocumentRef.current = true;
         if (loaded.kind === 'document') {
           setDocumentBuffer(null);
@@ -857,6 +869,7 @@ export function App() {
         if (!legacyForcedEditor) navigate('/document/new');
         setView('editor');
       } catch (err) {
+        if (requestId !== documentLoadRequestRef.current) return;
         const message = err instanceof Error ? err.message : String(err);
         setStatus(`Failed to load template: ${message}`);
       }
@@ -866,6 +879,7 @@ export function App() {
 
   const handleOpenFromHome = useCallback(
     async (file: File) => {
+      const requestId = ++documentLoadRequestRef.current;
       try {
         suppressSeedDocumentRef.current = true;
         setStatus('Loading…');
@@ -879,8 +893,10 @@ export function App() {
         // .rtf and .eml open in dedicated read-only viewers.
         if (fmt === 'md' || fmt === 'txt' || fmt === 'rtf' || fmt === 'eml') {
           const text = await file.text();
+          if (requestId !== documentLoadRequestRef.current) return;
           setDocumentBuffer(null);
           setCurrentDocument(null);
+          setFileName(file.name);
           setTextDoc({
             text,
             fileName: file.name,
@@ -896,6 +912,7 @@ export function App() {
             ?.isDesktop;
           if (!onDesktopOpen) {
             const bytes = await file.arrayBuffer();
+            if (requestId !== documentLoadRequestRef.current) return;
             void recordRecentFile({
               name: file.name,
               buffer: bytes,
@@ -910,6 +927,7 @@ export function App() {
         }
 
         const raw = await file.arrayBuffer();
+        if (requestId !== documentLoadRequestRef.current) return;
         // Other non-DOCX uploads (.odt) are converted to the DOCX model via
         // the WASM worker before the editor loads them — mirrors the editor's
         // File → Open path so the Home picker isn't DOCX-only.
@@ -917,6 +935,7 @@ export function App() {
         if (fmt && isForeignFormat(fmt)) {
           setStatus('Converting…');
           const out = await convertToDocx(new Uint8Array(raw), fmt);
+          if (requestId !== documentLoadRequestRef.current) return;
           buffer = out.buffer.slice(out.byteOffset, out.byteOffset + out.byteLength) as ArrayBuffer;
         }
         const cleanName = file.name.replace(/\.odt$/i, '.docx');
@@ -928,6 +947,7 @@ export function App() {
         if (!legacyForcedEditor) navigate('/document/new');
         setView('editor');
       } catch {
+        if (requestId !== documentLoadRequestRef.current) return;
         setStatus('Error loading file');
       }
     },
@@ -1442,7 +1462,13 @@ export function App() {
   }
 
   if (view === 'home') {
-    return <Home onSelectTemplate={handleSelectTemplate} onOpenFile={handleOpenFromHome} />;
+    return (
+      <Home
+        onNewDocument={handleNewDocument}
+        onSelectTemplate={handleSelectTemplate}
+        onOpenFile={handleOpenFromHome}
+      />
+    );
   }
 
   if (textDoc) {

--- a/docx-editor/examples/vite/src/Home.test.tsx
+++ b/docx-editor/examples/vite/src/Home.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Casual Office. All rights reserved.
+ */
+
+import React from 'react';
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+import { afterAll, afterEach, expect, mock, test } from 'bun:test';
+
+GlobalRegistrator.register();
+mock.module('@casualoffice/docs', () => ({
+  AutosaveStatus: () => null,
+  DocxEditor: () => null,
+  PersonalAuthGate: ({ children }: { children: React.ReactNode }) => children,
+  PresenceCluster: () => null,
+  UserMenu: () => null,
+  convertToDocx: async () => new ArrayBuffer(0),
+  createEmptyDocument: () => ({ type: 'document', children: [] }),
+  deleteRecentFile: async () => undefined,
+  formatFromFilename: () => 'docx',
+  formatSize: (size: number) => `${size} B`,
+  isForeignFormat: () => false,
+  listRecentFiles: async () => [],
+  recordRecentFile: async () => undefined,
+  useFileSourceAutoSave: () => ({ status: 'idle' }),
+}));
+
+const { act, cleanup, fireEvent, render, within } = await import('@testing-library/react');
+const { Home } = await import('./Home');
+
+afterEach(cleanup);
+afterAll(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  GlobalRegistrator.unregister();
+});
+
+test('new cards use the DOCX and Markdown creation seams', async () => {
+  const onNewDocument = mock(() => {});
+  const onSelectTemplate = mock(() => {});
+  const view = render(
+    <Home onNewDocument={onNewDocument} onSelectTemplate={onSelectTemplate} onOpenFile={() => {}} />
+  );
+  await act(async () => {
+    await Promise.resolve();
+  });
+  const createNew = view.getByRole('region', { name: 'Create new' });
+
+  expect(view.getAllByRole('button', { name: 'Blank document — Personal' })).toHaveLength(1);
+  expect(view.getAllByRole('button', { name: 'Blank Markdown — Personal' })).toHaveLength(1);
+
+  fireEvent.click(within(createNew).getByRole('button', { name: 'Blank document — Personal' }));
+  fireEvent.click(within(createNew).getByRole('button', { name: 'Blank Markdown — Personal' }));
+
+  expect(onNewDocument).toHaveBeenCalledTimes(1);
+  expect(onSelectTemplate).toHaveBeenCalledWith(
+    expect.objectContaining({ id: 'blank-markdown', source: { kind: 'text', textKind: 'markdown' } })
+  );
+});

--- a/docx-editor/examples/vite/src/Home.tsx
+++ b/docx-editor/examples/vite/src/Home.tsx
@@ -28,11 +28,15 @@ function useIsMobile(): boolean {
 }
 
 interface HomeProps {
+  onNewDocument: () => void;
   onSelectTemplate: (entry: TemplateEntry) => void;
   onOpenFile: (file: File) => void;
 }
 
 type CategoryFilter = 'All' | TemplateCategory;
+
+const isCreationTemplate = (template: TemplateEntry) =>
+  template.id === 'blank' || template.id === 'blank-markdown';
 
 // Theme-aware — these resolve through the editor's design tokens (loaded
 // globally via styles.css -> editor.css -> tokens.css), which flip on
@@ -755,7 +759,7 @@ function RecentCard({
   );
 }
 
-export function Home({ onSelectTemplate, onOpenFile }: HomeProps): React.JSX.Element {
+export function Home({ onNewDocument, onSelectTemplate, onOpenFile }: HomeProps): React.JSX.Element {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<CategoryFilter>('All');
@@ -807,8 +811,8 @@ export function Home({ onSelectTemplate, onOpenFile }: HomeProps): React.JSX.Ele
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     return TEMPLATES.filter((t) => {
-      // Blank always shows (cosmetic Personal, but useful from every filter).
-      if (category !== 'All' && t.category !== category && t.id !== 'blank') return false;
+      if (isCreationTemplate(t)) return false;
+      if (category !== 'All' && t.category !== category) return false;
       if (!q) return true;
       return (
         t.name.toLowerCase().includes(q) ||
@@ -825,11 +829,15 @@ export function Home({ onSelectTemplate, onOpenFile }: HomeProps): React.JSX.Ele
     () => TEMPLATES.filter((t) => t.featured && !isBlankEntry(t)).slice(0, 4),
     []
   );
+  const blankDocument = TEMPLATES.find((t) => t.id === 'blank');
+  const blankMarkdown = TEMPLATES.find((t) => t.id === 'blank-markdown');
 
   const byCategory = useMemo(() => {
     const m = new Map<TemplateCategory, TemplateEntry[]>();
     for (const c of CATEGORIES) m.set(c, []);
-    for (const t of TEMPLATES) m.get(t.category)?.push(t);
+    for (const t of TEMPLATES) {
+      if (!isCreationTemplate(t)) m.get(t.category)?.push(t);
+    }
     // Sort the blank cards to the end of each category so the rich previews
     // lead and the sparse tiles group together instead of holing the grid.
     for (const list of m.values()) {
@@ -888,6 +896,22 @@ export function Home({ onSelectTemplate, onOpenFile }: HomeProps): React.JSX.Ele
           template designed for the way you actually work — or open a file from your computer.
         </p>
       </section>
+
+      {blankDocument && blankMarkdown && (
+        <section style={{ ...styles.section, ...(isMobile && mobile.section) }} aria-label="Create new">
+          <div style={{ ...styles.sectionHead, ...(isMobile && mobile.sectionHead) }}>
+            <h2 style={styles.sectionTitle}>Create new</h2>
+          </div>
+          <div style={{ ...styles.featuredRow, ...(isMobile && mobile.featuredRow) }}>
+            <TemplateCard
+              entry={blankDocument}
+              onSelect={onNewDocument}
+              isMobile={isMobile}
+            />
+            <TemplateCard entry={blankMarkdown} onSelect={onSelectTemplate} isMobile={isMobile} />
+          </div>
+        </section>
+      )}
 
       <section style={{ ...styles.controls, ...(isMobile && mobile.controls) }}>
         <label style={{ ...styles.searchWrap, ...(isMobile && mobile.searchWrap) }}>


### PR DESCRIPTION
## Summary

- add visible Blank document and Blank Markdown cards to the existing Docs home
- route both cards through the existing DOCX/template creation handlers
- clear stale document, recovery, error, title, and desktop file-binding state
- prevent a late template/open operation from replacing a newer creation choice
- keep the cards keyboard-accessible through the existing button-card pattern

## Verification

- `bun test ./examples/vite/src/Home.test.tsx ./examples/vite/src/App.new-document.test.tsx` (4 passed)
- `bun run build:demo` passed in the implementation checkout
- clean latest-upstream worktree build reached application bundling but its reused dependency tree predates the declared `y-indexeddb` lock entry; no dependency install was performed

## Scope

- existing Open file and non-blank template flows remain app-owned
- no duplicate creation pipeline or editor extraction
- no version change in this PR; versioning is deferred until approval
